### PR TITLE
统一后端 VM 状态判定入口

### DIFF
--- a/backend/biz/host/usecase/host.go
+++ b/backend/biz/host/usecase/host.go
@@ -27,6 +27,7 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/pkg/entx"
 	"github.com/chaitin/MonkeyCode/backend/pkg/random"
 	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
+	"github.com/chaitin/MonkeyCode/backend/pkg/vmstatus"
 	"github.com/chaitin/MonkeyCode/backend/templates"
 )
 
@@ -225,12 +226,14 @@ func (h *HostUsecase) List(ctx context.Context, uid uuid.UUID) (*domain.HostList
 		dHost := cvt.From(host, &domain.Host{Status: status})
 		dHost.IsDefault = dHost.GetIsDefault(user)
 		dHost.VirtualMachines = cvt.Iter(host.Edges.Vms, func(_ int, vm *db.VirtualMachine) *domain.VirtualMachine {
-			status := taskflow.VirtualMachineStatusOffline
-			if vmonline.OnlineMap[vm.ID] {
-				status = taskflow.VirtualMachineStatusOnline
-			}
 			return cvt.From(vm, &domain.VirtualMachine{
-				Status: status,
+				Status: vmstatus.Resolve(vmstatus.Input{
+					Online:     vmonline.OnlineMap[vm.ID],
+					Conditions: vm.Conditions.Conditions,
+					IsRecycled: vm.IsRecycled,
+					CreatedAt:  vm.CreatedAt,
+					Now:        time.Now(),
+				}),
 			})
 		})
 
@@ -476,17 +479,22 @@ func (h *HostUsecase) VMInfo(ctx context.Context, uid uuid.UUID, id string) (*do
 		return nil, err
 	}
 
-	status := taskflow.VirtualMachineStatusOffline
+	reportedStatus := taskflow.VirtualMachineStatusUnknown
 	if info, err := h.taskflow.VirtualMachiner().Info(ctx, taskflow.VirtualMachineInfoReq{
 		ID:     vm.ID,
 		UserID: vm.UserID.String(),
 	}); err == nil && info != nil && info.Status != taskflow.VirtualMachineStatusUnknown {
-		status = info.Status
-	} else if vmonline.OnlineMap[vm.ID] {
-		status = taskflow.VirtualMachineStatusOnline
+		reportedStatus = info.Status
 	}
 	dvm := cvt.From(vm, &domain.VirtualMachine{
-		Status: status,
+		Status: vmstatus.Resolve(vmstatus.Input{
+			ReportedStatus: reportedStatus,
+			Online:         vmonline.OnlineMap[vm.ID],
+			Conditions:     vm.Conditions.Conditions,
+			IsRecycled:     vm.IsRecycled,
+			CreatedAt:      vm.CreatedAt,
+			Now:            time.Now(),
+		}),
 	})
 
 	if dvm.Host != nil {

--- a/backend/biz/host/usecase/host.go
+++ b/backend/biz/host/usecase/host.go
@@ -479,21 +479,13 @@ func (h *HostUsecase) VMInfo(ctx context.Context, uid uuid.UUID, id string) (*do
 		return nil, err
 	}
 
-	reportedStatus := taskflow.VirtualMachineStatusUnknown
-	if info, err := h.taskflow.VirtualMachiner().Info(ctx, taskflow.VirtualMachineInfoReq{
-		ID:     vm.ID,
-		UserID: vm.UserID.String(),
-	}); err == nil && info != nil && info.Status != taskflow.VirtualMachineStatusUnknown {
-		reportedStatus = info.Status
-	}
 	dvm := cvt.From(vm, &domain.VirtualMachine{
 		Status: vmstatus.Resolve(vmstatus.Input{
-			ReportedStatus: reportedStatus,
-			Online:         vmonline.OnlineMap[vm.ID],
-			Conditions:     vm.Conditions.Conditions,
-			IsRecycled:     vm.IsRecycled,
-			CreatedAt:      vm.CreatedAt,
-			Now:            time.Now(),
+			Online:     vmonline.OnlineMap[vm.ID],
+			Conditions: vm.Conditions.Conditions,
+			IsRecycled: vm.IsRecycled,
+			CreatedAt:  vm.CreatedAt,
+			Now:        time.Now(),
 		}),
 	})
 

--- a/backend/biz/task/usecase/task.go
+++ b/backend/biz/task/usecase/task.go
@@ -23,7 +23,6 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/domain"
-	"github.com/chaitin/MonkeyCode/backend/ent/types"
 	"github.com/chaitin/MonkeyCode/backend/errcode"
 	"github.com/chaitin/MonkeyCode/backend/pkg/cvt"
 	"github.com/chaitin/MonkeyCode/backend/pkg/entx"
@@ -31,6 +30,7 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/pkg/loki"
 	"github.com/chaitin/MonkeyCode/backend/pkg/notify/dispatcher"
 	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
+	"github.com/chaitin/MonkeyCode/backend/pkg/vmstatus"
 	"github.com/chaitin/MonkeyCode/backend/templates"
 )
 
@@ -128,27 +128,12 @@ func (a *TaskUsecase) Info(ctx context.Context, user *domain.User, id uuid.UUID)
 			IDs: []string{vm.ID},
 		})
 		a.logger.With("resp", resp, "id", vm.ID).DebugContext(ctx, "is online check")
