### PR TITLE
feat: 为 mcp_upstreams 补充软删除

### DIFF
--- a/backend/biz/setting/repo/mcp_test.go
+++ b/backend/biz/setting/repo/mcp_test.go
@@ -1,0 +1,87 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db/enttest"
+	"github.com/google/uuid"
+)
+
+func TestDeleteUserUpstreamMarksDeletedAt(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dsn := "file:user-mcp-upstream-delete?mode=memory&cache=shared&_fk=1"
+	client := enttest.Open(t, "sqlite3", dsn)
+	defer client.Close()
+
+	sqlDB, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("open sql db: %v", err)
+	}
+	defer sqlDB.Close()
+
+	uid := uuid.New()
+	if _, err := client.User.Create().
+		SetID(uid).
+		SetName("tester").
+		SetRole(consts.UserRoleIndividual).
+		SetStatus(consts.UserStatusActive).
+		Save(ctx); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	upstreamID := uuid.New()
+	if _, err := client.MCPUpstream.Create().
+		SetID(upstreamID).
+		SetName("Docs").
+		SetSlug("docs").
+		SetScope("user").
+		SetUserID(uid).
+		SetType("server").
+		SetURL("https://example.com/mcp").
+		SetHeaders(map[string]string{}).
+		Save(ctx); err != nil {
+		t.Fatalf("create upstream: %v", err)
+	}
+
+	toolID := uuid.New()
+	if _, err := client.MCPTool.Create().
+		SetID(toolID).
+		SetUpstreamID(upstreamID).
+		SetName("search_docs").
+		SetNamespacedName("docs__search_docs").
+		SetScope("user").
+		SetUserID(uid).
+		SetInputSchema(map[string]any{}).
+		Save(ctx); err != nil {
+		t.Fatalf("create tool: %v", err)
+	}
+
+	if _, err := client.MCPUserToolSetting.Create().
+		SetID(uuid.New()).
+		SetUserID(uid).
+		SetToolID(toolID).
+		SetEnabled(true).
+		Save(ctx); err != nil {
+		t.Fatalf("create tool setting: %v", err)
+	}
+
+	repo := &mcpRepo{db: client}
+	if err := repo.DeleteUserUpstream(ctx, uid, upstreamID); err != nil {
+		t.Fatalf("DeleteUserUpstream() error = %v", err)
+	}
+
+	var deletedAt sql.NullTime
+	if err := sqlDB.QueryRowContext(ctx, "SELECT deleted_at FROM mcp_upstreams WHERE id = ?", upstreamID.String()).Scan(&deletedAt); err != nil {
+		t.Fatalf("query deleted_at: %v", err)
+	}
+	if !deletedAt.Valid {
+		t.Fatal("deleted_at is NULL, want soft-deleted upstream")
+	}
+}

