### PR TITLE
引入了用户拒绝补全时的记录请求

### DIFF
--- a/backend/consts/proxy.go
+++ b/backend/consts/proxy.go
@@ -6,4 +6,5 @@ const (
 	ReportActionAccept      ReportAction = "accept"
 	ReportActionSuggest     ReportAction = "suggest"
 	ReportActionFileWritten ReportAction = "file_written"
+	ReportActionReject      ReportAction = "reject"
 )

--- a/backend/domain/proxy.go
+++ b/backend/domain/proxy.go
@@ -45,10 +45,13 @@ type AcceptCompletionReq struct {
 }
 
 type ReportReq struct {
-	Action  consts.ReportAction `json:"action"`
-	ID      string              `json:"id"`      // task_id or resp_id
-	Content string              `json:"content"` // 内容
-	Tool    string              `json:"tool"`    // 工具
+	Action         consts.ReportAction `json:"action"`
+	ID             string              `json:"id"`              // task_id or resp_id
+	Content        string              `json:"content"`         // 内容
+	Tool           string              `json:"tool"`            // 工具
+	UserInput      string              `json:"user_input"`      // 用户输入的新文本（用于reject action）
+	SourceCode     string              `json:"source_code"`     // 当前文件的原文（用于reject action）
+	CursorPosition int64               `json:"cursor_position"` // 光标位置（用于reject action）
 }
 
 type RecordParam struct {

--- a/backend/internal/openai/handler/v1/v1.go
+++ b/backend/internal/openai/handler/v1/v1.go
@@ -101,7 +101,7 @@ func (h *V1Handler) AcceptCompletion(c *web.Context, req domain.AcceptCompletion
 //
 //	@Tags			OpenAIV1
 //	@Summary		报告
-//	@Description	报告
+//	@Description	报告，支持多种操作：accept（接受补全）、suggest（建议）、reject（拒绝补全并记录用户输入）、file_written（文件写入）
 //	@ID				report
 //	@Accept			json
 //	@Produce		json


### PR DESCRIPTION
## 变更描述
<!-- 请在此描述本次PR引入的变更内容 -->
引入了用户拒绝补全时的记录请求。我们想提升补全的效果，希望收集更全面的反馈，所以想要检测用户在看到我们的补全代码之后拒绝补全直接输入新的内容这一行为，来获取这个时候的数据
## 变更类型
- [ ] Bug修复 (不兼容的变更，修复某个问题)
- [ ✅] 新功能 (不兼容的变更，添加新功能) 
- [ ] 破坏性变更 (修复或功能会导致现有功能无法按预期工作)
- [ ] 文档更新
- [ ] 代码重构
- [ ] 其他 (请说明)

## 影响范围
<!-- 描述这些变更的影响范围和涉及的组件 -->
report接口

## 测试验证
<!-- 描述你如何测试这些变更以及需要哪些额外的测试步骤 -->
使用postman测试返回
{
    "code": 0,
    "message": "success"
}
数据库里也得到了更新。但是前端还没有展示该补全的体现

## 相关问题
<!-- 在此列出相关问题，使用#符号 -->

关闭 #