-
-		if resp != nil && resp.OnlineMap[vm.ID] {
-			vm.Status = taskflow.VirtualMachineStatusOnline
-		} else {
-			vm.Status = taskflow.VirtualMachineStatusPending
-
-			for _, cond := range vm.Conditions {
-				switch cond.Type {
-				case types.ConditionTypeFailed:
-					vm.Status = taskflow.VirtualMachineStatusOffline
-				case types.ConditionTypeHibernated:
-					if strings.ToLower(strings.TrimSpace(cond.Reason)) == "hibernated" {
-						vm.Status = taskflow.VirtualMachineStatusHibernated
-					}
-				case types.ConditionTypeReady:
-					if time.Since(time.Unix(vm.CreatedAt, 0)) > 2*time.Minute {
-						vm.Status = taskflow.VirtualMachineStatusOffline
-					}
-				}
-			}
-		}
+		vm.Status = vmstatus.Resolve(vmstatus.Input{
+			Online:     resp != nil && resp.OnlineMap[vm.ID],
+			Conditions: vm.Conditions,
+			CreatedAt:  time.Unix(vm.CreatedAt, 0),
+			Now:        time.Now(),
+		})
 	}
 
 	if stat, err := a.repo.Stat(ctx, id); err == nil {

--- a/backend/biz/team/usecase/host.go
+++ b/backend/biz/team/usecase/host.go
@@ -18,6 +18,7 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/pkg/cvt"
 	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
+	"github.com/chaitin/MonkeyCode/backend/pkg/vmstatus"
 )
 
 // TeamHostUsecase 团队宿主机业务逻辑层
@@ -103,12 +104,14 @@ func (u *TeamHostUsecase) List(ctx context.Context, teamUser *domain.TeamUser) (
 		})
 
 		dHost.VirtualMachines = cvt.Iter(host.Edges.Vms, func(_ int, vm *db.VirtualMachine) *domain.VirtualMachine {
-			status := taskflow.VirtualMachineStatusOffline
-			if vmonline.OnlineMap[vm.ID] {
-				status = taskflow.VirtualMachineStatusOnline
-			}
 			return cvt.From(vm, &domain.VirtualMachine{
-				Status: status,
+				Status: vmstatus.Resolve(vmstatus.Input{
+					Online:     vmonline.OnlineMap[vm.ID],
+					Conditions: vm.Conditions.Conditions,
+					IsRecycled: vm.IsRecycled,
+					CreatedAt:  vm.CreatedAt,
+					Now:        time.Now(),
+				}),
 			})
 		})
 

--- a/backend/domain/host.go
+++ b/backend/domain/host.go
@@ -12,6 +12,7 @@ import (
 	etypes "github.com/chaitin/MonkeyCode/backend/ent/types"
 	"github.com/chaitin/MonkeyCode/backend/pkg/cvt"
 	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
+	"github.com/chaitin/MonkeyCode/backend/pkg/vmstatus"
 )
 
 // HostUsecase 主机业务逻辑接口