--- a/backend/db/client.go
+++ b/backend/db/client.go
@@ -2180,12 +2180,14 @@ func (c *MCPUpstreamClient) QueryUser(_m *MCPUpstream) *UserQuery {
 
 // Hooks returns the client hooks.
 func (c *MCPUpstreamClient) Hooks() []Hook {
-	return c.hooks.MCPUpstream
+	hooks := c.hooks.MCPUpstream
+	return append(hooks[:len(hooks):len(hooks)], mcpupstream.Hooks[:]...)
 }
 
 // Interceptors returns the client interceptors.
 func (c *MCPUpstreamClient) Interceptors() []Interceptor {
-	return c.inters.MCPUpstream
+	inters := c.inters.MCPUpstream
+	return append(inters[:len(inters):len(inters)], mcpupstream.Interceptors[:]...)
 }
 
 func (c *MCPUpstreamClient) mutate(ctx context.Context, m *MCPUpstreamMutation) (Value, error) {

--- a/backend/db/mcpupstream.go
+++ b/backend/db/mcpupstream.go
@@ -20,6 +20,8 @@ type MCPUpstream struct {
 	config `json:"-"`
 	// ID of the ent.
 	ID uuid.UUID `json:"id,omitempty"`
+	// DeletedAt holds the value of the "deleted_at" field.
+	DeletedAt time.Time `json:"deleted_at,omitempty"`
 	// Name holds the value of the "name" field.
 	Name string `json:"name,omitempty"`
 	// Slug holds the value of the "slug" field.
@@ -100,7 +102,7 @@ func (*MCPUpstream) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case mcpupstream.FieldName, mcpupstream.FieldSlug, mcpupstream.FieldScope, mcpupstream.FieldType, mcpupstream.FieldURL, mcpupstream.FieldDescription, mcpupstream.FieldHealthStatus, mcpupstream.FieldSyncStatus:
 			values[i] = new(sql.NullString)
-		case mcpupstream.FieldHealthCheckedAt, mcpupstream.FieldLastSyncedAt, mcpupstream.FieldCreatedAt, mcpupstream.FieldUpdatedAt:
+		case mcpupstream.FieldDeletedAt, mcpupstream.FieldHealthCheckedAt, mcpupstream.FieldLastSyncedAt, mcpupstream.FieldCreatedAt, mcpupstream.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
 		case mcpupstream.FieldID:
 			values[i] = new(uuid.UUID)
@@ -124,6 +126,12 @@ func (_m *MCPUpstream) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field id", values[i])
 			} else if value != nil {
 				_m.ID = *value
+			}
+		case mcpupstream.FieldDeletedAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field deleted_at", values[i])
+			} else if value.Valid {
+				_m.DeletedAt = value.Time
 			}
 		case mcpupstream.FieldName:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -266,6 +274,9 @@ func (_m *MCPUpstream) String() string {
 	var builder strings.Builder
 	builder.WriteString("MCPUpstream(")
 	builder.WriteString(fmt.Sprintf("id=%v, ", _m.ID))
+	builder.WriteString("deleted_at=")
+	builder.WriteString(_m.DeletedAt.Format(time.ANSIC))
+	builder.WriteString(", ")
 	builder.WriteString("name=")
 	builder.WriteString(_m.Name)
 	builder.WriteString(", ")

--- a/backend/db/mcpupstream/mcpupstream.go
+++ b/backend/db/mcpupstream/mcpupstream.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 )
@@ -15,6 +16,8 @@ const (
 	Label = "mcp_upstream"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
+	// FieldDeletedAt holds the string denoting the deleted_at field in the database.
+	FieldDeletedAt = "deleted_at"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
 	// FieldSlug holds the string denoting the slug field in the database.
@@ -70,6 +73,7 @@ const (
 // Columns holds all SQL columns for mcpupstream fields.
 var Columns = []string{
 	FieldID,
+	FieldDeletedAt,
 	FieldName,
 	FieldSlug,
 	FieldScope,
@@ -97,7 +101,14 @@ func ValidColumn(column string) bool {
 	return false
 }
 
+// Note that the variables below are initialized by the runtime
+// package on the initialization of the application. Therefore,
+// it should be imported in the main as follows:
+//
+//	import _ "github.com/chaitin/MonkeyCode/backend/db/runtime"
 var (
+	Hooks        [1]ent.Hook
+	Interceptors [1]ent.Interceptor
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
 	// SlugValidator is a validator for the "slug" field. It is called by the builders before save.
@@ -155,6 +166,11 @@ type OrderOption func(*sql.Selector)
 // ByID orders the results by the id field.
 func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByDeletedAt orders the results by the deleted_at field.
+func ByDeletedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDeletedAt, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.

--- a/backend/db/mcpupstream/where.go
+++ b/backend/db/mcpupstream/where.go
@@ -56,6 +56,11 @@ func IDLTE(id uuid.UUID) predicate.MCPUpstream {
 	return predicate.MCPUpstream(sql.FieldLTE(FieldID, id))
 }
 
+// DeletedAt applies equality check predicate on the "deleted_at" field. It's identical to DeletedAtEQ.
+func DeletedAt(v time.Time) predicate.MCPUpstream {
+	return predicate.MCPUpstream(sql.FieldEQ(FieldDeletedAt, v))
+}
+
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
 func Name(v string) predicate.MCPUpstream {
 	return predicate.MCPUpstream(sql.FieldEQ(FieldName, v))
@@ -119,6 +124,56 @@ func CreatedAt(v time.Time) predicate.MCPUpstream {
 // UpdatedAt applies equality check predicate on the "updated_at" field. It's identical to UpdatedAtEQ.
 func UpdatedAt(v time.Time) predicate.MCPUpstream {
 	return predicate.MCPUpstream(sql.FieldEQ(FieldUpdatedAt, v))
+}
+
+// DeletedAtEQ applies the EQ predicate on the "deleted_at" field.
+func DeletedAtEQ(v time.Time) predicate.MCPUpstream {
+	return predicate.MCPUpstream(sql.FieldEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtNEQ applies the NEQ predicate on the "deleted_at" field.
+func DeletedAtNEQ(v time.Time) predicate.MCPUpstream {
+	return predicate.MCPUpstream(sql.FieldNEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtIn applies the In predicate on the "deleted_at" field.
+func DeletedAtIn(vs ...time.Time) predicate.MCPUpstream {
+	return predicate.MCPUpstream(sql.FieldIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtNotIn applies the NotIn predicate on the "deleted_at" field.
+func DeletedAtNotIn(vs ...time.Time) predicate.MCPUpstream {
+	return predicate.MCPUpstream(sql.FieldNotIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtGT applies the GT predicate on the "deleted_at" field.
+func DeletedAtGT(v time.Time) predicate.MCPUpstream {
+	return predicate.MCPUpstream(sql.FieldGT(FieldDeletedAt, v))
+}
+
+// DeletedAtGTE applies the GTE predicate on the "deleted_at" field.
+func DeletedAtGTE(v time.Time) predicate.MCPUpstream {
+	return predicate.MCPUpstream(sql.FieldGTE(FieldDeletedAt, v))
+}
+
+// DeletedAtLT applies the LT predicate on the "deleted_at" field.
+func DeletedAtLT(v time.Time) predicate.MCPUpstream {
+	return predicate.MCPUpstream(sql.FieldLT(FieldDeletedAt, v))
+}
+
+// DeletedAtLTE applies the LTE predicate on the "deleted_at" field.
+func DeletedAtLTE(v time.Time) predicate.MCPUpstream {
+	return predicate.MCPUpstream(sql.FieldLTE(FieldDeletedAt, v))
+}
+
+// DeletedAtIsNil applies the IsNil predicate on the "deleted_at" field.
+func DeletedAtIsNil() predicate.MCPUpstream {
+	return predicate.MCPUpstream(sql.FieldIsNull(FieldDeletedAt))
+}
+
+// DeletedAtNotNil applies the NotNil predicate on the "deleted_at" field.
+func DeletedAtNotNil() predicate.MCPUpstream {
+	return predicate.MCPUpstream(sql.FieldNotNull(FieldDeletedAt))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.

--- a/backend/db/mcpupstream_create.go
+++ b/backend/db/mcpupstream_create.go
@@ -26,6 +26,20 @@ type MCPUpstreamCreate struct {
 	conflict []sql.ConflictOption
 }
 
+// SetDeletedAt sets the "deleted_at" field.
+func (_c *MCPUpstreamCreate) SetDeletedAt(v time.Time) *MCPUpstreamCreate {
+	_c.mutation.SetDeletedAt(v)
+	return _c
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (_c *MCPUpstreamCreate) SetNillableDeletedAt(v *time.Time) *MCPUpstreamCreate {
+	if v != nil {
+		_c.SetDeletedAt(*v)
+	}
+	return _c
+}
+
 // SetName sets the "name" field.
 func (_c *MCPUpstreamCreate) SetName(v string) *MCPUpstreamCreate {
 	_c.mutation.SetName(v)
@@ -229,7 +243,9 @@ func (_c *MCPUpstreamCreate) Mutation() *MCPUpstreamMutation {
 
 // Save creates the MCPUpstream in the database.
 func (_c *MCPUpstreamCreate) Save(ctx context.Context) (*MCPUpstream, error) {
-	_c.defaults()
+	if err := _c.defaults(); err != nil {
+		return nil, err
+	}
 	return withHooks(ctx, _c.sqlSave, _c.mutation, _c.hooks)
 }
 
@@ -256,7 +272,7 @@ func (_c *MCPUpstreamCreate) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (_c *MCPUpstreamCreate) defaults() {
+func (_c *MCPUpstreamCreate) defaults() error {
 	if _, ok := _c.mutation.GetType(); !ok {
 		v := mcpupstream.DefaultType
 		_c.mutation.SetType(v)
@@ -274,13 +290,20 @@ func (_c *MCPUpstreamCreate) defaults() {
 		_c.mutation.SetSyncStatus(v)
 	}
 	if _, ok := _c.mutation.CreatedAt(); !ok {
+		if mcpupstream.DefaultCreatedAt == nil {
+			return fmt.Errorf("db: uninitialized mcpupstream.DefaultCreatedAt (forgotten import db/runtime?)")
+		}
 		v := mcpupstream.DefaultCreatedAt()
 		_c.mutation.SetCreatedAt(v)
 	}
 	if _, ok := _c.mutation.UpdatedAt(); !ok {
+		if mcpupstream.DefaultUpdatedAt == nil {
+			return fmt.Errorf("db: uninitialized mcpupstream.DefaultUpdatedAt (forgotten import db/runtime?)")
+		}
 		v := mcpupstream.DefaultUpdatedAt()
 		_c.mutation.SetUpdatedAt(v)
 	}
+	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -386,6 +409,10 @@ func (_c *MCPUpstreamCreate) createSpec() (*MCPUpstream, *sqlgraph.CreateSpec) {
 		_node.ID = id
 		_spec.ID.Value = &id
 	}
+	if value, ok := _c.mutation.DeletedAt(); ok {
+		_spec.SetField(mcpupstream.FieldDeletedAt, field.TypeTime, value)
+		_node.DeletedAt = value
+	}
 	if value, ok := _c.mutation.Name(); ok {
 		_spec.SetField(mcpupstream.FieldName, field.TypeString, value)
 		_node.Name = value
@@ -482,7 +509,7 @@ func (_c *MCPUpstreamCreate) createSpec() (*MCPUpstream, *sqlgraph.CreateSpec) {
 // of the `INSERT` statement. For example:
 //
 //	client.MCPUpstream.Create().
-//		SetName(v).
+//		SetDeletedAt(v).
 //		OnConflict(
 //			// Update the row with the new values
 //			// the was proposed for insertion.
@@ -491,7 +518,7 @@ func (_c *MCPUpstreamCreate) createSpec() (*MCPUpstream, *sqlgraph.CreateSpec) {
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.MCPUpstreamUpsert) {
-//			SetName(v+v).
+//			SetDeletedAt(v+v).
 //		}).
 //		Exec(ctx)
 func (_c *MCPUpstreamCreate) OnConflict(opts ...sql.ConflictOption) *MCPUpstreamUpsertOne {
@@ -526,6 +553,24 @@ type (
 		*sql.UpdateSet
 	}
 )
+
+// SetDeletedAt sets the "deleted_at" field.
+func (u *MCPUpstreamUpsert) SetDeletedAt(v time.Time) *MCPUpstreamUpsert {
+	u.Set(mcpupstream.FieldDeletedAt, v)
+	return u
+}
+
+// UpdateDeletedAt sets the "deleted_at" field to the value that was provided on create.
+func (u *MCPUpstreamUpsert) UpdateDeletedAt() *MCPUpstreamUpsert {
+	u.SetExcluded(mcpupstream.FieldDeletedAt)
+	return u
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (u *MCPUpstreamUpsert) ClearDeletedAt() *MCPUpstreamUpsert {
+	u.SetNull(mcpupstream.FieldDeletedAt)
+	return u
+}
 
 // SetName sets the "name" field.
 func (u *MCPUpstreamUpsert) SetName(v string) *MCPUpstreamUpsert {
@@ -783,6 +828,27 @@ func (u *MCPUpstreamUpsertOne) Update(set func(*MCPUpstreamUpsert)) *MCPUpstream
 		set(&MCPUpstreamUpsert{UpdateSet: update})
 	}))
 	return u
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (u *MCPUpstreamUpsertOne) SetDeletedAt(v time.Time) *MCPUpstreamUpsertOne {
+	return u.Update(func(s *MCPUpstreamUpsert) {
+		s.SetDeletedAt(v)
+	})
+}
+
+// UpdateDeletedAt sets the "deleted_at" field to the value that was provided on create.
+func (u *MCPUpstreamUpsertOne) UpdateDeletedAt() *MCPUpstreamUpsertOne {
+	return u.Update(func(s *MCPUpstreamUpsert) {
+		s.UpdateDeletedAt()
+	})
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (u *MCPUpstreamUpsertOne) ClearDeletedAt() *MCPUpstreamUpsertOne {
+	return u.Update(func(s *MCPUpstreamUpsert) {
+		s.ClearDeletedAt()
+	})
 }
 
 // SetName sets the "name" field.
@@ -1166,7 +1232,7 @@ func (_c *MCPUpstreamCreateBulk) ExecX(ctx context.Context) {
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.MCPUpstreamUpsert) {
-//			SetName(v+v).
+//			SetDeletedAt(v+v).
 //		}).
 //		Exec(ctx)
 func (_c *MCPUpstreamCreateBulk) OnConflict(opts ...sql.ConflictOption) *MCPUpstreamUpsertBulk {
@@ -1243,6 +1309,27 @@ func (u *MCPUpstreamUpsertBulk) Update(set func(*MCPUpstreamUpsert)) *MCPUpstrea
 		set(&MCPUpstreamUpsert{UpdateSet: update})
 	}))
 	return u
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (u *MCPUpstreamUpsertBulk) SetDeletedAt(v time.Time) *MCPUpstreamUpsertBulk {
+	return u.Update(func(s *MCPUpstreamUpsert) {
+		s.SetDeletedAt(v)
+	})
+}
+
+// UpdateDeletedAt sets the "deleted_at" field to the value that was provided on create.
+func (u *MCPUpstreamUpsertBulk) UpdateDeletedAt() *MCPUpstreamUpsertBulk {
+	return u.Update(func(s *MCPUpstreamUpsert) {
+		s.UpdateDeletedAt()
+	})
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (u *MCPUpstreamUpsertBulk) ClearDeletedAt() *MCPUpstreamUpsertBulk {
+	return u.Update(func(s *MCPUpstreamUpsert) {
+		s.ClearDeletedAt()
+	})
 }
 
 // SetName sets the "name" field.

--- a/backend/db/mcpupstream_query.go
+++ b/backend/db/mcpupstream_query.go
@@ -339,12 +339,12 @@ func (_q *MCPUpstreamQuery) WithUser(opts ...func(*UserQuery)) *MCPUpstreamQuery
 // Example:
 //
 //	var v []struct {
-//		Name string `json:"name,omitempty"`
+//		DeletedAt time.Time `json:"deleted_at,omitempty"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
 //	client.MCPUpstream.Query().
-//		GroupBy(mcpupstream.FieldName).
+//		GroupBy(mcpupstream.FieldDeletedAt).
 //		Aggregate(db.Count()).
 //		Scan(ctx, &v)
 func (_q *MCPUpstreamQuery) GroupBy(field string, fields ...string) *MCPUpstreamGroupBy {
@@ -362,11 +362,11 @@ func (_q *MCPUpstreamQuery) GroupBy(field string, fields ...string) *MCPUpstream
 // Example:
 //
 //	var v []struct {
-//		Name string `json:"name,omitempty"`
+//		DeletedAt time.Time `json:"deleted_at,omitempty"`
 //	}
 //
 //	client.MCPUpstream.Query().
-//		Select(mcpupstream.FieldName).
+//		Select(mcpupstream.FieldDeletedAt).
 //		Scan(ctx, &v)
 func (_q *MCPUpstreamQuery) Select(fields ...string) *MCPUpstreamSelect {
 	_q.ctx.Fields = append(_q.ctx.Fields, fields...)

--- a/backend/db/mcpupstream_update.go
+++ b/backend/db/mcpupstream_update.go
@@ -32,6 +32,26 @@ func (_u *MCPUpstreamUpdate) Where(ps ...predicate.MCPUpstream) *MCPUpstreamUpda
 	return _u
 }
 
+// SetDeletedAt sets the "deleted_at" field.
+func (_u *MCPUpstreamUpdate) SetDeletedAt(v time.Time) *MCPUpstreamUpdate {
+	_u.mutation.SetDeletedAt(v)
+	return _u
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (_u *MCPUpstreamUpdate) SetNillableDeletedAt(v *time.Time) *MCPUpstreamUpdate {
+	if v != nil {
+		_u.SetDeletedAt(*v)
+	}
+	return _u
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (_u *MCPUpstreamUpdate) ClearDeletedAt() *MCPUpstreamUpdate {
+	_u.mutation.ClearDeletedAt()
+	return _u
+}
+
 // SetName sets the "name" field.
 func (_u *MCPUpstreamUpdate) SetName(v string) *MCPUpstreamUpdate {
 	_u.mutation.SetName(v)
@@ -310,7 +330,9 @@ func (_u *MCPUpstreamUpdate) ClearUser() *MCPUpstreamUpdate {
 
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (_u *MCPUpstreamUpdate) Save(ctx context.Context) (int, error) {
-	_u.defaults()
+	if err := _u.defaults(); err != nil {
+		return 0, err
+	}
 	return withHooks(ctx, _u.sqlSave, _u.mutation, _u.hooks)
 }
 
@@ -337,11 +359,15 @@ func (_u *MCPUpstreamUpdate) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (_u *MCPUpstreamUpdate) defaults() {
+func (_u *MCPUpstreamUpdate) defaults() error {
 	if _, ok := _u.mutation.UpdatedAt(); !ok {
+		if mcpupstream.UpdateDefaultUpdatedAt == nil {
+			return fmt.Errorf("db: uninitialized mcpupstream.UpdateDefaultUpdatedAt (forgotten import db/runtime?)")
+		}
 		v := mcpupstream.UpdateDefaultUpdatedAt()
 		_u.mutation.SetUpdatedAt(v)
 	}
+	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -401,6 +427,12 @@ func (_u *MCPUpstreamUpdate) sqlSave(ctx context.Context) (_node int, err error)
 				ps[i](selector)
 			}
 		}
+	}
+	if value, ok := _u.mutation.DeletedAt(); ok {
+		_spec.SetField(mcpupstream.FieldDeletedAt, field.TypeTime, value)
+	}
+	if _u.mutation.DeletedAtCleared() {
+		_spec.ClearField(mcpupstream.FieldDeletedAt, field.TypeTime)
 	}
 	if value, ok := _u.mutation.Name(); ok {
 		_spec.SetField(mcpupstream.FieldName, field.TypeString, value)
@@ -550,6 +582,26 @@ type MCPUpstreamUpdateOne struct {
 	hooks     []Hook
 	mutation  *MCPUpstreamMutation
 	modifiers []func(*sql.UpdateBuilder)
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (_u *MCPUpstreamUpdateOne) SetDeletedAt(v time.Time) *MCPUpstreamUpdateOne {
+	_u.mutation.SetDeletedAt(v)
+	return _u
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (_u *MCPUpstreamUpdateOne) SetNillableDeletedAt(v *time.Time) *MCPUpstreamUpdateOne {
+	if v != nil {
+		_u.SetDeletedAt(*v)
+	}
+	return _u
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (_u *MCPUpstreamUpdateOne) ClearDeletedAt() *MCPUpstreamUpdateOne {
+	_u.mutation.ClearDeletedAt()
+	return _u
 }
 
 // SetName sets the "name" field.
@@ -843,7 +895,9 @@ func (_u *MCPUpstreamUpdateOne) Select(field string, fields ...string) *MCPUpstr
 
 // Save executes the query and returns the updated MCPUpstream entity.
 func (_u *MCPUpstreamUpdateOne) Save(ctx context.Context) (*MCPUpstream, error) {
-	_u.defaults()
+	if err := _u.defaults(); err != nil {
+		return nil, err
+	}
 	return withHooks(ctx, _u.sqlSave, _u.mutation, _u.hooks)
 }
 
@@ -870,11 +924,15 @@ func (_u *MCPUpstreamUpdateOne) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (_u *MCPUpstreamUpdateOne) defaults() {
+func (_u *MCPUpstreamUpdateOne) defaults() error {
 	if _, ok := _u.mutation.UpdatedAt(); !ok {
+		if mcpupstream.UpdateDefaultUpdatedAt == nil {
+			return fmt.Errorf("db: uninitialized mcpupstream.UpdateDefaultUpdatedAt (forgotten import db/runtime?)")
+		}
 		v := mcpupstream.UpdateDefaultUpdatedAt()
 		_u.mutation.SetUpdatedAt(v)
 	}
+	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -951,6 +1009,12 @@ func (_u *MCPUpstreamUpdateOne) sqlSave(ctx context.Context) (_node *MCPUpstream
 				ps[i](selector)
 			}
 		}
+	}
+	if value, ok := _u.mutation.DeletedAt(); ok {
+		_spec.SetField(mcpupstream.FieldDeletedAt, field.TypeTime, value)
+	}
+	if _u.mutation.DeletedAtCleared() {
+		_spec.ClearField(mcpupstream.FieldDeletedAt, field.TypeTime)
 	}
 	if value, ok := _u.mutation.Name(); ok {
 		_spec.SetField(mcpupstream.FieldName, field.TypeString, value)

--- a/backend/db/migrate/schema.go
+++ b/backend/db/migrate/schema.go
@@ -252,6 +252,7 @@ var (
 	// McpUpstreamsColumns holds the columns for the "mcp_upstreams" table.
 	McpUpstreamsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeUUID, Unique: true},
+		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "name", Type: field.TypeString, Size: 128},
 		{Name: "slug", Type: field.TypeString, Size: 64},
 		{Name: "scope", Type: field.TypeEnum, Enums: []string{"user", "platform"}},
@@ -276,7 +277,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "mcp_upstreams_users_mcp_upstreams",
-				Columns:    []*schema.Column{McpUpstreamsColumns[15]},
+				Columns:    []*schema.Column{McpUpstreamsColumns[16]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -285,7 +286,10 @@ var (
 			{
 				Name:    "mcpupstream_scope_user_id_slug",
 				Unique:  true,
-				Columns: []*schema.Column{McpUpstreamsColumns[3], McpUpstreamsColumns[15], McpUpstreamsColumns[2]},
+				Columns: []*schema.Column{McpUpstreamsColumns[4], McpUpstreamsColumns[16], McpUpstreamsColumns[3]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "deleted_at IS NULL",
+				},
 			},
 		},
 	}

--- a/backend/db/mutation.go
+++ b/backend/db/mutation.go
@@ -9015,6 +9015,7 @@ type MCPUpstreamMutation struct {
 	op                Op
 	typ               string
 	id                *uuid.UUID
+	deleted_at        *time.Time
 	name              *string
 	slug              *string
 	scope             *mcpupstream.Scope
@@ -9142,6 +9143,55 @@ func (m *MCPUpstreamMutation) IDs(ctx context.Context) ([]uuid.UUID, error) {
 	default:
 		return nil, fmt.Errorf("IDs is not allowed on %s operations", m.op)
 	}
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (m *MCPUpstreamMutation) SetDeletedAt(t time.Time) {
+	m.deleted_at = &t
+}
+
+// DeletedAt returns the value of the "deleted_at" field in the mutation.
+func (m *MCPUpstreamMutation) DeletedAt() (r time.Time, exists bool) {
+	v := m.deleted_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeletedAt returns the old "deleted_at" field's value of the MCPUpstream entity.
+// If the MCPUpstream object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *MCPUpstreamMutation) OldDeletedAt(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeletedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeletedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeletedAt: %w", err)
+	}
+	return oldValue.DeletedAt, nil
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (m *MCPUpstreamMutation) ClearDeletedAt() {
+	m.deleted_at = nil
+	m.clearedFields[mcpupstream.FieldDeletedAt] = struct{}{}
+}
+
+// DeletedAtCleared returns if the "deleted_at" field was cleared in this mutation.
+func (m *MCPUpstreamMutation) DeletedAtCleared() bool {
+	_, ok := m.clearedFields[mcpupstream.FieldDeletedAt]
+	return ok
+}
+
+// ResetDeletedAt resets all changes to the "deleted_at" field.
+func (m *MCPUpstreamMutation) ResetDeletedAt() {
+	m.deleted_at = nil
+	delete(m.clearedFields, mcpupstream.FieldDeletedAt)
 }
 
 // SetName sets the "name" field.
@@ -9864,7 +9914,10 @@ func (m *MCPUpstreamMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *MCPUpstreamMutation) Fields() []string {
-	fields := make([]string, 0, 15)
+	fields := make([]string, 0, 16)
+	if m.deleted_at != nil {
+		fields = append(fields, mcpupstream.FieldDeletedAt)
+	}
 	if m.name != nil {
 		fields = append(fields, mcpupstream.FieldName)
 	}
@@ -9918,6 +9971,8 @@ func (m *MCPUpstreamMutation) Fields() []string {
 // schema.
 func (m *MCPUpstreamMutation) Field(name string) (ent.Value, bool) {
 	switch name {
+	case mcpupstream.FieldDeletedAt:
+		return m.DeletedAt()
 	case mcpupstream.FieldName:
 		return m.Name()
 	case mcpupstream.FieldSlug:
@@ -9957,6 +10012,8 @@ func (m *MCPUpstreamMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *MCPUpstreamMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
+	case mcpupstream.FieldDeletedAt:
+		return m.OldDeletedAt(ctx)
 	case mcpupstream.FieldName:
 		return m.OldName(ctx)
 	case mcpupstream.FieldSlug:
@@ -9996,6 +10053,13 @@ func (m *MCPUpstreamMutation) OldField(ctx context.Context, name string) (ent.Va
 // type.
 func (m *MCPUpstreamMutation) SetField(name string, value ent.Value) error {
 	switch name {
+	case mcpupstream.FieldDeletedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeletedAt(v)
+		return nil
 	case mcpupstream.FieldName:
 		v, ok := value.(string)
 		if !ok {
@@ -10131,6 +10195,9 @@ func (m *MCPUpstreamMutation) AddField(name string, value ent.Value) error {
 // mutation.
 func (m *MCPUpstreamMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(mcpupstream.FieldDeletedAt) {
+		fields = append(fields, mcpupstream.FieldDeletedAt)
+	}
 	if m.FieldCleared(mcpupstream.FieldUserID) {
 		fields = append(fields, mcpupstream.FieldUserID)
 	}
@@ -10160,6 +10227,9 @@ func (m *MCPUpstreamMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *MCPUpstreamMutation) ClearField(name string) error {
 	switch name {
+	case mcpupstream.FieldDeletedAt:
+		m.ClearDeletedAt()
+		return nil
 	case mcpupstream.FieldUserID:
 		m.ClearUserID()
 		return nil
@@ -10183,6 +10253,9 @@ func (m *MCPUpstreamMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *MCPUpstreamMutation) ResetField(name string) error {
 	switch name {
+	case mcpupstream.FieldDeletedAt:
+		m.ResetDeletedAt()
+		return nil
 	case mcpupstream.FieldName:
 		m.ResetName()
 		return nil

--- a/backend/db/runtime/runtime.go
+++ b/backend/db/runtime/runtime.go
@@ -208,6 +208,11 @@ func init() {
 	mcptool.DefaultUpdatedAt = mcptoolDescUpdatedAt.Default.(func() time.Time)
 	// mcptool.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	mcptool.UpdateDefaultUpdatedAt = mcptoolDescUpdatedAt.UpdateDefault.(func() time.Time)
+	mcpupstreamMixin := schema.MCPUpstream{}.Mixin()
+	mcpupstreamMixinHooks0 := mcpupstreamMixin[0].Hooks()
+	mcpupstream.Hooks[0] = mcpupstreamMixinHooks0[0]
+	mcpupstreamMixinInters0 := mcpupstreamMixin[0].Interceptors()
+	mcpupstream.Interceptors[0] = mcpupstreamMixinInters0[0]
 	mcpupstreamFields := schema.MCPUpstream{}.Fields()
 	_ = mcpupstreamFields
 	// mcpupstreamDescName is the schema descriptor for name field.

--- a/backend/ent/schema/mcpupstream.go
+++ b/backend/ent/schema/mcpupstream.go
@@ -10,6 +10,8 @@ import (
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
 	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/pkg/entx"
 )
 
 type MCPUpstream struct {
@@ -19,6 +21,12 @@ type MCPUpstream struct {
 func (MCPUpstream) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entsql.Table("mcp_upstreams"),
+	}
+}
+
+func (MCPUpstream) Mixin() []ent.Mixin {
+	return []ent.Mixin{
+		entx.SoftDeleteMixin2{},
 	}
 }
 
@@ -45,7 +53,9 @@ func (MCPUpstream) Fields() []ent.Field {
 
 func (MCPUpstream) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("scope", "user_id", "slug").Unique(),
+		index.Fields("scope", "user_id", "slug").
+			Unique().
+			Annotations(entsql.IndexWhere("deleted_at IS NULL")),
 	}
 }
 


### PR DESCRIPTION
## Summary
- 为 MCPUpstream 接入 entx.SoftDeleteMixin2
- 生成 ent 代码并让删除查询默认走软删除
- 补充删除后写入 deleted_at 的回归测试

## Test Plan
- go test ./biz/setting/repo -run TestDeleteUserUpstreamMarksDeletedAt
- go test ./biz/setting/...