### PR TITLE
fix: 成员管理中添加pagesize 和 page传参

### DIFF
--- a/ui/src/pages/generalSetting/components/adminLoginHistory.tsx
+++ b/ui/src/pages/generalSetting/components/adminLoginHistory.tsx
@@ -13,7 +13,7 @@ type LoginHistory = NonNullable<
 >[number];
 
 const AdminLoginHistory = () => {
-  const { data, loading } = useRequest(() => getAdminLoginHistory({}));
+  const { data, loading } = useRequest(() => getAdminLoginHistory({page: 1, size: 50}));
   const columns: ColumnsType<LoginHistory> = [
     {
       title: '账号',
@@ -79,7 +79,7 @@ const AdminLoginHistory = () => {
         pagination={false}
         rowKey='id'
         loading={loading}
-        sx={{ mx: -2 }}
+        sx={{ mx: -2, maxHeight: '900px', overflow: 'auto' }}
       />
     </Card>
   );

--- a/ui/src/pages/memberManage/groupList.tsx
+++ b/ui/src/pages/memberManage/groupList.tsx
@@ -30,7 +30,7 @@ const GroupList = () => {
   const [openCreateGroupModal, setOpenCreateGroupModal] = useState(false);
   const [openUpdateGroupModal, setOpenUpdateGroupModal] = useState(false);
   const [currentGroup, setCurrentGroup] = useState<DomainUserGroup | null>(null);
-  const groupData = useRequest(() => getListUserGroup({}));
+  const groupData = useRequest(() => getListUserGroup({page: 1, size: 999}));
   const userData = useRequest(() => getListUser({}));
   const adminData = useRequest(() => getListAdminUser({}));
   

--- a/ui/src/pages/memberManage/memberManage.tsx
+++ b/ui/src/pages/memberManage/memberManage.tsx
@@ -151,7 +151,7 @@ const MemberManage = () => {
   const [open, setOpen] = useState(false);
   const [resetPasswordOpen, setResetPasswordOpen] = useState(false);
   const [currentUser, setCurrentUser] = useState<DomainUser | null>(null);
-  const { data, loading, refresh } = useRequest(() => getListUser({}));
+  const { data, loading, refresh } = useRequest(() => getListUser({page: 1, size: 999}));
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const handleClick = (


### PR DESCRIPTION
## 变更描述
<!-- 请在此描述本次PR引入的变更内容 -->
成员管理中的成员组、成员列表，通用设置里的管理员登录记录都增加了page和pagesize 传参
## 变更类型
- [x] Bug修复 (不兼容的变更，修复某个问题)
- [ ] 新功能 (不兼容的变更，添加新功能) 
- [ ] 破坏性变更 (修复或功能会导致现有功能无法按预期工作)
- [ ] 文档更新
- [ ] 代码重构
- [ ] 其他 (请说明)

## 影响范围
<!-- 描述这些变更的影响范围和涉及的组件 -->
管理员账号下成员管理中的成员组、成员列表，通用设置中的管理员登录记录
## 测试验证
<!-- 描述你如何测试这些变更以及需要哪些额外的测试步骤 -->

## 相关问题
<!-- 在此列出相关问题，使用#符号 -->

关闭 #