@@ -167,29 +168,16 @@ func (v *VirtualMachine) From(vm *db.VirtualMachine) *VirtualMachine {
 	v.Version = vm.Version
 	v.EnvironmentID = vm.EnvironmentID
 	v.CreatedAt = vm.CreatedAt.Unix()
-
 	if vm.Conditions != nil {
 		v.Conditions = vm.Conditions.Conditions
-		if v.Status != taskflow.VirtualMachineStatusOnline {
-			v.Status = taskflow.VirtualMachineStatusPending
-			for _, cond := range vm.Conditions.Conditions {
-				switch cond.Type {
-				case etypes.ConditionTypeFailed:
-					v.Status = taskflow.VirtualMachineStatusOffline
-				case etypes.ConditionTypeHibernated:
-					v.Status = taskflow.VirtualMachineStatusHibernated
-				case etypes.ConditionTypeReady:
-					if time.Since(time.UnixMilli(cond.LastTransitionTime)) > 3*time.Minute {
-						v.Status = taskflow.VirtualMachineStatusOffline
-					}
-				}
-			}
-		}
 	}
-
-	if vm.IsRecycled {
-		v.Status = taskflow.VirtualMachineStatusOffline
-	}
+	v.Status = vmstatus.Resolve(vmstatus.Input{
+		Online:     v.Status == taskflow.VirtualMachineStatusOnline,
+		Conditions: v.Conditions,
+		IsRecycled: vm.IsRecycled,
+		CreatedAt:  vm.CreatedAt,
+		Now:        time.Now(),
+	})
 
 	switch vm.TTLKind {
 	case consts.CountDown:

--- a/backend/pkg/vmstatus/status.go
+++ b/backend/pkg/vmstatus/status.go
@@ -10,21 +10,16 @@ import (
 const readyTimeout = 3 * time.Minute
 
 type Input struct {
-	ReportedStatus taskflow.VirtualMachineStatus
-	Online         bool
-	Conditions     []*etypes.Condition
-	IsRecycled     bool
-	CreatedAt      time.Time
-	Now            time.Time
+	Online     bool
+	Conditions []*etypes.Condition
+	IsRecycled bool
+	CreatedAt  time.Time
+	Now        time.Time
 }
 
 func Resolve(input Input) taskflow.VirtualMachineStatus {
 	if input.IsRecycled {
 		return taskflow.VirtualMachineStatusOffline
-	}
-
-	if input.ReportedStatus != "" && input.ReportedStatus != taskflow.VirtualMachineStatusUnknown {
-		return input.ReportedStatus
 	}
 
 	if input.Online {

--- a/backend/pkg/vmstatus/status.go
+++ b/backend/pkg/vmstatus/status.go
@@ -1,0 +1,48 @@
+package vmstatus
+
+import (
+	"time"
+
+	etypes "github.com/chaitin/MonkeyCode/backend/ent/types"
+	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
+)
+
+const readyTimeout = 3 * time.Minute
+
+type Input struct {
+	ReportedStatus taskflow.VirtualMachineStatus
+	Online         bool
+	Conditions     []*etypes.Condition
+	IsRecycled     bool
+	CreatedAt      time.Time
+	Now            time.Time
+}
+
+func Resolve(input Input) taskflow.VirtualMachineStatus {
+	if input.IsRecycled {
+		return taskflow.VirtualMachineStatusOffline
+	}
+
+	if input.ReportedStatus != "" && input.ReportedStatus != taskflow.VirtualMachineStatusUnknown {
+		return input.ReportedStatus
+	}
+
+	if input.Online {
+		return taskflow.VirtualMachineStatusOnline
+	}
+
+	for _, cond := range input.Conditions {
+		switch cond.Type {
+		case etypes.ConditionTypeFailed:
+			return taskflow.VirtualMachineStatusOffline
+		case etypes.ConditionTypeHibernated:
+			return taskflow.VirtualMachineStatusHibernated
+		case etypes.ConditionTypeReady:
+			if !input.CreatedAt.IsZero() && input.Now.Sub(input.CreatedAt) > readyTimeout {
+				return taskflow.VirtualMachineStatusOffline
+			}
+		}
+	}
+
+	return taskflow.VirtualMachineStatusPending
+}

--- a/backend/pkg/vmstatus/status_test.go
+++ b/backend/pkg/vmstatus/status_test.go
@@ -1,0 +1,114 @@
+package vmstatus
+
+import (
+	"testing"
+	"time"
+
+	etypes "github.com/chaitin/MonkeyCode/backend/ent/types"
+	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
+)
+
+func TestResolve(t *testing.T) {
+	now := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		input Input
+		want  taskflow.VirtualMachineStatus
+	}{
+		{
+			name: "is recycled overrides everything",
+			input: Input{
+				ReportedStatus: taskflow.VirtualMachineStatusOnline,
+				Online:         true,
+				IsRecycled:     true,
+				CreatedAt:      now.Add(-10 * time.Minute),
+				Now:            now,
+			},
+			want: taskflow.VirtualMachineStatusOffline,
+		},
+		{
+			name: "reported status wins over online and conditions",
+			input: Input{
+				ReportedStatus: taskflow.VirtualMachineStatusHibernated,
+				Online:         true,
+				Conditions: []*etypes.Condition{
+					{Type: etypes.ConditionTypeFailed},
+				},
+				CreatedAt: now.Add(-10 * time.Minute),
+				Now:       now,
+			},
+			want: taskflow.VirtualMachineStatusHibernated,
+		},
+		{
+			name: "online returns online when no reported status",
+			input: Input{
+				Online:    true,
+				CreatedAt: now.Add(-10 * time.Minute),
+				Now:       now,
+			},
+			want: taskflow.VirtualMachineStatusOnline,
+		},
+		{
+			name: "failed condition returns offline",
+			input: Input{
+				Conditions: []*etypes.Condition{
+					{Type: etypes.ConditionTypeFailed},
+				},
+				CreatedAt: now.Add(-10 * time.Minute),
+				Now:       now,
+			},
+			want: taskflow.VirtualMachineStatusOffline,
+		},
+		{
+			name: "hibernated condition returns hibernated",
+			input: Input{
+				Conditions: []*etypes.Condition{
+					{Type: etypes.ConditionTypeHibernated},
+				},
+				CreatedAt: now.Add(-10 * time.Minute),
+				Now:       now,
+			},
+			want: taskflow.VirtualMachineStatusHibernated,
+		},
+		{
+			name: "ready older than three minutes returns offline",
+			input: Input{
+				Conditions: []*etypes.Condition{
+					{Type: etypes.ConditionTypeReady},
+				},
+				CreatedAt: now.Add(-3*time.Minute - time.Second),
+				Now:       now,
+			},
+			want: taskflow.VirtualMachineStatusOffline,
+		},
+		{
+			name: "ready within three minutes stays pending",
+			input: Input{
+				Conditions: []*etypes.Condition{
+					{Type: etypes.ConditionTypeReady},
+				},
+				CreatedAt: now.Add(-2 * time.Minute),
+				Now:       now,
+			},
+			want: taskflow.VirtualMachineStatusPending,
+		},
+		{
+			name: "defaults to pending",
+			input: Input{
+				CreatedAt: now,
+				Now:       now,
+			},
+			want: taskflow.VirtualMachineStatusPending,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Resolve(tt.input)
+			if got != tt.want {
+				t.Fatalf("Resolve() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/pkg/vmstatus/status_test.go
+++ b/backend/pkg/vmstatus/status_test.go
@@ -1,12 +1,19 @@
 package vmstatus
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
 	etypes "github.com/chaitin/MonkeyCode/backend/ent/types"
 	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
 )
+
+func TestInputDoesNotExposeReportedStatus(t *testing.T) {
+	if _, ok := reflect.TypeOf(Input{}).FieldByName("ReportedStatus"); ok {
+		t.Fatal("Input should not expose ReportedStatus")
+	}
+}
 
 func TestResolve(t *testing.T) {
 	now := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
@@ -19,29 +26,27 @@ func TestResolve(t *testing.T) {
 		{
 			name: "is recycled overrides everything",
 			input: Input{
-				ReportedStatus: taskflow.VirtualMachineStatusOnline,
-				Online:         true,
-				IsRecycled:     true,
-				CreatedAt:      now.Add(-10 * time.Minute),
-				Now:            now,
+				Online:     true,
+				IsRecycled: true,
+				CreatedAt:  now.Add(-10 * time.Minute),
+				Now:        now,
 			},
 			want: taskflow.VirtualMachineStatusOffline,
 		},
 		{
-			name: "reported status wins over online and conditions",
+			name: "online returns online before conditions",
 			input: Input{
-				ReportedStatus: taskflow.VirtualMachineStatusHibernated,
-				Online:         true,
+				Online: true,
 				Conditions: []*etypes.Condition{
 					{Type: etypes.ConditionTypeFailed},
 				},
 				CreatedAt: now.Add(-10 * time.Minute),
 				Now:       now,
 			},
-			want: taskflow.VirtualMachineStatusHibernated,
+			want: taskflow.VirtualMachineStatusOnline,
 		},
 		{
-			name: "online returns online when no reported status",
+			name: "online returns online",
 			input: Input{
 				Online:    true,
 				CreatedAt: now.Add(-10 * time.Minute),


### PR DESCRIPTION
## Summary
- 新增 `backend/pkg/vmstatus` 统一后端 VM 展示状态解析入口
- 将 host/task/team 相关后端调用点改为复用同一套状态推导规则
- 统一 `Ready` 超时规则为基于 `created_at` 的 3 分钟，并补充解析器单测

## Test Plan
- [x] `cd backend && go test ./...`
