### PR TITLE
add 3 keywords

### DIFF
--- a/backend/db/migrate/schema.go
+++ b/backend/db/migrate/schema.go
@@ -271,6 +271,9 @@ var (
 		{Name: "input_tokens", Type: field.TypeInt64, Nullable: true},
 		{Name: "output_tokens", Type: field.TypeInt64, Nullable: true},
 		{Name: "is_suggested", Type: field.TypeBool, Default: false},
+		{Name: "source_code", Type: field.TypeString, Nullable: true},
+		{Name: "cursor_position", Type: field.TypeInt64, Nullable: true},
+		{Name: "user_input", Type: field.TypeString, Nullable: true},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "model_id", Type: field.TypeUUID, Nullable: true},
@@ -284,13 +287,13 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "tasks_models_tasks",
-				Columns:    []*schema.Column{TasksColumns[14]},
+				Columns:    []*schema.Column{TasksColumns[17]},
 				RefColumns: []*schema.Column{ModelsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "tasks_users_tasks",
-				Columns:    []*schema.Column{TasksColumns[15]},
+				Columns:    []*schema.Column{TasksColumns[18]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.SetNull,
 			},

--- a/backend/db/mutation.go
+++ b/backend/db/mutation.go
@@ -9877,6 +9877,10 @@ type TaskMutation struct {
 	output_tokens       *int64
 	addoutput_tokens    *int64
 	is_suggested        *bool
+	source_code         *string
+	cursor_position     *int64
+	addcursor_position  *int64
+	user_input          *string
 	created_at          *time.Time
 	updated_at          *time.Time
 	clearedFields       map[string]struct{}
@@ -10644,6 +10648,174 @@ func (m *TaskMutation) ResetIsSuggested() {
 	m.is_suggested = nil
 }
 
+// SetSourceCode sets the "source_code" field.
+func (m *TaskMutation) SetSourceCode(s string) {
+	m.source_code = &s
+}
+
+// SourceCode returns the value of the "source_code" field in the mutation.
+func (m *TaskMutation) SourceCode() (r string, exists bool) {
+	v := m.source_code
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSourceCode returns the old "source_code" field's value of the Task entity.
+// If the Task object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TaskMutation) OldSourceCode(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSourceCode is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSourceCode requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSourceCode: %w", err)
+	}
+	return oldValue.SourceCode, nil
+}
+
+// ClearSourceCode clears the value of the "source_code" field.
+func (m *TaskMutation) ClearSourceCode() {
+	m.source_code = nil
+	m.clearedFields[task.FieldSourceCode] = struct{}{}
+}
+
+// SourceCodeCleared returns if the "source_code" field was cleared in this mutation.
+func (m *TaskMutation) SourceCodeCleared() bool {
+	_, ok := m.clearedFields[task.FieldSourceCode]
+	return ok
+}
+
+// ResetSourceCode resets all changes to the "source_code" field.
+func (m *TaskMutation) ResetSourceCode() {
+	m.source_code = nil
+	delete(m.clearedFields, task.FieldSourceCode)
+}
+
+// SetCursorPosition sets the "cursor_position" field.
+func (m *TaskMutation) SetCursorPosition(i int64) {
+	m.cursor_position = &i
+	m.addcursor_position = nil
+}
+
+// CursorPosition returns the value of the "cursor_position" field in the mutation.
+func (m *TaskMutation) CursorPosition() (r int64, exists bool) {
+	v := m.cursor_position
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCursorPosition returns the old "cursor_position" field's value of the Task entity.
+// If the Task object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TaskMutation) OldCursorPosition(ctx context.Context) (v int64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCursorPosition is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCursorPosition requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCursorPosition: %w", err)
+	}
+	return oldValue.CursorPosition, nil
+}
+
+// AddCursorPosition adds i to the "cursor_position" field.
+func (m *TaskMutation) AddCursorPosition(i int64) {
+	if m.addcursor_position != nil {
+		*m.addcursor_position += i
+	} else {
+		m.addcursor_position = &i
+	}
+}
+
+// AddedCursorPosition returns the value that was added to the "cursor_position" field in this mutation.
+func (m *TaskMutation) AddedCursorPosition() (r int64, exists bool) {
+	v := m.addcursor_position
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearCursorPosition clears the value of the "cursor_position" field.
+func (m *TaskMutation) ClearCursorPosition() {
+	m.cursor_position = nil
+	m.addcursor_position = nil
+	m.clearedFields[task.FieldCursorPosition] = struct{}{}
+}
+
+// CursorPositionCleared returns if the "cursor_position" field was cleared in this mutation.
+func (m *TaskMutation) CursorPositionCleared() bool {
+	_, ok := m.clearedFields[task.FieldCursorPosition]
+	return ok
+}
+
+// ResetCursorPosition resets all changes to the "cursor_position" field.
+func (m *TaskMutation) ResetCursorPosition() {
+	m.cursor_position = nil
+	m.addcursor_position = nil
+	delete(m.clearedFields, task.FieldCursorPosition)
+}
+
+// SetUserInput sets the "user_input" field.
+func (m *TaskMutation) SetUserInput(s string) {
+	m.user_input = &s
+}
+
+// UserInput returns the value of the "user_input" field in the mutation.
+func (m *TaskMutation) UserInput() (r string, exists bool) {
+	v := m.user_input
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldUserInput returns the old "user_input" field's value of the Task entity.
+// If the Task object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TaskMutation) OldUserInput(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldUserInput is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldUserInput requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldUserInput: %w", err)
+	}
+	return oldValue.UserInput, nil
+}
+
+// ClearUserInput clears the value of the "user_input" field.
+func (m *TaskMutation) ClearUserInput() {
+	m.user_input = nil
+	m.clearedFields[task.FieldUserInput] = struct{}{}
+}
+
+// UserInputCleared returns if the "user_input" field was cleared in this mutation.
+func (m *TaskMutation) UserInputCleared() bool {
+	_, ok := m.clearedFields[task.FieldUserInput]
+	return ok
+}
+
+// ResetUserInput resets all changes to the "user_input" field.
+func (m *TaskMutation) ResetUserInput() {
+	m.user_input = nil
+	delete(m.clearedFields, task.FieldUserInput)
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (m *TaskMutation) SetCreatedAt(t time.Time) {
 	m.created_at = &t
@@ -10858,7 +11030,7 @@ func (m *TaskMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *TaskMutation) Fields() []string {
-	fields := make([]string, 0, 15)
+	fields := make([]string, 0, 18)
 	if m.task_id != nil {
 		fields = append(fields, task.FieldTaskID)
 	}
@@ -10897,6 +11069,15 @@ func (m *TaskMutation) Fields() []string {
 	}
 	if m.is_suggested != nil {
 		fields = append(fields, task.FieldIsSuggested)
+	}
+	if m.source_code != nil {
+		fields = append(fields, task.FieldSourceCode)
+	}
+	if m.cursor_position != nil {
+		fields = append(fields, task.FieldCursorPosition)
+	}
+	if m.user_input != nil {
+		fields = append(fields, task.FieldUserInput)
 	}
 	if m.created_at != nil {
 		fields = append(fields, task.FieldCreatedAt)
@@ -10938,6 +11119,12 @@ func (m *TaskMutation) Field(name string) (ent.Value, bool) {
 		return m.OutputTokens()
 	case task.FieldIsSuggested:
 		return m.IsSuggested()
+	case task.FieldSourceCode:
+		return m.SourceCode()
+	case task.FieldCursorPosition:
+		return m.CursorPosition()
+	case task.FieldUserInput:
+		return m.UserInput()
 	case task.FieldCreatedAt:
 		return m.CreatedAt()
 	case task.FieldUpdatedAt:
@@ -10977,6 +11164,12 @@ func (m *TaskMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldOutputTokens(ctx)
 	case task.FieldIsSuggested:
 		return m.OldIsSuggested(ctx)
+	case task.FieldSourceCode:
+		return m.OldSourceCode(ctx)
+	case task.FieldCursorPosition:
+		return m.OldCursorPosition(ctx)
+	case task.FieldUserInput:
+		return m.OldUserInput(ctx)
 	case task.FieldCreatedAt:
 		return m.OldCreatedAt(ctx)
 	case task.FieldUpdatedAt:
@@ -11081,6 +11274,27 @@ func (m *TaskMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetIsSuggested(v)
 		return nil
+	case task.FieldSourceCode:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSourceCode(v)
+		return nil
+	case task.FieldCursorPosition:
+		v, ok := value.(int64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCursorPosition(v)
+		return nil
+	case task.FieldUserInput:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetUserInput(v)
+		return nil
 	case task.FieldCreatedAt:
 		v, ok := value.(time.Time)
 		if !ok {
@@ -11112,6 +11326,9 @@ func (m *TaskMutation) AddedFields() []string {
 	if m.addoutput_tokens != nil {
 		fields = append(fields, task.FieldOutputTokens)
 	}
+	if m.addcursor_position != nil {
+		fields = append(fields, task.FieldCursorPosition)
+	}
 	return fields
 }
 
@@ -11126,6 +11343,8 @@ func (m *TaskMutation) AddedField(name string) (ent.Value, bool) {
 		return m.AddedInputTokens()
 	case task.FieldOutputTokens:
 		return m.AddedOutputTokens()
+	case task.FieldCursorPosition:
+		return m.AddedCursorPosition()
 	}
 	return nil, false
 }
@@ -11155,6 +11374,13 @@ func (m *TaskMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddOutputTokens(v)
+		return nil
+	case task.FieldCursorPosition:
+		v, ok := value.(int64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddCursorPosition(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Task numeric field %s", name)
@@ -11190,6 +11416,15 @@ func (m *TaskMutation) ClearedFields() []string {
 	}
 	if m.FieldCleared(task.FieldOutputTokens) {
 		fields = append(fields, task.FieldOutputTokens)
+	}
+	if m.FieldCleared(task.FieldSourceCode) {
+		fields = append(fields, task.FieldSourceCode)
+	}
+	if m.FieldCleared(task.FieldCursorPosition) {
+		fields = append(fields, task.FieldCursorPosition)
+	}
+	if m.FieldCleared(task.FieldUserInput) {
+		fields = append(fields, task.FieldUserInput)
 	}
 	return fields
 }
@@ -11231,6 +11466,15 @@ func (m *TaskMutation) ClearField(name string) error {
 		return nil
 	case task.FieldOutputTokens:
 		m.ClearOutputTokens()
+		return nil
+	case task.FieldSourceCode:
+		m.ClearSourceCode()
+		return nil
+	case task.FieldCursorPosition:
+		m.ClearCursorPosition()
+		return nil
+	case task.FieldUserInput:
+		m.ClearUserInput()
 		return nil
 	}
 	return fmt.Errorf("unknown Task nullable field %s", name)
@@ -11278,6 +11522,15 @@ func (m *TaskMutation) ResetField(name string) error {
 		return nil
 	case task.FieldIsSuggested:
 		m.ResetIsSuggested()
+		return nil
+	case task.FieldSourceCode:
+		m.ResetSourceCode()
+		return nil
+	case task.FieldCursorPosition:
+		m.ResetCursorPosition()
+		return nil
+	case task.FieldUserInput:
+		m.ResetUserInput()
 		return nil
 	case task.FieldCreatedAt:
 		m.ResetCreatedAt()

--- a/backend/db/task.go
+++ b/backend/db/task.go
@@ -47,6 +47,12 @@ type Task struct {
 	OutputTokens int64 `json:"output_tokens,omitempty"`
 	// IsSuggested holds the value of the "is_suggested" field.
 	IsSuggested bool `json:"is_suggested,omitempty"`
+	// SourceCode holds the value of the "source_code" field.
+	SourceCode string `json:"source_code,omitempty"`
+	// CursorPosition holds the value of the "cursor_position" field.
+	CursorPosition int64 `json:"cursor_position,omitempty"`
+	// UserInput holds the value of the "user_input" field.
+	UserInput string `json:"user_input,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
@@ -108,9 +114,9 @@ func (*Task) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case task.FieldIsAccept, task.FieldIsSuggested:
 			values[i] = new(sql.NullBool)
-		case task.FieldCodeLines, task.FieldInputTokens, task.FieldOutputTokens:
+		case task.FieldCodeLines, task.FieldInputTokens, task.FieldOutputTokens, task.FieldCursorPosition:
 			values[i] = new(sql.NullInt64)
-		case task.FieldTaskID, task.FieldRequestID, task.FieldModelType, task.FieldProgramLanguage, task.FieldWorkMode, task.FieldCompletion:
+		case task.FieldTaskID, task.FieldRequestID, task.FieldModelType, task.FieldProgramLanguage, task.FieldWorkMode, task.FieldCompletion, task.FieldSourceCode, task.FieldUserInput:
 			values[i] = new(sql.NullString)
 		case task.FieldCreatedAt, task.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -215,6 +221,24 @@ func (t *Task) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				t.IsSuggested = value.Bool
 			}
+		case task.FieldSourceCode:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field source_code", values[i])
+			} else if value.Valid {
+				t.SourceCode = value.String
+			}
+		case task.FieldCursorPosition:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field cursor_position", values[i])
+			} else if value.Valid {
+				t.CursorPosition = value.Int64
+			}
+		case task.FieldUserInput:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field user_input", values[i])
+			} else if value.Valid {
+				t.UserInput = value.String
+			}
 		case task.FieldCreatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field created_at", values[i])
@@ -316,6 +340,15 @@ func (t *Task) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("is_suggested=")
 	builder.WriteString(fmt.Sprintf("%v", t.IsSuggested))
+	builder.WriteString(", ")
+	builder.WriteString("source_code=")
+	builder.WriteString(t.SourceCode)
+	builder.WriteString(", ")
+	builder.WriteString("cursor_position=")
+	builder.WriteString(fmt.Sprintf("%v", t.CursorPosition))
+	builder.WriteString(", ")
+	builder.WriteString("user_input=")
+	builder.WriteString(t.UserInput)
 	builder.WriteString(", ")
 	builder.WriteString("created_at=")
 	builder.WriteString(t.CreatedAt.Format(time.ANSIC))

--- a/backend/db/task/task.go
+++ b/backend/db/task/task.go
@@ -40,6 +40,12 @@ const (
 	FieldOutputTokens = "output_tokens"
 	// FieldIsSuggested holds the string denoting the is_suggested field in the database.
 	FieldIsSuggested = "is_suggested"
+	// FieldSourceCode holds the string denoting the source_code field in the database.
+	FieldSourceCode = "source_code"
+	// FieldCursorPosition holds the string denoting the cursor_position field in the database.
+	FieldCursorPosition = "cursor_position"
+	// FieldUserInput holds the string denoting the user_input field in the database.
+	FieldUserInput = "user_input"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
 	FieldCreatedAt = "created_at"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
@@ -91,6 +97,9 @@ var Columns = []string{
 	FieldInputTokens,
 	FieldOutputTokens,
 	FieldIsSuggested,
+	FieldSourceCode,
+	FieldCursorPosition,
+	FieldUserInput,
 	FieldCreatedAt,
 	FieldUpdatedAt,
 }
@@ -189,6 +198,21 @@ func ByOutputTokens(opts ...sql.OrderTermOption) OrderOption {
 // ByIsSuggested orders the results by the is_suggested field.
 func ByIsSuggested(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldIsSuggested, opts...).ToFunc()
+}
+
+// BySourceCode orders the results by the source_code field.
+func BySourceCode(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSourceCode, opts...).ToFunc()
+}
+
+// ByCursorPosition orders the results by the cursor_position field.
+func ByCursorPosition(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldCursorPosition, opts...).ToFunc()
+}
+
+// ByUserInput orders the results by the user_input field.
+func ByUserInput(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldUserInput, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.

--- a/backend/db/task/where.go
+++ b/backend/db/task/where.go
@@ -123,6 +123,21 @@ func IsSuggested(v bool) predicate.Task {
 	return predicate.Task(sql.FieldEQ(FieldIsSuggested, v))
 }
 
+// SourceCode applies equality check predicate on the "source_code" field. It's identical to SourceCodeEQ.
+func SourceCode(v string) predicate.Task {
+	return predicate.Task(sql.FieldEQ(FieldSourceCode, v))
+}
+
+// CursorPosition applies equality check predicate on the "cursor_position" field. It's identical to CursorPositionEQ.
+func CursorPosition(v int64) predicate.Task {
+	return predicate.Task(sql.FieldEQ(FieldCursorPosition, v))
+}
+
+// UserInput applies equality check predicate on the "user_input" field. It's identical to UserInputEQ.
+func UserInput(v string) predicate.Task {
+	return predicate.Task(sql.FieldEQ(FieldUserInput, v))
+}
+
 // CreatedAt applies equality check predicate on the "created_at" field. It's identical to CreatedAtEQ.
 func CreatedAt(v time.Time) predicate.Task {
 	return predicate.Task(sql.FieldEQ(FieldCreatedAt, v))
@@ -810,6 +825,206 @@ func IsSuggestedEQ(v bool) predicate.Task {
 // IsSuggestedNEQ applies the NEQ predicate on the "is_suggested" field.
 func IsSuggestedNEQ(v bool) predicate.Task {
 	return predicate.Task(sql.FieldNEQ(FieldIsSuggested, v))
+}
+
+// SourceCodeEQ applies the EQ predicate on the "source_code" field.
+func SourceCodeEQ(v string) predicate.Task {
+	return predicate.Task(sql.FieldEQ(FieldSourceCode, v))
+}
+
+// SourceCodeNEQ applies the NEQ predicate on the "source_code" field.
+func SourceCodeNEQ(v string) predicate.Task {
+	return predicate.Task(sql.FieldNEQ(FieldSourceCode, v))
+}
+
+// SourceCodeIn applies the In predicate on the "source_code" field.
+func SourceCodeIn(vs ...string) predicate.Task {
+	return predicate.Task(sql.FieldIn(FieldSourceCode, vs...))
+}
+
+// SourceCodeNotIn applies the NotIn predicate on the "source_code" field.
+func SourceCodeNotIn(vs ...string) predicate.Task {
+	return predicate.Task(sql.FieldNotIn(FieldSourceCode, vs...))
+}
+
+// SourceCodeGT applies the GT predicate on the "source_code" field.
+func SourceCodeGT(v string) predicate.Task {
+	return predicate.Task(sql.FieldGT(FieldSourceCode, v))
+}
+
+// SourceCodeGTE applies the GTE predicate on the "source_code" field.
+func SourceCodeGTE(v string) predicate.Task {
+	return predicate.Task(sql.FieldGTE(FieldSourceCode, v))
+}
+
+// SourceCodeLT applies the LT predicate on the "source_code" field.
+func SourceCodeLT(v string) predicate.Task {
+	return predicate.Task(sql.FieldLT(FieldSourceCode, v))
+}
+
+// SourceCodeLTE applies the LTE predicate on the "source_code" field.
+func SourceCodeLTE(v string) predicate.Task {
+	return predicate.Task(sql.FieldLTE(FieldSourceCode, v))
+}
+
+// SourceCodeContains applies the Contains predicate on the "source_code" field.
+func SourceCodeContains(v string) predicate.Task {
+	return predicate.Task(sql.FieldContains(FieldSourceCode, v))
+}
+
+// SourceCodeHasPrefix applies the HasPrefix predicate on the "source_code" field.
+func SourceCodeHasPrefix(v string) predicate.Task {
+	return predicate.Task(sql.FieldHasPrefix(FieldSourceCode, v))
+}
+
+// SourceCodeHasSuffix applies the HasSuffix predicate on the "source_code" field.
+func SourceCodeHasSuffix(v string) predicate.Task {
+	return predicate.Task(sql.FieldHasSuffix(FieldSourceCode, v))
+}
+
+// SourceCodeIsNil applies the IsNil predicate on the "source_code" field.
+func SourceCodeIsNil() predicate.Task {
+	return predicate.Task(sql.FieldIsNull(FieldSourceCode))
+}
+
+// SourceCodeNotNil applies the NotNil predicate on the "source_code" field.
+func SourceCodeNotNil() predicate.Task {
+	return predicate.Task(sql.FieldNotNull(FieldSourceCode))
+}
+
+// SourceCodeEqualFold applies the EqualFold predicate on the "source_code" field.
+func SourceCodeEqualFold(v string) predicate.Task {
+	return predicate.Task(sql.FieldEqualFold(FieldSourceCode, v))
+}
+
+// SourceCodeContainsFold applies the ContainsFold predicate on the "source_code" field.
+func SourceCodeContainsFold(v string) predicate.Task {
+	return predicate.Task(sql.FieldContainsFold(FieldSourceCode, v))
+}
+
+// CursorPositionEQ applies the EQ predicate on the "cursor_position" field.
+func CursorPositionEQ(v int64) predicate.Task {
+	return predicate.Task(sql.FieldEQ(FieldCursorPosition, v))
+}
+
+// CursorPositionNEQ applies the NEQ predicate on the "cursor_position" field.
+func CursorPositionNEQ(v int64) predicate.Task {
+	return predicate.Task(sql.FieldNEQ(FieldCursorPosition, v))
+}
+
+// CursorPositionIn applies the In predicate on the "cursor_position" field.
+func CursorPositionIn(vs ...int64) predicate.Task {
+	return predicate.Task(sql.FieldIn(FieldCursorPosition, vs...))
+}
+
+// CursorPositionNotIn applies the NotIn predicate on the "cursor_position" field.
+func CursorPositionNotIn(vs ...int64) predicate.Task {
+	return predicate.Task(sql.FieldNotIn(FieldCursorPosition, vs...))
+}
+
+// CursorPositionGT applies the GT predicate on the "cursor_position" field.
+func CursorPositionGT(v int64) predicate.Task {
+	return predicate.Task(sql.FieldGT(FieldCursorPosition, v))
+}
+
+// CursorPositionGTE applies the GTE predicate on the "cursor_position" field.
+func CursorPositionGTE(v int64) predicate.Task {
+	return predicate.Task(sql.FieldGTE(FieldCursorPosition, v))
+}
+
+// CursorPositionLT applies the LT predicate on the "cursor_position" field.
+func CursorPositionLT(v int64) predicate.Task {
+	return predicate.Task(sql.FieldLT(FieldCursorPosition, v))
+}
+
+// CursorPositionLTE applies the LTE predicate on the "cursor_position" field.
+func CursorPositionLTE(v int64) predicate.Task {
+	return predicate.Task(sql.FieldLTE(FieldCursorPosition, v))
+}
+
+// CursorPositionIsNil applies the IsNil predicate on the "cursor_position" field.
+func CursorPositionIsNil() predicate.Task {
+	return predicate.Task(sql.FieldIsNull(FieldCursorPosition))
+}
+
+// CursorPositionNotNil applies the NotNil predicate on the "cursor_position" field.
+func CursorPositionNotNil() predicate.Task {
+	return predicate.Task(sql.FieldNotNull(FieldCursorPosition))
+}
+
+// UserInputEQ applies the EQ predicate on the "user_input" field.
+func UserInputEQ(v string) predicate.Task {
+	return predicate.Task(sql.FieldEQ(FieldUserInput, v))
+}
+
+// UserInputNEQ applies the NEQ predicate on the "user_input" field.
+func UserInputNEQ(v string) predicate.Task {
+	return predicate.Task(sql.FieldNEQ(FieldUserInput, v))
+}
+
+// UserInputIn applies the In predicate on the "user_input" field.
+func UserInputIn(vs ...string) predicate.Task {
+	return predicate.Task(sql.FieldIn(FieldUserInput, vs...))
+}
+
+// UserInputNotIn applies the NotIn predicate on the "user_input" field.
+func UserInputNotIn(vs ...string) predicate.Task {
+	return predicate.Task(sql.FieldNotIn(FieldUserInput, vs...))
+}
+
+// UserInputGT applies the GT predicate on the "user_input" field.
+func UserInputGT(v string) predicate.Task {
+	return predicate.Task(sql.FieldGT(FieldUserInput, v))
+}
+
+// UserInputGTE applies the GTE predicate on the "user_input" field.
+func UserInputGTE(v string) predicate.Task {
+	return predicate.Task(sql.FieldGTE(FieldUserInput, v))
+}
+
+// UserInputLT applies the LT predicate on the "user_input" field.
+func UserInputLT(v string) predicate.Task {
+	return predicate.Task(sql.FieldLT(FieldUserInput, v))
+}
+
+// UserInputLTE applies the LTE predicate on the "user_input" field.
+func UserInputLTE(v string) predicate.Task {
+	return predicate.Task(sql.FieldLTE(FieldUserInput, v))
+}
+
+// UserInputContains applies the Contains predicate on the "user_input" field.
+func UserInputContains(v string) predicate.Task {
+	return predicate.Task(sql.FieldContains(FieldUserInput, v))
+}
+
+// UserInputHasPrefix applies the HasPrefix predicate on the "user_input" field.
+func UserInputHasPrefix(v string) predicate.Task {
+	return predicate.Task(sql.FieldHasPrefix(FieldUserInput, v))
+}
+
+// UserInputHasSuffix applies the HasSuffix predicate on the "user_input" field.
+func UserInputHasSuffix(v string) predicate.Task {
+	return predicate.Task(sql.FieldHasSuffix(FieldUserInput, v))
+}
+
+// UserInputIsNil applies the IsNil predicate on the "user_input" field.
+func UserInputIsNil() predicate.Task {
+	return predicate.Task(sql.FieldIsNull(FieldUserInput))
+}
+
+// UserInputNotNil applies the NotNil predicate on the "user_input" field.
+func UserInputNotNil() predicate.Task {
+	return predicate.Task(sql.FieldNotNull(FieldUserInput))
+}
+
+// UserInputEqualFold applies the EqualFold predicate on the "user_input" field.
+func UserInputEqualFold(v string) predicate.Task {
+	return predicate.Task(sql.FieldEqualFold(FieldUserInput, v))
+}
+
+// UserInputContainsFold applies the ContainsFold predicate on the "user_input" field.
+func UserInputContainsFold(v string) predicate.Task {
+	return predicate.Task(sql.FieldContainsFold(FieldUserInput, v))
 }
 
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.

--- a/backend/db/task_create.go
+++ b/backend/db/task_create.go
@@ -194,6 +194,48 @@ func (tc *TaskCreate) SetNillableIsSuggested(b *bool) *TaskCreate {
 	return tc
 }
 
+// SetSourceCode sets the "source_code" field.
+func (tc *TaskCreate) SetSourceCode(s string) *TaskCreate {
+	tc.mutation.SetSourceCode(s)
+	return tc
+}
+
+// SetNillableSourceCode sets the "source_code" field if the given value is not nil.
+func (tc *TaskCreate) SetNillableSourceCode(s *string) *TaskCreate {
+	if s != nil {
+		tc.SetSourceCode(*s)
+	}
+	return tc
+}
+
+// SetCursorPosition sets the "cursor_position" field.
+func (tc *TaskCreate) SetCursorPosition(i int64) *TaskCreate {
+	tc.mutation.SetCursorPosition(i)
+	return tc
+}
+
+// SetNillableCursorPosition sets the "cursor_position" field if the given value is not nil.
+func (tc *TaskCreate) SetNillableCursorPosition(i *int64) *TaskCreate {
+	if i != nil {
+		tc.SetCursorPosition(*i)
+	}
+	return tc
+}
+
+// SetUserInput sets the "user_input" field.
+func (tc *TaskCreate) SetUserInput(s string) *TaskCreate {
+	tc.mutation.SetUserInput(s)
+	return tc
+}
+
+// SetNillableUserInput sets the "user_input" field if the given value is not nil.
+func (tc *TaskCreate) SetNillableUserInput(s *string) *TaskCreate {
+	if s != nil {
+		tc.SetUserInput(*s)
+	}
+	return tc
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (tc *TaskCreate) SetCreatedAt(t time.Time) *TaskCreate {
 	tc.mutation.SetCreatedAt(t)
@@ -405,6 +447,18 @@ func (tc *TaskCreate) createSpec() (*Task, *sqlgraph.CreateSpec) {
 	if value, ok := tc.mutation.IsSuggested(); ok {
 		_spec.SetField(task.FieldIsSuggested, field.TypeBool, value)
 		_node.IsSuggested = value
+	}
+	if value, ok := tc.mutation.SourceCode(); ok {
+		_spec.SetField(task.FieldSourceCode, field.TypeString, value)
+		_node.SourceCode = value
+	}
+	if value, ok := tc.mutation.CursorPosition(); ok {
+		_spec.SetField(task.FieldCursorPosition, field.TypeInt64, value)
+		_node.CursorPosition = value
+	}
+	if value, ok := tc.mutation.UserInput(); ok {
+		_spec.SetField(task.FieldUserInput, field.TypeString, value)
+		_node.UserInput = value
 	}
 	if value, ok := tc.mutation.CreatedAt(); ok {
 		_spec.SetField(task.FieldCreatedAt, field.TypeTime, value)
@@ -744,6 +798,66 @@ func (u *TaskUpsert) UpdateIsSuggested() *TaskUpsert {
 	return u
 }
 
+// SetSourceCode sets the "source_code" field.
+func (u *TaskUpsert) SetSourceCode(v string) *TaskUpsert {
+	u.Set(task.FieldSourceCode, v)
+	return u
+}
+
+// UpdateSourceCode sets the "source_code" field to the value that was provided on create.
+func (u *TaskUpsert) UpdateSourceCode() *TaskUpsert {
+	u.SetExcluded(task.FieldSourceCode)
+	return u
+}
+
+// ClearSourceCode clears the value of the "source_code" field.
+func (u *TaskUpsert) ClearSourceCode() *TaskUpsert {
+	u.SetNull(task.FieldSourceCode)
+	return u
+}
+
+// SetCursorPosition sets the "cursor_position" field.
+func (u *TaskUpsert) SetCursorPosition(v int64) *TaskUpsert {
+	u.Set(task.FieldCursorPosition, v)
+	return u
+}
+
+// UpdateCursorPosition sets the "cursor_position" field to the value that was provided on create.
+func (u *TaskUpsert) UpdateCursorPosition() *TaskUpsert {
+	u.SetExcluded(task.FieldCursorPosition)
+	return u
+}
+
+// AddCursorPosition adds v to the "cursor_position" field.
+func (u *TaskUpsert) AddCursorPosition(v int64) *TaskUpsert {
+	u.Add(task.FieldCursorPosition, v)
+	return u
+}
+
+// ClearCursorPosition clears the value of the "cursor_position" field.
+func (u *TaskUpsert) ClearCursorPosition() *TaskUpsert {
+	u.SetNull(task.FieldCursorPosition)
+	return u
+}
+
+// SetUserInput sets the "user_input" field.
+func (u *TaskUpsert) SetUserInput(v string) *TaskUpsert {
+	u.Set(task.FieldUserInput, v)
+	return u
+}
+
+// UpdateUserInput sets the "user_input" field to the value that was provided on create.
+func (u *TaskUpsert) UpdateUserInput() *TaskUpsert {
+	u.SetExcluded(task.FieldUserInput)
+	return u
+}
+
+// ClearUserInput clears the value of the "user_input" field.
+func (u *TaskUpsert) ClearUserInput() *TaskUpsert {
+	u.SetNull(task.FieldUserInput)
+	return u
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (u *TaskUpsert) SetCreatedAt(v time.Time) *TaskUpsert {
 	u.Set(task.FieldCreatedAt, v)
@@ -1079,6 +1193,76 @@ func (u *TaskUpsertOne) SetIsSuggested(v bool) *TaskUpsertOne {
 func (u *TaskUpsertOne) UpdateIsSuggested() *TaskUpsertOne {
 	return u.Update(func(s *TaskUpsert) {
 		s.UpdateIsSuggested()
+	})
+}
+
+// SetSourceCode sets the "source_code" field.
+func (u *TaskUpsertOne) SetSourceCode(v string) *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.SetSourceCode(v)
+	})
+}
+
+// UpdateSourceCode sets the "source_code" field to the value that was provided on create.
+func (u *TaskUpsertOne) UpdateSourceCode() *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.UpdateSourceCode()
+	})
+}
+
+// ClearSourceCode clears the value of the "source_code" field.
+func (u *TaskUpsertOne) ClearSourceCode() *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.ClearSourceCode()
+	})
+}
+
+// SetCursorPosition sets the "cursor_position" field.
+func (u *TaskUpsertOne) SetCursorPosition(v int64) *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.SetCursorPosition(v)
+	})
+}
+
+// AddCursorPosition adds v to the "cursor_position" field.
+func (u *TaskUpsertOne) AddCursorPosition(v int64) *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.AddCursorPosition(v)
+	})
+}
+
+// UpdateCursorPosition sets the "cursor_position" field to the value that was provided on create.
+func (u *TaskUpsertOne) UpdateCursorPosition() *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.UpdateCursorPosition()
+	})
+}
+
+// ClearCursorPosition clears the value of the "cursor_position" field.
+func (u *TaskUpsertOne) ClearCursorPosition() *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.ClearCursorPosition()
+	})
+}
+
+// SetUserInput sets the "user_input" field.
+func (u *TaskUpsertOne) SetUserInput(v string) *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.SetUserInput(v)
+	})
+}
+
+// UpdateUserInput sets the "user_input" field to the value that was provided on create.
+func (u *TaskUpsertOne) UpdateUserInput() *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.UpdateUserInput()
+	})
+}
+
+// ClearUserInput clears the value of the "user_input" field.
+func (u *TaskUpsertOne) ClearUserInput() *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.ClearUserInput()
 	})
 }
 
@@ -1588,6 +1772,76 @@ func (u *TaskUpsertBulk) SetIsSuggested(v bool) *TaskUpsertBulk {
 func (u *TaskUpsertBulk) UpdateIsSuggested() *TaskUpsertBulk {
 	return u.Update(func(s *TaskUpsert) {
 		s.UpdateIsSuggested()
+	})
+}
+
+// SetSourceCode sets the "source_code" field.
+func (u *TaskUpsertBulk) SetSourceCode(v string) *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.SetSourceCode(v)
+	})
+}
+
+// UpdateSourceCode sets the "source_code" field to the value that was provided on create.
+func (u *TaskUpsertBulk) UpdateSourceCode() *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.UpdateSourceCode()
+	})
+}
+
+// ClearSourceCode clears the value of the "source_code" field.
+func (u *TaskUpsertBulk) ClearSourceCode() *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.ClearSourceCode()
+	})
+}
+
+// SetCursorPosition sets the "cursor_position" field.
+func (u *TaskUpsertBulk) SetCursorPosition(v int64) *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.SetCursorPosition(v)
+	})
+}
+
+// AddCursorPosition adds v to the "cursor_position" field.
+func (u *TaskUpsertBulk) AddCursorPosition(v int64) *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.AddCursorPosition(v)
+	})
+}
+
+// UpdateCursorPosition sets the "cursor_position" field to the value that was provided on create.
+func (u *TaskUpsertBulk) UpdateCursorPosition() *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.UpdateCursorPosition()
+	})
+}
+
+// ClearCursorPosition clears the value of the "cursor_position" field.
+func (u *TaskUpsertBulk) ClearCursorPosition() *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.ClearCursorPosition()
+	})
+}
+
+// SetUserInput sets the "user_input" field.
+func (u *TaskUpsertBulk) SetUserInput(v string) *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.SetUserInput(v)
+	})
+}
+
+// UpdateUserInput sets the "user_input" field to the value that was provided on create.
+func (u *TaskUpsertBulk) UpdateUserInput() *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.UpdateUserInput()
+	})
+}
+
+// ClearUserInput clears the value of the "user_input" field.
+func (u *TaskUpsertBulk) ClearUserInput() *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.ClearUserInput()
 	})
 }
 

--- a/backend/db/task_update.go
+++ b/backend/db/task_update.go
@@ -291,6 +291,73 @@ func (tu *TaskUpdate) SetNillableIsSuggested(b *bool) *TaskUpdate {
 	return tu
 }
 
+// SetSourceCode sets the "source_code" field.
+func (tu *TaskUpdate) SetSourceCode(s string) *TaskUpdate {
+	tu.mutation.SetSourceCode(s)
+	return tu
+}
+
+// SetNillableSourceCode sets the "source_code" field if the given value is not nil.
+func (tu *TaskUpdate) SetNillableSourceCode(s *string) *TaskUpdate {
+	if s != nil {
+		tu.SetSourceCode(*s)
+	}
+	return tu
+}
+
+// ClearSourceCode clears the value of the "source_code" field.
+func (tu *TaskUpdate) ClearSourceCode() *TaskUpdate {
+	tu.mutation.ClearSourceCode()
+	return tu
+}
+
+// SetCursorPosition sets the "cursor_position" field.
+func (tu *TaskUpdate) SetCursorPosition(i int64) *TaskUpdate {
+	tu.mutation.ResetCursorPosition()
+	tu.mutation.SetCursorPosition(i)
+	return tu
+}
+
+// SetNillableCursorPosition sets the "cursor_position" field if the given value is not nil.
+func (tu *TaskUpdate) SetNillableCursorPosition(i *int64) *TaskUpdate {
+	if i != nil {
+		tu.SetCursorPosition(*i)
+	}
+	return tu
+}
+
+// AddCursorPosition adds i to the "cursor_position" field.
+func (tu *TaskUpdate) AddCursorPosition(i int64) *TaskUpdate {
+	tu.mutation.AddCursorPosition(i)
+	return tu
+}
+
+// ClearCursorPosition clears the value of the "cursor_position" field.
+func (tu *TaskUpdate) ClearCursorPosition() *TaskUpdate {
+	tu.mutation.ClearCursorPosition()
+	return tu
+}
+
+// SetUserInput sets the "user_input" field.
+func (tu *TaskUpdate) SetUserInput(s string) *TaskUpdate {
+	tu.mutation.SetUserInput(s)
+	return tu
+}
+
+// SetNillableUserInput sets the "user_input" field if the given value is not nil.
+func (tu *TaskUpdate) SetNillableUserInput(s *string) *TaskUpdate {
+	if s != nil {
+		tu.SetUserInput(*s)
+	}
+	return tu
+}
+
+// ClearUserInput clears the value of the "user_input" field.
+func (tu *TaskUpdate) ClearUserInput() *TaskUpdate {
+	tu.mutation.ClearUserInput()
+	return tu
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (tu *TaskUpdate) SetCreatedAt(t time.Time) *TaskUpdate {
 	tu.mutation.SetCreatedAt(t)
@@ -487,6 +554,27 @@ func (tu *TaskUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := tu.mutation.IsSuggested(); ok {
 		_spec.SetField(task.FieldIsSuggested, field.TypeBool, value)
+	}
+	if value, ok := tu.mutation.SourceCode(); ok {
+		_spec.SetField(task.FieldSourceCode, field.TypeString, value)
+	}
+	if tu.mutation.SourceCodeCleared() {
+		_spec.ClearField(task.FieldSourceCode, field.TypeString)
+	}
+	if value, ok := tu.mutation.CursorPosition(); ok {
+		_spec.SetField(task.FieldCursorPosition, field.TypeInt64, value)
+	}
+	if value, ok := tu.mutation.AddedCursorPosition(); ok {
+		_spec.AddField(task.FieldCursorPosition, field.TypeInt64, value)
+	}
+	if tu.mutation.CursorPositionCleared() {
+		_spec.ClearField(task.FieldCursorPosition, field.TypeInt64)
+	}
+	if value, ok := tu.mutation.UserInput(); ok {
+		_spec.SetField(task.FieldUserInput, field.TypeString, value)
+	}
+	if tu.mutation.UserInputCleared() {
+		_spec.ClearField(task.FieldUserInput, field.TypeString)
 	}
 	if value, ok := tu.mutation.CreatedAt(); ok {
 		_spec.SetField(task.FieldCreatedAt, field.TypeTime, value)
@@ -876,6 +964,73 @@ func (tuo *TaskUpdateOne) SetNillableIsSuggested(b *bool) *TaskUpdateOne {
 	return tuo
 }
 
+// SetSourceCode sets the "source_code" field.
+func (tuo *TaskUpdateOne) SetSourceCode(s string) *TaskUpdateOne {
+	tuo.mutation.SetSourceCode(s)
+	return tuo
+}
+
+// SetNillableSourceCode sets the "source_code" field if the given value is not nil.
+func (tuo *TaskUpdateOne) SetNillableSourceCode(s *string) *TaskUpdateOne {
+	if s != nil {
+		tuo.SetSourceCode(*s)
+	}
+	return tuo
+}
+
+// ClearSourceCode clears the value of the "source_code" field.
+func (tuo *TaskUpdateOne) ClearSourceCode() *TaskUpdateOne {
+	tuo.mutation.ClearSourceCode()
+	return tuo
+}
+
+// SetCursorPosition sets the "cursor_position" field.
+func (tuo *TaskUpdateOne) SetCursorPosition(i int64) *TaskUpdateOne {
+	tuo.mutation.ResetCursorPosition()
+	tuo.mutation.SetCursorPosition(i)
+	return tuo
+}
+
+// SetNillableCursorPosition sets the "cursor_position" field if the given value is not nil.
+func (tuo *TaskUpdateOne) SetNillableCursorPosition(i *int64) *TaskUpdateOne {
+	if i != nil {
+		tuo.SetCursorPosition(*i)
+	}
+	return tuo
+}
+
+// AddCursorPosition adds i to the "cursor_position" field.
+func (tuo *TaskUpdateOne) AddCursorPosition(i int64) *TaskUpdateOne {
+	tuo.mutation.AddCursorPosition(i)
+	return tuo
+}
+
+// ClearCursorPosition clears the value of the "cursor_position" field.
+func (tuo *TaskUpdateOne) ClearCursorPosition() *TaskUpdateOne {
+	tuo.mutation.ClearCursorPosition()
+	return tuo
+}
+
+// SetUserInput sets the "user_input" field.
+func (tuo *TaskUpdateOne) SetUserInput(s string) *TaskUpdateOne {
+	tuo.mutation.SetUserInput(s)
+	return tuo
+}
+
+// SetNillableUserInput sets the "user_input" field if the given value is not nil.
+func (tuo *TaskUpdateOne) SetNillableUserInput(s *string) *TaskUpdateOne {
+	if s != nil {
+		tuo.SetUserInput(*s)
+	}
+	return tuo
+}
+
+// ClearUserInput clears the value of the "user_input" field.
+func (tuo *TaskUpdateOne) ClearUserInput() *TaskUpdateOne {
+	tuo.mutation.ClearUserInput()
+	return tuo
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (tuo *TaskUpdateOne) SetCreatedAt(t time.Time) *TaskUpdateOne {
 	tuo.mutation.SetCreatedAt(t)
@@ -1102,6 +1257,27 @@ func (tuo *TaskUpdateOne) sqlSave(ctx context.Context) (_node *Task, err error) 
 	}
 	if value, ok := tuo.mutation.IsSuggested(); ok {
 		_spec.SetField(task.FieldIsSuggested, field.TypeBool, value)
+	}
+	if value, ok := tuo.mutation.SourceCode(); ok {
+		_spec.SetField(task.FieldSourceCode, field.TypeString, value)
+	}
+	if tuo.mutation.SourceCodeCleared() {
+		_spec.ClearField(task.FieldSourceCode, field.TypeString)
+	}
+	if value, ok := tuo.mutation.CursorPosition(); ok {
+		_spec.SetField(task.FieldCursorPosition, field.TypeInt64, value)
+	}
+	if value, ok := tuo.mutation.AddedCursorPosition(); ok {
+		_spec.AddField(task.FieldCursorPosition, field.TypeInt64, value)
+	}
+	if tuo.mutation.CursorPositionCleared() {
+		_spec.ClearField(task.FieldCursorPosition, field.TypeInt64)
+	}
+	if value, ok := tuo.mutation.UserInput(); ok {
+		_spec.SetField(task.FieldUserInput, field.TypeString, value)
+	}
+	if tuo.mutation.UserInputCleared() {
+		_spec.ClearField(task.FieldUserInput, field.TypeString)
 	}
 	if value, ok := tuo.mutation.CreatedAt(); ok {
 		_spec.SetField(task.FieldCreatedAt, field.TypeTime, value)

--- a/backend/domain/proxy.go
+++ b/backend/domain/proxy.go
@@ -67,6 +67,9 @@ type RecordParam struct {
 	WorkMode        string
 	CodeLines       int64
 	Code            string
+	SourceCode      string // 当前文件的原文
+	CursorPosition  int64  // 光标位置
+	UserInput       string // 用户实际输入的内容
 }
 
 func (r *RecordParam) Clone() *RecordParam {
@@ -85,5 +88,8 @@ func (r *RecordParam) Clone() *RecordParam {
 		Completion:      r.Completion,
 		WorkMode:        r.WorkMode,
 		CodeLines:       r.CodeLines,
+		SourceCode:      r.SourceCode,
+		CursorPosition:  r.CursorPosition,
+		UserInput:       r.UserInput,
 	}
 }

--- a/backend/ent/schema/task.go
+++ b/backend/ent/schema/task.go
@@ -42,6 +42,9 @@ func (Task) Fields() []ent.Field {
 		field.Int64("input_tokens").Optional(),
 		field.Int64("output_tokens").Optional(),
 		field.Bool("is_suggested").Default(false),
+		field.String("source_code").Optional(),    // 当前文件的原文
+		field.Int64("cursor_position").Optional(), // 光标位置
+		field.String("user_input").Optional(),     // 用户实际输入的内容
 		field.Time("created_at").Default(time.Now),
 		field.Time("updated_at").Default(time.Now).UpdateDefault(time.Now),
 	}

--- a/backend/internal/proxy/recorder.go
+++ b/backend/internal/proxy/recorder.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -67,7 +68,8 @@ func (r *Recorder) handleShadow() {
 	}
 
 	var (
-		taskID, mode, prompt, language, tool, code string
+		taskID, mode, prompt, language, tool, code, sourceCode, userInput string
+		cursorPosition                                                    int64
 	)
 
 	switch r.ctx.Model.ModelType {
@@ -82,6 +84,11 @@ func (r *Recorder) handleShadow() {
 		mode = req.Metadata["mode"]
 		tool = req.Metadata["tool"]
 		code = req.Metadata["code"]
+		sourceCode = req.Metadata["source_code"]
+		if pos, err := strconv.ParseInt(req.Metadata["cursor_position"], 10, 64); err == nil {
+			cursorPosition = pos
+		}
+		userInput = req.Metadata["user_input"]
 
 	case consts.ModelTypeCoder:
 		var req domain.CompletionRequest
@@ -93,6 +100,11 @@ func (r *Recorder) handleShadow() {
 		taskID = req.Metadata["task_id"]
 		mode = req.Metadata["mode"]
 		language = req.Metadata["program_language"]
+		sourceCode = req.Metadata["source_code"]
+		if pos, err := strconv.ParseInt(req.Metadata["cursor_position"], 10, 64); err == nil {
+			cursorPosition = pos
+		}
+		userInput = req.Metadata["user_input"]
 
 	default:
 		r.logger.WarnContext(r.ctx.ctx, "skip handle shadow, model type not support", "modelType", r.ctx.Model.ModelType)
@@ -112,6 +124,9 @@ func (r *Recorder) handleShadow() {
 		Prompt:          prompt,
 		ProgramLanguage: language,
 		Role:            consts.ChatRoleAssistant,
+		SourceCode:      sourceCode,
+		CursorPosition:  cursorPosition,
+		UserInput:       userInput,
 	}
 
 	switch tool {

--- a/backend/internal/proxy/repo/proxy.go
+++ b/backend/internal/proxy/repo/proxy.go
@@ -101,6 +101,9 @@ func (r *ProxyRepo) Record(ctx context.Context, record *domain.RecordParam) erro
 				SetModelType(record.ModelType).
 				SetWorkMode(record.WorkMode).
 				SetCodeLines(record.CodeLines).
+				SetSourceCode(record.SourceCode).
+				SetCursorPosition(record.CursorPosition).
+				SetUserInput(record.UserInput).
 				Save(ctx)
 			isNew = true
 		}
@@ -121,6 +124,16 @@ func (r *ProxyRepo) Record(ctx context.Context, record *domain.RecordParam) erro
 			if t.RequestID != record.RequestID {
 				up.SetRequestID(record.RequestID)
 				up.AddInputTokens(record.InputTokens)
+			}
+			// 更新新字段，如果提供了的话
+			if record.SourceCode != "" {
+				up.SetSourceCode(record.SourceCode)
+			}
+			if record.CursorPosition > 0 {
+				up.SetCursorPosition(record.CursorPosition)
+			}
+			if record.UserInput != "" {
+				up.SetUserInput(record.UserInput)
 			}
 			if err := up.Exec(ctx); err != nil {
 				return err


### PR DESCRIPTION
add source_code, cursor_position, user_input

## 变更描述
<!-- 请在此描述本次PR引入的变更内容 -->
本次PR希望为未来能为monkeycode提供用户补全数据集，帮助我们更好的提高补全性能而建立。新增了三个字段，包括source_code, cursor_position, user_input，其中source_code为用户希望补全的文件原文，cursor_position是当前光标的位置，user_input是我们希望后期检测到用户在生成补全的同一光标位置重新进行自己的输入时，将is_accepted设置成false并记录的用户的正确的输入。后期将继续添加检测用户在生成补全的同一光标位置重新进行自己的输入并发送记录请求的逻辑。

## 变更类型
- [ ] Bug修复 (不兼容的变更，修复某个问题)
- [ ✅] 新功能 (不兼容的变更，添加新功能) 
- [ ] 破坏性变更 (修复或功能会导致现有功能无法按预期工作)
- [ ] 文档更新
- [ ] 代码重构
- [ ] 其他 (请说明)

## 影响范围
<!-- 描述这些变更的影响范围和涉及的组件 -->
应该不会影响其他功能

## 测试验证
<!-- 描述你如何测试这些变更以及需要哪些额外的测试步骤 -->
使用单元测试往数据库中插入这些字段

## 相关问题
<!-- 在此列出相关问题，使用#符号 -->

关闭 #