### PR TITLE
feat(host): 增加回收态虚拟机回收补偿逻辑

### DIFF
--- a/backend/biz/host/handler/v1/internal.go
+++ b/backend/biz/host/handler/v1/internal.go
@@ -28,27 +28,16 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/pkg/ws"
 )
 
-type internalHostRepo interface {
-	UpsertHost(context.Context, *taskflow.Host) error
-	UpsertVirtualMachine(context.Context, *taskflow.VirtualMachine) error
-	GetVirtualMachine(context.Context, string) (*db.VirtualMachine, error)
-	UpdateVirtualMachine(context.Context, string, func(*db.VirtualMachineUpdateOne) error) error
-	GetByID(context.Context, string) (*db.Host, error)
-	GetVirtualMachineByEnvID(context.Context, string) (*db.VirtualMachine, error)
-	GetGitCredentialByTask(context.Context, string) (*domain.GitCredentialInfo, error)
-}
-
 // InternalHostHandler 处理 taskflow 回调的 host/VM 相关接口
 type InternalHostHandler struct {
 	logger         *slog.Logger
-	repo           internalHostRepo
+	repo           domain.HostRepo
 	teamRepo       domain.TeamHostRepo
 	redis          *redis.Client
 	getAgentToken  agentTokenGetter
 	limiter        vmDeleteLimiter
 	vmDeleter      vmDeleter
 	skipSoftDelete func(context.Context) context.Context
-	runAsync       asyncRunner
 	cache          *cache.Cache
 	taskLifecycle  *lifecycle.Manager[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata]
 	hostUsecase    domain.HostUsecase
@@ -71,7 +60,6 @@ func NewInternalHostHandler(i *do.Injector) (*InternalHostHandler, error) {
 		limiter:        rdb,
 		vmDeleter:      tf.VirtualMachiner(),
 		skipSoftDelete: entx.SkipSoftDelete,
-		runAsync:       defaultAsyncRunner,
 		cache:          cache.New(15*time.Minute, 10*time.Minute),
 		taskLifecycle:  do.MustInvoke[*lifecycle.Manager[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata]](i),
 		hostUsecase:    do.MustInvoke[domain.HostUsecase](i),

--- a/backend/biz/host/handler/v1/internal.go
+++ b/backend/biz/host/handler/v1/internal.go
@@ -35,8 +35,8 @@ type InternalHostHandler struct {
 	teamRepo       domain.TeamHostRepo
 	redis          *redis.Client
 	getAgentToken  agentTokenGetter
-	limiter        vmDeleteLimiter
-	vmDeleter      vmDeleter
+	limiter        *redis.Client
+	vmDeleter      taskflow.VirtualMachiner
 	skipSoftDelete func(context.Context) context.Context
 	cache          *cache.Cache
 	taskLifecycle  *lifecycle.Manager[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata]

--- a/backend/biz/host/handler/v1/internal.go
+++ b/backend/biz/host/handler/v1/internal.go
@@ -22,17 +22,33 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	etypes "github.com/chaitin/MonkeyCode/backend/ent/types"
 	"github.com/chaitin/MonkeyCode/backend/pkg/cvt"
+	"github.com/chaitin/MonkeyCode/backend/pkg/entx"
 	"github.com/chaitin/MonkeyCode/backend/pkg/lifecycle"
 	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
 	"github.com/chaitin/MonkeyCode/backend/pkg/ws"
 )
 
+type internalHostRepo interface {
+	UpsertHost(context.Context, *taskflow.Host) error
+	UpsertVirtualMachine(context.Context, *taskflow.VirtualMachine) error
+	GetVirtualMachine(context.Context, string) (*db.VirtualMachine, error)
+	UpdateVirtualMachine(context.Context, string, func(*db.VirtualMachineUpdateOne) error) error
+	GetByID(context.Context, string) (*db.Host, error)
+	GetVirtualMachineByEnvID(context.Context, string) (*db.VirtualMachine, error)
+	GetGitCredentialByTask(context.Context, string) (*domain.GitCredentialInfo, error)
+}
+
 // InternalHostHandler 处理 taskflow 回调的 host/VM 相关接口
 type InternalHostHandler struct {
 	logger         *slog.Logger
-	repo           domain.HostRepo
+	repo           internalHostRepo
 	teamRepo       domain.TeamHostRepo
 	redis          *redis.Client
+	getAgentToken  agentTokenGetter
+	limiter        vmDeleteLimiter
+	vmDeleter      vmDeleter
+	skipSoftDelete func(context.Context) context.Context
+	runAsync       asyncRunner
 	cache          *cache.Cache
 	taskLifecycle  *lifecycle.Manager[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata]
 	hostUsecase    domain.HostUsecase
@@ -43,16 +59,23 @@ type InternalHostHandler struct {
 
 func NewInternalHostHandler(i *do.Injector) (*InternalHostHandler, error) {
 	w := do.MustInvoke[*web.Web](i)
+	tf := do.MustInvoke[taskflow.Clienter](i)
+	rdb := do.MustInvoke[*redis.Client](i)
 
 	h := &InternalHostHandler{
 		logger:         do.MustInvoke[*slog.Logger](i).With("module", "InternalHostHandler"),
 		repo:           do.MustInvoke[domain.HostRepo](i),
 		teamRepo:       do.MustInvoke[domain.TeamHostRepo](i),
-		redis:          do.MustInvoke[*redis.Client](i),
+		redis:          rdb,
+		getAgentToken:  defaultAgentTokenGetter(rdb),
+		limiter:        rdb,
+		vmDeleter:      tf.VirtualMachiner(),
+		skipSoftDelete: entx.SkipSoftDelete,
+		runAsync:       defaultAsyncRunner,
 		cache:          cache.New(15*time.Minute, 10*time.Minute),
+		taskLifecycle:  do.MustInvoke[*lifecycle.Manager[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata]](i),
 		hostUsecase:    do.MustInvoke[domain.HostUsecase](i),
 		taskConns:      do.MustInvoke[*ws.TaskConn](i),
-		taskLifecycle:  do.MustInvoke[*lifecycle.Manager[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata]](i),
 		projectUsecase: do.MustInvoke[domain.ProjectUsecase](i),
 		tokenProvider:  do.MustInvoke[*gituc.TokenProvider](i),
 	}
@@ -178,53 +201,44 @@ func (h *InternalHostHandler) CheckToken(c *web.Context, req taskflow.CheckToken
 func (h *InternalHostHandler) agentAuth(ctx context.Context, token, mid string) (*taskflow.Token, error) {
 	// 1) 优先从 Redis 读取一次性 agent token，并清除
 	key := fmt.Sprintf("agent:token:%s", token)
-	luaGetDel := `
-local v = redis.call('GET', KEYS[1])
-if v then
-	 redis.call('DEL', KEYS[1])
-	 return v
-end
-return nil
-`
-	res, err := h.redis.Eval(ctx, luaGetDel, []string{key}).Result()
-	h.logger.With("mid", mid, "key", key, "res", res, "error", err).DebugContext(ctx, "agent auth...")
+	res, err := h.getAgentToken(ctx, key)
+	h.logger.With("mid", mid, "key", key, "hit", err == nil, "error", err).DebugContext(ctx, "agent auth...")
 	if err == nil {
-		if b, ok := res.(string); ok && b != "" {
-			var t taskflow.Token
-			if uerr := json.Unmarshal([]byte(b), &t); uerr != nil {
-				h.logger.With("error", uerr, "token", token).ErrorContext(ctx, "failed to unmarshal token from redis")
-				return nil, uerr
-			}
-
-			if mid != "" {
-				if err := h.repo.UpdateVirtualMachine(ctx, token, func(up *db.VirtualMachineUpdateOne) error {
-					up.SetMachineID(mid)
-					return nil
-				}); err != nil {
-					h.logger.With("error", err, "token", token).ErrorContext(ctx, "failed to update virtual machine machine id")
-					return nil, err
-				}
-			}
-
-			return &t, nil
+		var t taskflow.Token
+		if uerr := json.Unmarshal([]byte(res), &t); uerr != nil {
+			h.logger.With("error", uerr, "token", token).ErrorContext(ctx, "failed to unmarshal token from redis")
+			return nil, uerr
 		}
+
+		if mid != "" {
+			if err := h.repo.UpdateVirtualMachine(ctx, token, func(up *db.VirtualMachineUpdateOne) error {
+				up.SetMachineID(mid)
+				return nil
+			}); err != nil {
+				h.logger.With("error", err, "token", token).ErrorContext(ctx, "failed to update virtual machine machine id")
+				return nil, err
+			}
+		}
+
+		return &t, nil
 	} else if !errors.Is(err, redis.Nil) {
 		h.logger.With("error", err, "token", token).ErrorContext(ctx, "failed to get redis token via lua, fallback to db")
 	}
 
 	// 2) Redis 没值时根据数据库校验 token
-	vm, err := h.repo.GetVirtualMachine(ctx, token)
+	vm, err := h.repo.GetVirtualMachine(h.skipSoftDelete(ctx), token)
 	if err != nil {
 		return nil, err
+	}
+
+	if vm.IsRecycled {
+		h.tryRecycledVMDelete(ctx, vm, mid)
+		return nil, errAgentVMRecycled
 	}
 
 	// 机器码绑定校验
 	if mid != "" && vm.MachineID != "" && vm.MachineID != mid {
 		return nil, fmt.Errorf("mismatch machine id")
-	}
-
-	if vm.IsRecycled {
-		return nil, fmt.Errorf("vm is recycled")
 	}
 
 	if vm.Edges.Host == nil {

--- a/backend/biz/host/handler/v1/internal_auth.go
+++ b/backend/biz/host/handler/v1/internal_auth.go
@@ -19,14 +19,6 @@ const (
 
 var errAgentVMRecycled = errors.New("agent vm is recycled")
 
-type vmDeleteLimiter interface {
-	SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) *redis.BoolCmd
-}
-
-type vmDeleter interface {
-	Delete(ctx context.Context, req *taskflow.DeleteVirtualMachineReq) error
-}
-
 type agentTokenGetter func(ctx context.Context, key string) (string, error)
 
 func defaultAgentTokenGetter(rdb *redis.Client) agentTokenGetter {

--- a/backend/biz/host/handler/v1/internal_auth.go
+++ b/backend/biz/host/handler/v1/internal_auth.go
@@ -1,0 +1,89 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
+)
+
+const (
+	recycledDeleteRetryTTL = 30 * time.Second
+	recycledDeleteTimeout  = 5 * time.Second
+)
+
+var errAgentVMRecycled = errors.New("agent vm is recycled")
+
+type vmDeleteLimiter interface {
+	SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) *redis.BoolCmd
+}
+
+type vmDeleter interface {
+	Delete(ctx context.Context, req *taskflow.DeleteVirtualMachineReq) error
+}
+
+type asyncRunner func(func())
+
+func defaultAsyncRunner(fn func()) {
+	go fn()
+}
+
+type agentTokenGetter func(ctx context.Context, key string) (string, error)
+
+func defaultAgentTokenGetter(rdb *redis.Client) agentTokenGetter {
+	const luaGetDel = `
+local v = redis.call('GET', KEYS[1])
+if v then
+	 redis.call('DEL', KEYS[1])
+	 return v
+end
+return nil
+`
+	return func(ctx context.Context, key string) (string, error) {
+		res, err := rdb.Eval(ctx, luaGetDel, []string{key}).Result()
+		if err != nil {
+			return "", err
+		}
+
+		b, ok := res.(string)
+		if !ok || b == "" {
+			return "", redis.Nil
+		}
+		return b, nil
+	}
+}
+
+func (h *InternalHostHandler) tryRecycledVMDelete(ctx context.Context, vm *db.VirtualMachine, machineID string) {
+	if h.limiter == nil || h.vmDeleter == nil || h.runAsync == nil {
+		h.logger.WarnContext(ctx, "skip recycled vm delete retry", "vm_id", vm.ID, "machine_id", machineID, "error", "missing dependency")
+		return
+	}
+
+	key := fmt.Sprintf("vm:recycle:retry:%s", vm.ID)
+	ok, err := h.limiter.SetNX(ctx, key, "1", recycledDeleteRetryTTL).Result()
+	if err != nil || !ok {
+		h.logger.WarnContext(ctx, "skip recycled vm delete retry", "vm_id", vm.ID, "machine_id", machineID, "rate_limited", !ok, "error", err)
+		return
+	}
+
+	h.runAsync(func() {
+		deleteCtx, cancel := context.WithTimeout(context.Background(), recycledDeleteTimeout)
+		defer cancel()
+
+		err := h.vmDeleter.Delete(deleteCtx, &taskflow.DeleteVirtualMachineReq{
+			UserID: vm.UserID.String(),
+			HostID: vm.HostID,
+			ID:     vm.EnvironmentID,
+		})
+		if err != nil {
+			h.logger.ErrorContext(deleteCtx, "reissue recycled vm delete failed", "vm_id", vm.ID, "machine_id", machineID, "error", err)
+			return
+		}
+		h.logger.InfoContext(deleteCtx, "reissue recycled vm delete success", "vm_id", vm.ID, "machine_id", machineID)
+	})
+}

--- a/backend/biz/host/handler/v1/internal_auth.go
+++ b/backend/biz/host/handler/v1/internal_auth.go
@@ -27,12 +27,6 @@ type vmDeleter interface {
 	Delete(ctx context.Context, req *taskflow.DeleteVirtualMachineReq) error
 }
 
-type asyncRunner func(func())
-
-func defaultAsyncRunner(fn func()) {
-	go fn()
-}
-
 type agentTokenGetter func(ctx context.Context, key string) (string, error)
 
 func defaultAgentTokenGetter(rdb *redis.Client) agentTokenGetter {
@@ -59,7 +53,7 @@ return nil
 }
 
 func (h *InternalHostHandler) tryRecycledVMDelete(ctx context.Context, vm *db.VirtualMachine, machineID string) {
-	if h.limiter == nil || h.vmDeleter == nil || h.runAsync == nil {
+	if h.limiter == nil || h.vmDeleter == nil {
 		h.logger.WarnContext(ctx, "skip recycled vm delete retry", "vm_id", vm.ID, "machine_id", machineID, "error", "missing dependency")
 		return
 	}
@@ -71,7 +65,7 @@ func (h *InternalHostHandler) tryRecycledVMDelete(ctx context.Context, vm *db.Vi
 		return
 	}
 
-	h.runAsync(func() {
+	go func() {
 		deleteCtx, cancel := context.WithTimeout(context.Background(), recycledDeleteTimeout)
 		defer cancel()
 
@@ -85,5 +79,5 @@ func (h *InternalHostHandler) tryRecycledVMDelete(ctx context.Context, vm *db.Vi
 			return
 		}
 		h.logger.InfoContext(deleteCtx, "reissue recycled vm delete success", "vm_id", vm.ID, "machine_id", machineID)
-	})
+	}()
 }

--- a/backend/biz/host/handler/v1/internal_auth_test.go
+++ b/backend/biz/host/handler/v1/internal_auth_test.go
@@ -1,0 +1,191 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
+)
+
+func TestAgentAuthRecycledVMTriggersDeleteOnce(t *testing.T) {
+	vmClient := &vmDeleterStub{}
+	handler := &InternalHostHandler{
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		getAgentToken: func(context.Context, string) (string, error) { return "", redis.Nil },
+		repo: &internalHostRepoStub{
+			vm: &db.VirtualMachine{
+				ID:            "agent_1",
+				HostID:        "host_1",
+				EnvironmentID: "env_1",
+				MachineID:     "bound-machine",
+				UserID:        uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+				IsRecycled:    true,
+			},
+		},
+		vmDeleter:      vmClient,
+		limiter:        &setNXLimiterStub{result: true},
+		skipSoftDelete: func(ctx context.Context) context.Context { return ctx },
+		runAsync:       func(fn func()) { fn() },
+	}
+
+	_, err := handler.agentAuth(context.Background(), "agent_1", "machine-1")
+	if !errors.Is(err, errAgentVMRecycled) {
+		t.Fatalf("agent auth error = %v, want %v", err, errAgentVMRecycled)
+	}
+	if len(vmClient.reqs) != 1 {
+		t.Fatalf("delete calls = %d, want 1", len(vmClient.reqs))
+	}
+	if vmClient.reqs[0].ID != "env_1" {
+		t.Fatalf("delete env id = %q, want env_1", vmClient.reqs[0].ID)
+	}
+}
+
+func TestAgentAuthRecycledVMLimitedSkipsDelete(t *testing.T) {
+	vmClient := &vmDeleterStub{}
+	handler := &InternalHostHandler{
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		getAgentToken: func(context.Context, string) (string, error) { return "", redis.Nil },
+		repo: &internalHostRepoStub{
+			vm: &db.VirtualMachine{
+				ID:            "agent_2",
+				HostID:        "host_2",
+				EnvironmentID: "env_2",
+				MachineID:     "bound-machine",
+				UserID:        uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+				IsRecycled:    true,
+			},
+		},
+		vmDeleter:      vmClient,
+		limiter:        &setNXLimiterStub{result: false},
+		skipSoftDelete: func(ctx context.Context) context.Context { return ctx },
+		runAsync:       func(fn func()) { fn() },
+	}
+
+	_, err := handler.agentAuth(context.Background(), "agent_2", "machine-2")
+	if !errors.Is(err, errAgentVMRecycled) {
+		t.Fatalf("agent auth error = %v, want %v", err, errAgentVMRecycled)
+	}
+	if len(vmClient.reqs) != 0 {
+		t.Fatalf("delete calls = %d, want 0", len(vmClient.reqs))
+	}
+}
+
+func TestAgentAuthSoftDeletedRecycledVMStillTriggersDelete(t *testing.T) {
+	vmClient := &vmDeleterStub{}
+	skipCalled := false
+	type testSkipMarkerKey struct{}
+	markerKey := testSkipMarkerKey{}
+	const markerValue = "skip-soft-delete-visible"
+	repo := &internalHostRepoStub{
+		vm: &db.VirtualMachine{
+			ID:            "agent_deleted",
+			HostID:        "host_deleted",
+			EnvironmentID: "env_deleted",
+			UserID:        uuid.MustParse("33333333-3333-3333-3333-333333333333"),
+			IsRecycled:    true,
+		},
+		assertSkipMarker: true,
+		skipMarkerKey:    markerKey,
+		skipMarkerValue:  markerValue,
+	}
+	handler := &InternalHostHandler{
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		getAgentToken: func(context.Context, string) (string, error) { return "", redis.Nil },
+		repo:          repo,
+		vmDeleter:     vmClient,
+		limiter:       &setNXLimiterStub{result: true},
+		skipSoftDelete: func(ctx context.Context) context.Context {
+			skipCalled = true
+			return context.WithValue(ctx, markerKey, markerValue)
+		},
+		runAsync: func(fn func()) { fn() },
+	}
+
+	_, err := handler.agentAuth(context.Background(), "agent_deleted", "machine-deleted")
+	if !errors.Is(err, errAgentVMRecycled) {
+		t.Fatalf("agent auth error = %v, want %v", err, errAgentVMRecycled)
+	}
+	if !skipCalled {
+		t.Fatal("expected skipSoftDelete to be called")
+	}
+	if len(vmClient.reqs) != 1 {
+		t.Fatalf("delete calls = %d, want 1", len(vmClient.reqs))
+	}
+}
+
+type internalHostRepoStub struct {
+	vm               *db.VirtualMachine
+	assertSkipMarker bool
+	skipMarkerKey    interface{}
+	skipMarkerValue  string
+}
+
+func (s *internalHostRepoStub) UpsertHost(context.Context, *taskflow.Host) error {
+	return nil
+}
+
+func (s *internalHostRepoStub) UpsertVirtualMachine(context.Context, *taskflow.VirtualMachine) error {
+	return nil
+}
+
+func (s *internalHostRepoStub) GetVirtualMachine(ctx context.Context, _ string) (*db.VirtualMachine, error) {
+	if s.assertSkipMarker {
+		v, ok := ctx.Value(s.skipMarkerKey).(string)
+		if !ok || v != s.skipMarkerValue {
+			return nil, errors.New("skip soft delete context marker missing")
+		}
+	}
+	if s.vm == nil {
+		return nil, errors.New("vm not found")
+	}
+	return s.vm, nil
+}
+
+func (s *internalHostRepoStub) UpdateVirtualMachine(context.Context, string, func(*db.VirtualMachineUpdateOne) error) error {
+	return nil
+}
+
+func (s *internalHostRepoStub) GetByID(context.Context, string) (*db.Host, error) {
+	return nil, errors.New("host not found")
+}
+
+func (s *internalHostRepoStub) GetVirtualMachineByEnvID(context.Context, string) (*db.VirtualMachine, error) {
+	return nil, errors.New("vm not found")
+}
+
+func (s *internalHostRepoStub) GetGitCredentialByTask(context.Context, string) (*domain.GitCredentialInfo, error) {
+	return nil, errors.New("task not found")
+}
+
+type setNXLimiterStub struct {
+	result bool
+	err    error
+	keys   []string
+	ttl    time.Duration
+}
+
+func (s *setNXLimiterStub) SetNX(_ context.Context, key string, _ interface{}, ttl time.Duration) *redis.BoolCmd {
+	s.keys = append(s.keys, key)
+	s.ttl = ttl
+	return redis.NewBoolResult(s.result, s.err)
+}
+
+type vmDeleterStub struct {
+	reqs []*taskflow.DeleteVirtualMachineReq
+	err  error
+}
+
+func (s *vmDeleterStub) Delete(_ context.Context, req *taskflow.DeleteVirtualMachineReq) error {
+	cp := *req
+	s.reqs = append(s.reqs, &cp)
+	return s.err
+}

--- a/backend/biz/host/handler/v1/internal_auth_test.go
+++ b/backend/biz/host/handler/v1/internal_auth_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestAgentAuthRecycledVMTriggersDeleteOnce(t *testing.T) {
-	vmClient := &vmDeleterStub{}
+	vmClient := &vmDeleterStub{ch: make(chan struct{}, 1)}
 	handler := &InternalHostHandler{
 		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
 		getAgentToken: func(context.Context, string) (string, error) { return "", redis.Nil },
@@ -34,23 +34,23 @@ func TestAgentAuthRecycledVMTriggersDeleteOnce(t *testing.T) {
 		vmDeleter:      vmClient,
 		limiter:        &setNXLimiterStub{result: true},
 		skipSoftDelete: func(ctx context.Context) context.Context { return ctx },
-		runAsync:       func(fn func()) { fn() },
 	}
 
 	_, err := handler.agentAuth(context.Background(), "agent_1", "machine-1")
 	if !errors.Is(err, errAgentVMRecycled) {
 		t.Fatalf("agent auth error = %v, want %v", err, errAgentVMRecycled)
 	}
-	if len(vmClient.reqs) != 1 {
+	reqs := vmClient.waitReqs(t, time.Second)
+	if len(reqs) != 1 {
 		t.Fatalf("delete calls = %d, want 1", len(vmClient.reqs))
 	}
-	if vmClient.reqs[0].ID != "env_1" {
-		t.Fatalf("delete env id = %q, want env_1", vmClient.reqs[0].ID)
+	if reqs[0].ID != "env_1" {
+		t.Fatalf("delete env id = %q, want env_1", reqs[0].ID)
 	}
 }
 
 func TestAgentAuthRecycledVMLimitedSkipsDelete(t *testing.T) {
-	vmClient := &vmDeleterStub{}
+	vmClient := &vmDeleterStub{ch: make(chan struct{}, 1)}
 	handler := &InternalHostHandler{
 		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
 		getAgentToken: func(context.Context, string) (string, error) { return "", redis.Nil },
@@ -67,20 +67,19 @@ func TestAgentAuthRecycledVMLimitedSkipsDelete(t *testing.T) {
 		vmDeleter:      vmClient,
 		limiter:        &setNXLimiterStub{result: false},
 		skipSoftDelete: func(ctx context.Context) context.Context { return ctx },
-		runAsync:       func(fn func()) { fn() },
 	}
 
 	_, err := handler.agentAuth(context.Background(), "agent_2", "machine-2")
 	if !errors.Is(err, errAgentVMRecycled) {
 		t.Fatalf("agent auth error = %v, want %v", err, errAgentVMRecycled)
 	}
-	if len(vmClient.reqs) != 0 {
+	if vmClient.hasReqWithin(50 * time.Millisecond) {
 		t.Fatalf("delete calls = %d, want 0", len(vmClient.reqs))
 	}
 }
 
 func TestAgentAuthSoftDeletedRecycledVMStillTriggersDelete(t *testing.T) {
-	vmClient := &vmDeleterStub{}
+	vmClient := &vmDeleterStub{ch: make(chan struct{}, 1)}
 	skipCalled := false
 	type testSkipMarkerKey struct{}
 	markerKey := testSkipMarkerKey{}
@@ -107,7 +106,6 @@ func TestAgentAuthSoftDeletedRecycledVMStillTriggersDelete(t *testing.T) {
 			skipCalled = true
 			return context.WithValue(ctx, markerKey, markerValue)
 		},
-		runAsync: func(fn func()) { fn() },
 	}
 
 	_, err := handler.agentAuth(context.Background(), "agent_deleted", "machine-deleted")
@@ -117,7 +115,7 @@ func TestAgentAuthSoftDeletedRecycledVMStillTriggersDelete(t *testing.T) {
 	if !skipCalled {
 		t.Fatal("expected skipSoftDelete to be called")
 	}
-	if len(vmClient.reqs) != 1 {
+	if len(vmClient.waitReqs(t, time.Second)) != 1 {
 		t.Fatalf("delete calls = %d, want 1", len(vmClient.reqs))
 	}
 }
@@ -127,6 +125,14 @@ type internalHostRepoStub struct {
 	assertSkipMarker bool
 	skipMarkerKey    interface{}
 	skipMarkerValue  string
+}
+
+func (s *internalHostRepoStub) List(context.Context, uuid.UUID) ([]*db.Host, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *internalHostRepoStub) GetHost(context.Context, uuid.UUID, string) (*domain.Host, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (s *internalHostRepoStub) UpsertHost(context.Context, *taskflow.Host) error {
@@ -162,6 +168,38 @@ func (s *internalHostRepoStub) GetVirtualMachineByEnvID(context.Context, string)
 	return nil, errors.New("vm not found")
 }
 
+func (s *internalHostRepoStub) GetVirtualMachineWithUser(context.Context, uuid.UUID, string) (*db.VirtualMachine, error) {
+	return nil, errors.New("vm not found")
+}
+
+func (s *internalHostRepoStub) CreateVirtualMachine(context.Context, *domain.User, *domain.CreateVMReq, func(context.Context) (string, error), func(*db.Model, *db.Image) (*domain.VirtualMachine, error)) (*domain.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *internalHostRepoStub) PastHourVirtualMachine(context.Context) ([]*db.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *internalHostRepoStub) AllCountDownVirtualMachine(context.Context) ([]*db.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *internalHostRepoStub) DeleteVirtualMachine(context.Context, uuid.UUID, string, string, func(*db.VirtualMachine) error) error {
+	return errors.New("not implemented")
+}
+
+func (s *internalHostRepoStub) DeleteHost(context.Context, uuid.UUID, string) error {
+	return errors.New("not implemented")
+}
+
+func (s *internalHostRepoStub) UpdateHost(context.Context, uuid.UUID, *domain.UpdateHostReq) error {
+	return errors.New("not implemented")
+}
+
+func (s *internalHostRepoStub) UpdateVM(context.Context, domain.UpdateVMReq, func(*db.VirtualMachine) error) (*db.VirtualMachine, int64, error) {
+	return nil, 0, errors.New("not implemented")
+}
+
 func (s *internalHostRepoStub) GetGitCredentialByTask(context.Context, string) (*domain.GitCredentialInfo, error) {
 	return nil, errors.New("task not found")
 }
@@ -182,10 +220,37 @@ func (s *setNXLimiterStub) SetNX(_ context.Context, key string, _ interface{}, t
 type vmDeleterStub struct {
 	reqs []*taskflow.DeleteVirtualMachineReq
 	err  error
+	ch   chan struct{}
 }
 
 func (s *vmDeleterStub) Delete(_ context.Context, req *taskflow.DeleteVirtualMachineReq) error {
 	cp := *req
 	s.reqs = append(s.reqs, &cp)
+	if s.ch != nil {
+		select {
+		case s.ch <- struct{}{}:
+		default:
+		}
+	}
 	return s.err
+}
+
+func (s *vmDeleterStub) waitReqs(t *testing.T, timeout time.Duration) []*taskflow.DeleteVirtualMachineReq {
+	t.Helper()
+	select {
+	case <-s.ch:
+		return s.reqs
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for delete call")
+		return nil
+	}
+}
+
+func (s *vmDeleterStub) hasReqWithin(timeout time.Duration) bool {
+	select {
+	case <-s.ch:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
 }

--- a/backend/biz/host/handler/v1/internal_auth_test.go
+++ b/backend/biz/host/handler/v1/internal_auth_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 
@@ -17,6 +18,7 @@ import (
 )
 
 func TestAgentAuthRecycledVMTriggersDeleteOnce(t *testing.T) {
+	rdb := newTestRedis(t)
 	vmClient := &vmDeleterStub{ch: make(chan struct{}, 1)}
 	handler := &InternalHostHandler{
 		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -32,7 +34,7 @@ func TestAgentAuthRecycledVMTriggersDeleteOnce(t *testing.T) {
 			},
 		},
 		vmDeleter:      vmClient,
-		limiter:        &setNXLimiterStub{result: true},
+		limiter:        rdb,
 		skipSoftDelete: func(ctx context.Context) context.Context { return ctx },
 	}
 
@@ -50,6 +52,10 @@ func TestAgentAuthRecycledVMTriggersDeleteOnce(t *testing.T) {
 }
 
 func TestAgentAuthRecycledVMLimitedSkipsDelete(t *testing.T) {
+	rdb := newTestRedis(t)
+	if ok, err := rdb.SetNX(context.Background(), "vm:recycle:retry:agent_2", "1", time.Minute).Result(); err != nil || !ok {
+		t.Fatalf("seed redis limiter failed, ok=%v err=%v", ok, err)
+	}
 	vmClient := &vmDeleterStub{ch: make(chan struct{}, 1)}
 	handler := &InternalHostHandler{
 		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -65,7 +71,7 @@ func TestAgentAuthRecycledVMLimitedSkipsDelete(t *testing.T) {
 			},
 		},
 		vmDeleter:      vmClient,
-		limiter:        &setNXLimiterStub{result: false},
+		limiter:        rdb,
 		skipSoftDelete: func(ctx context.Context) context.Context { return ctx },
 	}
 
@@ -79,6 +85,7 @@ func TestAgentAuthRecycledVMLimitedSkipsDelete(t *testing.T) {
 }
 
 func TestAgentAuthSoftDeletedRecycledVMStillTriggersDelete(t *testing.T) {
+	rdb := newTestRedis(t)
 	vmClient := &vmDeleterStub{ch: make(chan struct{}, 1)}
 	skipCalled := false
 	type testSkipMarkerKey struct{}
@@ -101,7 +108,7 @@ func TestAgentAuthSoftDeletedRecycledVMStillTriggersDelete(t *testing.T) {
 		getAgentToken: func(context.Context, string) (string, error) { return "", redis.Nil },
 		repo:          repo,
 		vmDeleter:     vmClient,
-		limiter:       &setNXLimiterStub{result: true},
+		limiter:       rdb,
 		skipSoftDelete: func(ctx context.Context) context.Context {
 			skipCalled = true
 			return context.WithValue(ctx, markerKey, markerValue)
@@ -204,19 +211,6 @@ func (s *internalHostRepoStub) GetGitCredentialByTask(context.Context, string) (
 	return nil, errors.New("task not found")
 }
 
-type setNXLimiterStub struct {
-	result bool
-	err    error
-	keys   []string
-	ttl    time.Duration
-}
-
-func (s *setNXLimiterStub) SetNX(_ context.Context, key string, _ interface{}, ttl time.Duration) *redis.BoolCmd {
-	s.keys = append(s.keys, key)
-	s.ttl = ttl
-	return redis.NewBoolResult(s.result, s.err)
-}
-
 type vmDeleterStub struct {
 	reqs []*taskflow.DeleteVirtualMachineReq
 	err  error
@@ -233,6 +227,46 @@ func (s *vmDeleterStub) Delete(_ context.Context, req *taskflow.DeleteVirtualMac
 		}
 	}
 	return s.err
+}
+
+func (s *vmDeleterStub) Create(context.Context, *taskflow.CreateVirtualMachineReq) (*taskflow.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *vmDeleterStub) Hibernate(context.Context, *taskflow.HibernateVirtualMachineReq) error {
+	return errors.New("not implemented")
+}
+
+func (s *vmDeleterStub) Resume(context.Context, *taskflow.ResumeVirtualMachineReq) error {
+	return errors.New("not implemented")
+}
+
+func (s *vmDeleterStub) List(context.Context, string) ([]*taskflow.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *vmDeleterStub) Info(context.Context, taskflow.VirtualMachineInfoReq) (*taskflow.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *vmDeleterStub) Terminal(context.Context, *taskflow.TerminalReq) (taskflow.Sheller, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *vmDeleterStub) Reports(context.Context, taskflow.ReportSubscribeReq) (taskflow.Reporter, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *vmDeleterStub) TerminalList(context.Context, string) ([]*taskflow.Terminal, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *vmDeleterStub) CloseTerminal(context.Context, *taskflow.CloseTerminalReq) error {
+	return errors.New("not implemented")
+}
+
+func (s *vmDeleterStub) IsOnline(context.Context, *taskflow.IsOnlineReq[string]) (*taskflow.IsOnlineResp, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (s *vmDeleterStub) waitReqs(t *testing.T, timeout time.Duration) []*taskflow.DeleteVirtualMachineReq {
@@ -253,4 +287,20 @@ func (s *vmDeleterStub) hasReqWithin(timeout time.Duration) bool {
 	case <-time.After(timeout):
 		return false
 	}
+}
+
+func newTestRedis(t *testing.T) *redis.Client {
+	t.Helper()
+
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run() error = %v", err)
+	}
+	t.Cleanup(mr.Close)
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() {
+		_ = rdb.Close()
+	})
+	return rdb
 }

--- a/backend/biz/host/repo/host.go
+++ b/backend/biz/host/repo/host.go
@@ -441,6 +441,12 @@ func (h *HostRepo) DeleteVirtualMachine(ctx context.Context, uid uuid.UUID, host
 			return err
 		}
 
+		if err := tx.VirtualMachine.UpdateOneID(vm.ID).
+			SetIsRecycled(true).
+			Exec(ctx); err != nil {
+			return err
+		}
+
 		_, err = tx.VirtualMachine.Delete().Where(virtualmachine.ID(id)).Exec(ctx)
 		if err != nil {
 			return err

--- a/backend/biz/host/repo/host_delete_test.go
+++ b/backend/biz/host/repo/host_delete_test.go
@@ -1,0 +1,84 @@
+package repo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/db/enttest"
+	"github.com/chaitin/MonkeyCode/backend/db/virtualmachine"
+	"github.com/chaitin/MonkeyCode/backend/pkg/entx"
+)
+
+func TestHostRepo_DeleteVirtualMachineMarksRecycledBeforeSoftDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:host-delete-test?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	repo := &HostRepo{db: client}
+	uid := uuid.New()
+
+	if _, err := client.User.Create().
+		SetID(uid).
+		SetName("tester").
+		SetRole(consts.UserRoleIndividual).
+		SetStatus(consts.UserStatusActive).
+		Save(ctx); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	hostID := "host-1"
+	if _, err := client.Host.Create().
+		SetID(hostID).
+		SetUserID(uid).
+		SetHostname("host").
+		Save(ctx); err != nil {
+		t.Fatalf("create host: %v", err)
+	}
+
+	vmID := "vm-1"
+	if _, err := client.VirtualMachine.Create().
+		SetID(vmID).
+		SetHostID(hostID).
+		SetUserID(uid).
+		SetName("vm").
+		Save(ctx); err != nil {
+		t.Fatalf("create vm: %v", err)
+	}
+
+	callbackCalled := false
+	if err := repo.DeleteVirtualMachine(ctx, uid, hostID, vmID, func(vm *db.VirtualMachine) error {
+		callbackCalled = true
+		if vm.ID != vmID {
+			t.Fatalf("unexpected vm id in callback: %s", vm.ID)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("delete virtual machine: %v", err)
+	}
+
+	if !callbackCalled {
+		t.Fatal("expected delete callback to be called")
+	}
+
+	deletedVM, err := client.VirtualMachine.Query().
+		Where(virtualmachine.ID(vmID)).
+		Only(entx.SkipSoftDelete(ctx))
+	if err != nil {
+		t.Fatalf("query deleted vm: %v", err)
+	}
+
+	if !deletedVM.IsRecycled {
+		t.Fatal("expected deleted vm to be marked recycled")
+	}
+
+	if deletedVM.DeletedAt.IsZero() {
+		t.Fatal("expected deleted vm to have deleted_at set")
+	}
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/labstack/echo/v4 v4.15.1
 	github.com/lib/pq v1.10.9
+	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/palantir/go-githubapp v0.38.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/redis/go-redis/v9 v9.18.0


### PR DESCRIPTION
## Summary
- CheckToken 遇到 `is_recycled=true` 的虚拟机时拒绝放行，并按 `vm_id` 限流异步补发 delete
- agent 鉴权的 DB fallback 放开软删可见查询，软删且已回收的虚拟机仍会走补删逻辑
- 手动删除虚拟机时在软删前补写 `is_recycled=true`，并补充 repo 集成测试

## Test Plan
- go test ./biz/host/handler/v1 ./biz/host/repo -v
- go test ./biz/host/... ./biz/task/... ./pkg/lifecycle/... -run '^$'
