### PR TITLE
将 restart 调用从异步改为同步模式

### DIFF
--- a/backend/biz/task/handler/v1/task_control.go
+++ b/backend/biz/task/handler/v1/task_control.go
@@ -78,10 +78,14 @@ import (
 //	@Description	[{"port":0,"status":"string","process":"string","forward_id":"string?","access_url":"string?","label":"string?","error_message":"string?","whitelist_ips":["string"]}]
 //	@Description	```
 //	@Description
-//	@Description	### Type=call, Kind=restart — 重启任务（无 call-response 返回）
+//	@Description	### Type=call, Kind=restart — 重启任务
 //	@Description	请求 Data:
 //	@Description	```json
 //	@Description	{"request_id":"string?","load_session":true}
+//	@Description	```
+//	@Description	响应 Data:
+//	@Description	```json
+//	@Description	{"id":"uuid","request_id":"string?","success":true,"message":"string","session_id":"string"}
 //	@Description	```
 //	@Description
 //	@Description	### Type=sync-my-ip — 同步 Web 客户端真实 IP
@@ -92,7 +96,7 @@ import (
 //	@Description
 //	@Description	## 下行消息
 //	@Description
-//	@Description	- Type=call-response: 同步请求响应（Kind 与请求一致，restart 除外）。失败时 Data 为:
+//	@Description	- Type=call-response: 同步请求响应（Kind 与请求一致）。失败时 Data 为:
 //	@Description	```json
 //	@Description	{"error":"string"}
 //	@Description	```
@@ -238,6 +242,7 @@ func (h *TaskHandler) controlReadMessages(ctx context.Context, wsConn *ws.Websoc
 			logger.WarnContext(ctx, "failed to unmarshal control message", "error", err, "data", string(d))
 			continue
 		}
+		h.logger.With("task req", m, "task_id", task.ID).DebugContext(ctx, "recv task message")
 
 		switch m.Type {
 		case consts.TaskStreamTypeCall:
@@ -262,6 +267,7 @@ func (h *TaskHandler) handleControlCall(ctx context.Context, wsConn *ws.Websocke
 			logger.WarnContext(ctx, "failed to unmarshal restart task", "error", err)
 			return
 		}
+		h.logger.With("restart", req, "task_id", task.ID).DebugContext(ctx, "recv restart call")
 		req.ID = task.ID
 		result, err = h.taskflow.TaskManager().Restart(ctx, req)
 

--- a/backend/biz/task/handler/v1/task_control.go
+++ b/backend/biz/task/handler/v1/task_control.go
@@ -252,24 +252,19 @@ func (h *TaskHandler) controlReadMessages(ctx context.Context, wsConn *ws.Websoc
 func (h *TaskHandler) handleControlCall(ctx context.Context, wsConn *ws.WebsocketManager, logger *slog.Logger, task *domain.Task, m domain.TaskStream) {
 	taskID := task.ID.String()
 
-	// restart 是 fire-and-forget，无响应
-	if m.Kind == "restart" {
+	var result any
+	var err error
+
+	switch m.Kind {
+	case "restart":
 		var req taskflow.RestartTaskReq
 		if err := json.Unmarshal(m.Data, &req); err != nil {
 			logger.WarnContext(ctx, "failed to unmarshal restart task", "error", err)
 			return
 		}
 		req.ID = task.ID
-		if err := h.taskflow.TaskManager().Restart(ctx, req); err != nil {
-			logger.WarnContext(ctx, "failed to restart task", "error", err)
-		}
-		return
-	}
+		result, err = h.taskflow.TaskManager().Restart(ctx, req)
 
-	var result any
-	var err error
-
-	switch m.Kind {
 	case "repo_file_diff":
 		var req taskflow.RepoFileDiffReq
 		if err := json.Unmarshal(m.Data, &req); err != nil {

--- a/backend/pkg/taskflow/client.go
+++ b/backend/pkg/taskflow/client.go
@@ -70,7 +70,7 @@ type FileManager interface {
 type TaskManager interface {
 	Create(ctx context.Context, req CreateTaskReq) error
 	Stop(ctx context.Context, req TaskReq) error
-	Restart(ctx context.Context, req RestartTaskReq) error
+	Restart(ctx context.Context, req RestartTaskReq) (*RestartTaskResp, error)
 	Cancel(ctx context.Context, req TaskReq) error
 	Continue(ctx context.Context, req TaskReq) error
 	AutoApprove(ctx context.Context, req TaskApproveReq) error

--- a/backend/pkg/taskflow/task.go
+++ b/backend/pkg/taskflow/task.go
@@ -23,9 +23,12 @@ func (t *taskClient) Create(ctx context.Context, req CreateTaskReq) error {
 }
 
 // Restart implements TaskManager.
-func (t *taskClient) Restart(ctx context.Context, req RestartTaskReq) error {
-	_, err := request.Post[Resp[any]](t.client, ctx, "/internal/task/restart", req)
-	return err
+func (t *taskClient) Restart(ctx context.Context, req RestartTaskReq) (*RestartTaskResp, error) {
+	resp, err := request.Post[Resp[*RestartTaskResp]](t.client, ctx, "/internal/task/restart", req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
 }
 
 // Stop implements TaskManager.


### PR DESCRIPTION
## Summary

- `TaskManager.Restart` 接口从 `error` 改为 `(*RestartTaskResp, error)`
- `handleControlCall` 中 restart 合入标准 switch-case，复用 call-response 返回逻辑
- 更新 Swagger 注释
