### PR TITLE
fix: 邮件 token 改用 UUID，避免 base32 填充被邮件链路破坏

### DIFF
--- a/backend/biz/team/usecase/user.go
+++ b/backend/biz/team/usecase/user.go
@@ -15,7 +15,6 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/errcode"
-	"github.com/chaitin/MonkeyCode/backend/pkg/crypto"
 	"github.com/chaitin/MonkeyCode/backend/pkg/cvt"
 )
 
@@ -269,12 +268,10 @@ func (u *TeamGroupUserUsecase) UpdateUser(ctx context.Context, req *domain.Updat
 }
 
 // generateResetPWDToken 生成重置密码的 token
+// 使用 UUID 作为随机 handle，实际过期时间由 Redis TTL 控制，
+// 避免 base32 填充字符在邮件传输中被破坏。
 func (u *TeamGroupUserUsecase) generateResetPWDToken(ctx context.Context, userID uuid.UUID) (string, error) {
-	token, err := crypto.Simple(userID.String(), time.Now().Add(time.Hour*24*3))
-	if err != nil {
-		return "", err
-	}
-	return token, nil
+	return uuid.NewString(), nil
 }
 
 // sendResetPasswordEmail 发送重置密码邮件

--- a/backend/biz/user/usecase/user.go
+++ b/backend/biz/user/usecase/user.go
@@ -15,7 +15,6 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/errcode"
-	"github.com/chaitin/MonkeyCode/backend/pkg/crypto"
 	"github.com/chaitin/MonkeyCode/backend/pkg/cvt"
 )
 
@@ -159,16 +158,12 @@ func (u *UserUsecase) SendBindEmailVerification(ctx context.Context, userID uuid
 		return errcode.ErrEmailTaken
 	}
 
-	// 生成验证 token
-	token, err := crypto.Simple(userID.String(), time.Now().Add(time.Hour*24))
-	if err != nil {
-		u.logger.ErrorContext(ctx, "generate bind email token failed", "error", err)
-		return errcode.ErrInternalServer.Wrap(err)
-	}
+	// 生成验证 token（使用 UUID，避免 base32 填充字符在邮件传输中被破坏）
+	token := uuid.NewString()
 
-	// 存储 token 到 Redis，格式：{token}:{email}，有效期 24 小时
-	key := fmt.Sprintf("bind_email_token:%s", userID.String())
-	value := fmt.Sprintf("%s:%s", token, req.Email)
+	// 存储 token 到 Redis，key: bind_email_token:{token}，value: {userID}:{email}，有效期 24 小时
+	key := fmt.Sprintf("bind_email_token:%s", token)
+	value := fmt.Sprintf("%s:%s", userID.String(), req.Email)
 	if err := u.redis.Set(ctx, key, value, time.Hour*24).Err(); err != nil {
 		u.logger.ErrorContext(ctx, "set redis key failed", "error", err)
 		return errcode.ErrDatabaseOperation.Wrap(err)
@@ -194,21 +189,8 @@ func (u *UserUsecase) SendBindEmailVerification(ctx context.Context, userID uuid
 
 // VerifyBindEmail 验证邮箱绑定
 func (u *UserUsecase) VerifyBindEmail(ctx context.Context, token string) error {
-	// 验证 token 的有效性（检查签名和过期时间）
-	userIDStr, err := crypto.ValidateSimple(token)
-	if err != nil {
-		u.logger.WarnContext(ctx, "validate token failed", "error", err)
-		return errcode.ErrEmailVerifyFailed.Wrap(err)
-	}
-
-	userID, err := uuid.Parse(userIDStr)
-	if err != nil {
-		u.logger.WarnContext(ctx, "parse user id from token failed", "error", err)
-		return errcode.ErrEmailVerifyFailed.Wrap(err)
-	}
-
-	// 从 Redis 中取出存储的 token 和邮箱（一次性消费）
-	key := fmt.Sprintf("bind_email_token:%s", userID.String())
+	// 以 token 为 key 从 Redis 中取出 userID 和邮箱（一次性消费）
+	key := fmt.Sprintf("bind_email_token:%s", token)
 	redisValue, err := u.redis.GetDel(ctx, key).Result()
 	if err != nil {
 		if err == redis.Nil {
@@ -218,21 +200,19 @@ func (u *UserUsecase) VerifyBindEmail(ctx context.Context, token string) error {
 		return errcode.ErrDatabaseOperation.Wrap(err)
 	}
 
-	// 解析 Redis 中的值：{token}:{email}
+	// 解析 Redis 中的值：{userID}:{email}
 	parts := strings.SplitN(redisValue, ":", 2)
 	if len(parts) != 2 {
 		u.logger.WarnContext(ctx, "invalid redis value format", "value", redisValue)
 		return errcode.ErrEmailVerifyFailed
 	}
 
-	storedToken := parts[0]
-	email := parts[1]
-
-	// 验证 token 是否匹配（防止 token 替换）
-	if storedToken != token {
-		u.logger.WarnContext(ctx, "token mismatch")
-		return errcode.ErrEmailVerifyFailed
+	userID, err := uuid.Parse(parts[0])
+	if err != nil {
+		u.logger.WarnContext(ctx, "parse user id from redis value failed", "error", err)
+		return errcode.ErrEmailVerifyFailed.Wrap(err)
 	}
+	email := parts[1]
 
 	// 再次检查邮箱是否被其他用户占用（防止竞态条件）
 	existingUsers, err := u.repo.GetUserByEmail(ctx, []string{email})


### PR DESCRIPTION
问题：
  邮箱绑定 / 重置密码 token 由 crypto.Simple 生成，为 base32 编码
  且必然以 6 个 `=` 填充结尾。邮件经过 MTA、quoted-printable
  归一化或链接重写器时，末尾 `=` 会被吃掉，导致 base32 解码在
  byte 82 报错 "illegal base32 data at input byte 82"，用户无法
  完成邮箱绑定（100% 复现）。

方案：
  将 token 改为 uuid.NewString()：字符集仅 [0-9a-f-]，URL 安全，
  长度 36，没有 padding；熵 122 bit 反而高于原 5 字节随机。过期
  由 Redis TTL 控制。

改动：
  - biz/user/usecase/user.go SendBindEmailVerification / VerifyBindEmail： Redis key 由 bind_email_token:{userID} 改为 bind_email_token:{token}， value 由 {token}:{email} 改为 {userID}:{email}， 去掉 ValidateSimple 及冗余的 storedToken 比对。
  - biz/team/usecase/user.go generateResetPWDToken 内部改为 uuid.NewString()，签名保持不变 以最小化调用方改动（verify 侧 auth.go 无需修改）。

注意：
  语义变化——原实现 key 为 {userID}，同用户多次请求只有最新 token
  有效；新实现下多次请求的 token 并存有效（均受 24h TTL 控制）。