### PR TITLE
feat(proxy): 添加环境变量代理支持

### DIFF
--- a/backend/internal/model/usecase/model.go
+++ b/backend/internal/model/usecase/model.go
@@ -36,6 +36,7 @@ func NewModelUsecase(
 			MaxIdleConnsPerHost: 100,
 			MaxConnsPerHost:     100,
 			IdleConnTimeout:     time.Second * 30,
+			Proxy:               http.ProxyFromEnvironment,
 		},
 	}
 	return &ModelUsecase{repo: repo, cfg: cfg, logger: logger, client: client}

--- a/backend/internal/proxy/proxy.go
+++ b/backend/internal/proxy/proxy.go
@@ -58,6 +58,7 @@ func NewLLMProxy(
 		MaxConnsPerHost:     cfg.LLMProxy.ClientPoolSize,
 		MaxIdleConnsPerHost: cfg.LLMProxy.ClientPoolSize,
 		IdleConnTimeout:     24 * time.Hour,
+		Proxy:               http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 24 * time.Hour,


### PR DESCRIPTION
为HTTP客户端配置添加ProxyFromEnvironment支持，允许通过环境变量配置代理

## 变更描述
<!-- 请在此描述本次PR引入的变更内容 -->
针对企业内网中部署无法访问公网环境，需要用到代理。
但这两处地方Transport没有获取代理，导致无法使用环境中的代理配置

修改后，支持从环境变量中获取代理配置，如
export HTTP_PROXY=http://127.0.0.1:8080
export HTTPS_PROXY=http://127.0.0.1:8080
export NO_PROXY=localhost,127.0.0.1,.example.com

## 变更类型
- [ ] Bug修复 (不兼容的变更，修复某个问题)
- [x] 新功能 (不兼容的变更，添加新功能) 
- [ ] 破坏性变更 (修复或功能会导致现有功能无法按预期工作)
- [ ] 文档更新
- [ ] 代码重构
- [ ] 其他 (请说明)

## 影响范围
<!-- 描述这些变更的影响范围和涉及的组件 -->
ModelUsecase - 模型创建
LLMProxy - 模型请求转发

## 测试验证
<!-- 描述你如何测试这些变更以及需要哪些额外的测试步骤 -->
目前暂时无法测试，原因如下：
1. 本地打包可以运行开源版的管理后台，但是缺少对应的asset，比如与管理后台对应的插件
2. Pro 代码不公开，开源版部分功能依赖 Pro版本，比如邀请用户的 edition配置，开源版好像没地方配置

缺少开发者贡献的本地打包和测试的指导教程，本地打包自己摸索了较长时间，希望后续能完善相关贡献指南

希望有进一步建议，我可以完善相关测试

## 相关问题
<!-- 在此列出相关问题，使用#符号 -->

关闭 #287 