### PR TITLE
feat(team): 新增 TeamHook 支持团队成员添加后回调

### DIFF
--- a/backend/biz/team/usecase/user.go
+++ b/backend/biz/team/usecase/user.go
@@ -27,6 +27,7 @@ type TeamGroupUserUsecase struct {
 	config      *config.Config
 	smtpClient  domain.EmailSender
 	redisClient *redis.Client
+	teamHook    domain.TeamHook
 }
 
 // NewTeamGroupUserUsecase 创建团队分组成员业务逻辑层实例
@@ -40,6 +41,10 @@ func NewTeamGroupUserUsecase(i *do.Injector) (domain.TeamGroupUserUsecase, error
 		config:      cfg,
 		smtpClient:  do.MustInvoke[domain.EmailSender](i),
 		redisClient: do.MustInvoke[*redis.Client](i),
+	}
+
+	if hook, err := do.Invoke[domain.TeamHook](i); err == nil {
+		t.teamHook = hook
 	}
 
 	go t.initTeam()
@@ -93,6 +98,13 @@ func (u *TeamGroupUserUsecase) AddUser(ctx context.Context, teamUser *domain.Tea
 	if err != nil {
 		return nil, err
 	}
+	if u.teamHook != nil {
+		for _, user := range users {
+			if err := u.teamHook.OnMemberAdded(ctx, teamUser.GetTeamID(), user.ID); err != nil {
+				u.logger.WarnContext(ctx, "teamHook.OnMemberAdded failed", "user_id", user.ID, "error", err)
+			}
+		}
+	}
 	// 发送重置密码邮件（如果没有发送成功就用户自己请求重置）
 	for _, user := range users {
 		if user.Email != "" {
@@ -122,6 +134,11 @@ func (u *TeamGroupUserUsecase) AddAdmin(ctx context.Context, teamUser *domain.Te
 	user, err := u.repo.CreateAdmin(ctx, teamUser.GetTeamID(), req)
 	if err != nil {
 		return nil, err
+	}
+	if u.teamHook != nil {
+		if err := u.teamHook.OnMemberAdded(ctx, teamUser.GetTeamID(), user.ID); err != nil {
+			u.logger.WarnContext(ctx, "teamHook.OnMemberAdded failed", "user_id", user.ID, "error", err)
+		}
 	}
 	if user.Email != "" {
 		token, err := u.generateResetPWDToken(ctx, user.ID)

--- a/backend/bridge.go
+++ b/backend/bridge.go
@@ -78,6 +78,13 @@ func WithProjectHook(hook domain.ProjectHook) BridgeOption {
 	}
 }
 
+// WithTeamHook 注入团队成员变更回调
+func WithTeamHook(hook domain.TeamHook) BridgeOption {
+	return func(i *do.Injector) {
+		do.ProvideValue(i, hook)
+	}
+}
+
 // WithSiteResolver 注入站点解析器
 func WithSiteResolver(resolver domain.SiteResolver) BridgeOption {
 	return func(i *do.Injector) {

--- a/backend/domain/domain.go
+++ b/backend/domain/domain.go
@@ -56,6 +56,12 @@ type ProjectHook interface {
 	GetInternalRepoToken(ctx context.Context, userID uuid.UUID, projectID uuid.UUID) (string, error)
 }
 
+// TeamHook 团队成员变更回调接口（可选，内部项目通过 WithTeamHook 注入）
+type TeamHook interface {
+	// OnMemberAdded 团队成员添加后回调（如授予专业版订阅）
+	OnMemberAdded(ctx context.Context, teamID, userID uuid.UUID) error
+}
+
 // SiteResolver 站点解析接口（可选，内部项目通过 WithSiteResolver 注入）
 type SiteResolver interface {
 	// ResolveByHost 通过域名解析站点配置


### PR DESCRIPTION
## Summary
- 新增 `TeamHook` 接口（`domain/domain.go`），包含 `OnMemberAdded` 回调方法
- 新增 `WithTeamHook` BridgeOption（`bridge.go`），供外部项目注入实现
- `AddUser`/`AddAdmin` 创建团队成员后调用 `TeamHook.OnMemberAdded`，失败仅记日志不阻断主流程

## 背景
从 monkeycode-ai 迁移团队管理接口时，订阅授予逻辑丢失。团队管理员邀请的用户无法自动获得专业版。
通过 TeamHook 机制，内部项目可在成员添加时注入订阅逻辑，与现有 TaskHook/ModelHook 模式一致。

## Test plan
- [ ] `go build ./...` 编译通过
- [ ] `go vet ./...` 无警告
- [ ] 未注入 TeamHook 时，AddUser/AddAdmin 行为不变
- [ ] 注入 TeamHook 后，OnMemberAdded 被正确调用

🤖 Generated with [Claude Code](https://claude.com/claude-code)