### PR TITLE
feat(task): 增加任务最近活跃时间

### DIFF
--- a/backend/biz/task/handler/v1/task.go
+++ b/backend/biz/task/handler/v1/task.go
@@ -46,6 +46,7 @@ type TaskHandler struct {
 	taskConns     *ws.TaskConn
 	controlConns  *ws.ControlConn
 	taskSummary   *service.TaskSummaryService
+	taskActivity  service.TaskActivityRefresher
 	idleRefresher vmidle.VMIdleRefresher
 	activeRepo    domain.UserActiveRepo
 }
@@ -64,6 +65,7 @@ func NewTaskHandler(i *do.Injector) (*TaskHandler, error) {
 	tc := do.MustInvoke[*ws.TaskConn](i)
 	cc := do.MustInvoke[*ws.ControlConn](i)
 	ts := do.MustInvoke[*service.TaskSummaryService](i)
+	ta := do.MustInvoke[service.TaskActivityRefresher](i)
 	ir := do.MustInvoke[vmidle.VMIdleRefresher](i)
 
 	// Optional deps
@@ -91,6 +93,7 @@ func NewTaskHandler(i *do.Injector) (*TaskHandler, error) {
 		taskConns:     tc,
 		controlConns:  cc,
 		taskSummary:   ts,
+		taskActivity:  ta,
 		idleRefresher: ir,
 		activeRepo:    activeRepo,
 	}

--- a/backend/biz/task/handler/v1/task_control.go
+++ b/backend/biz/task/handler/v1/task_control.go
@@ -10,7 +10,9 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/GoYoko/web"
+	"github.com/google/uuid"
 
+	"github.com/chaitin/MonkeyCode/backend/biz/task/service"
 	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/middleware"
@@ -130,6 +132,9 @@ func (h *TaskHandler) Control(c *web.Context, req domain.TaskControlReq) error {
 
 	logger := h.logger.With("task_id", task.ID, "fn", "task.control")
 	taskID := task.ID.String()
+	if err := h.taskActivity.Refresh(c.Request().Context(), task.ID); err != nil {
+		logger.WarnContext(c.Request().Context(), "failed to refresh task last active on control connect", "error", err)
+	}
 
 	// 连接建立：刷新空闲计时器
 	if vm := task.VirtualMachine; vm != nil {
@@ -182,7 +187,7 @@ func (h *TaskHandler) Control(c *web.Context, req domain.TaskControlReq) error {
 	// 定期刷新空闲计时器，保持 VM 活跃
 	if vm := task.VirtualMachine; vm != nil {
 		g.Go(func() error {
-			return h.controlKeepAlive(ctx, vm.ID)
+			return h.controlKeepAlive(ctx, task.ID, vm.ID)
 		})
 	}
 
@@ -211,16 +216,22 @@ func (h *TaskHandler) controlPing(ctx context.Context, wsConn *ws.WebsocketManag
 }
 
 // controlKeepAlive 定期刷新空闲计时器，防止 VM 被误判空闲
-func (h *TaskHandler) controlKeepAlive(ctx context.Context, vmID string) error {
-	ticker := time.NewTicker(1 * time.Minute)
-	defer ticker.Stop()
+func (h *TaskHandler) controlKeepAlive(ctx context.Context, taskID uuid.UUID, vmID string) error {
+	idleTicker := time.NewTicker(1 * time.Minute)
+	activityTicker := time.NewTicker(service.TaskActivityRefreshInterval)
+	defer idleTicker.Stop()
+	defer activityTicker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-ticker.C:
+		case <-idleTicker.C:
 			if err := h.idleRefresher.Refresh(ctx, vmID); err != nil {
 				h.logger.WarnContext(ctx, "keepalive refresh failed", "vmID", vmID, "error", err)
+			}
+		case <-activityTicker.C:
+			if err := h.taskActivity.Refresh(ctx, taskID); err != nil {
+				h.logger.WarnContext(ctx, "task activity refresh failed", "taskID", taskID, "error", err)
 			}
 		}
 	}

--- a/backend/biz/task/handler/v1/task_control.go
+++ b/backend/biz/task/handler/v1/task_control.go
@@ -217,6 +217,13 @@ func (h *TaskHandler) controlPing(ctx context.Context, wsConn *ws.WebsocketManag
 
 // controlKeepAlive 定期刷新空闲计时器，防止 VM 被误判空闲
 func (h *TaskHandler) controlKeepAlive(ctx context.Context, taskID uuid.UUID, vmID string) error {
+	if err := h.idleRefresher.Refresh(ctx, vmID); err != nil {
+		h.logger.WarnContext(ctx, "keepalive refresh failed", "vmID", vmID, "error", err)
+	}
+	if err := h.taskActivity.Refresh(ctx, taskID); err != nil {
+		h.logger.WarnContext(ctx, "task activity refresh failed", "taskID", taskID, "error", err)
+	}
+
 	idleTicker := time.NewTicker(1 * time.Minute)
 	activityTicker := time.NewTicker(service.TaskActivityRefreshInterval)
 	defer idleTicker.Stop()

--- a/backend/biz/task/handler/v1/task_control_test.go
+++ b/backend/biz/task/handler/v1/task_control_test.go
@@ -1,0 +1,93 @@
+package v1
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/biz/task/service"
+)
+
+func TestControlKeepAliveRefreshesImmediately(t *testing.T) {
+	taskID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	vmID := "vm-1"
+
+	idleRefresher := &testVMIdleRefresher{ch: make(chan string, 1)}
+	taskActivity := &testTaskActivityRefresher{ch: make(chan uuid.UUID, 1)}
+	handler := &TaskHandler{
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		idleRefresher: idleRefresher,
+		taskActivity:  taskActivity,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- handler.controlKeepAlive(ctx, taskID, vmID)
+	}()
+
+	select {
+	case got := <-idleRefresher.ch:
+		if got != vmID {
+			t.Fatalf("idle refresher vm id = %q, want %q", got, vmID)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected idle refresher to run immediately")
+	}
+
+	select {
+	case got := <-taskActivity.ch:
+		if got != taskID {
+			t.Fatalf("task activity task id = %s, want %s", got, taskID)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected task activity refresher to run immediately")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("controlKeepAlive() error = nil, want context canceled")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("controlKeepAlive() did not exit after cancel")
+	}
+}
+
+type testVMIdleRefresher struct {
+	ch chan string
+}
+
+func (r *testVMIdleRefresher) Refresh(_ context.Context, vmID string) error {
+	select {
+	case r.ch <- vmID:
+	default:
+	}
+	return nil
+}
+
+type testTaskActivityRefresher struct {
+	ch chan uuid.UUID
+}
+
+func (r *testTaskActivityRefresher) Refresh(_ context.Context, taskID uuid.UUID) error {
+	select {
+	case r.ch <- taskID:
+	default:
+	}
+	return nil
+}
+
+func (r *testTaskActivityRefresher) ForceRefresh(context.Context, uuid.UUID) error {
+	return nil
+}
+
+var _ service.TaskActivityRefresher = (*testTaskActivityRefresher)(nil)

--- a/backend/biz/task/register.go
+++ b/backend/biz/task/register.go
@@ -13,6 +13,7 @@ import (
 func ProvideTask(i *do.Injector) {
 	do.Provide(i, usecase.NewTaskUsecase)
 	do.Provide(i, usecase.NewGitTaskUsecase)
+	do.Provide(i, service.NewTaskActivityRefresher)
 	do.Provide(i, service.NewTaskSummaryService)
 	do.Provide(i, v1.NewTaskHandler)
 	do.Provide(i, repo.NewTaskRepo)

--- a/backend/biz/task/repo/task.go
+++ b/backend/biz/task/repo/task.go
@@ -261,6 +261,15 @@ func (t *TaskRepo) Update(ctx context.Context, _ *domain.User, id uuid.UUID, fn 
 	})
 }
 
+func (t *TaskRepo) RefreshLastActiveAt(ctx context.Context, id uuid.UUID, at time.Time, minInterval time.Duration) error {
+	up := t.db.Task.Update().Where(task.ID(id))
+	if minInterval > 0 {
+		up = up.Where(task.LastActiveAtLT(at.Add(-minInterval)))
+	}
+	_, err := up.SetLastActiveAt(at).Save(ctx)
+	return err
+}
+
 // Delete implements domain.TaskRepo.
 func (t *TaskRepo) Delete(ctx context.Context, user *domain.User, id uuid.UUID) error {
 	_, err := t.db.Task.Delete().

--- a/backend/biz/task/service/activity.go
+++ b/backend/biz/task/service/activity.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/samber/do"
+
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+const TaskActivityRefreshInterval = 5 * time.Minute
+
+type TaskActivityRefresher interface {
+	Refresh(ctx context.Context, taskID uuid.UUID) error
+	ForceRefresh(ctx context.Context, taskID uuid.UUID) error
+}
+
+type taskActivityRefresher struct {
+	repo  taskActivityRepo
+	clock func() time.Time
+}
+
+type taskActivityRepo interface {
+	RefreshLastActiveAt(ctx context.Context, id uuid.UUID, at time.Time, minInterval time.Duration) error
+}
+
+func NewTaskActivityRefresher(i *do.Injector) (TaskActivityRefresher, error) {
+	return &taskActivityRefresher{
+		repo:  do.MustInvoke[domain.TaskRepo](i),
+		clock: time.Now,
+	}, nil
+}
+
+func (r *taskActivityRefresher) Refresh(ctx context.Context, taskID uuid.UUID) error {
+	return r.repo.RefreshLastActiveAt(ctx, taskID, r.clock(), TaskActivityRefreshInterval)
+}
+
+func (r *taskActivityRefresher) ForceRefresh(ctx context.Context, taskID uuid.UUID) error {
+	return r.repo.RefreshLastActiveAt(ctx, taskID, r.clock(), 0)
+}

--- a/backend/biz/task/service/activity_test.go
+++ b/backend/biz/task/service/activity_test.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestTaskActivityRefresherRefreshUsesThrottleInterval(t *testing.T) {
+	taskID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	now := time.Unix(1_700_000_000, 0).UTC()
+	repo := &taskActivityRepoStub{}
+	refresher := &taskActivityRefresher{
+		repo:  repo,
+		clock: func() time.Time { return now },
+	}
+
+	if err := refresher.Refresh(context.Background(), taskID); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	if repo.taskID != taskID {
+		t.Fatalf("task id = %s, want %s", repo.taskID, taskID)
+	}
+	if !repo.at.Equal(now) {
+		t.Fatalf("refresh time = %s, want %s", repo.at, now)
+	}
+	if repo.minInterval != TaskActivityRefreshInterval {
+		t.Fatalf("min interval = %s, want %s", repo.minInterval, TaskActivityRefreshInterval)
+	}
+}
+
+func TestTaskActivityRefresherForceRefreshBypassesThrottle(t *testing.T) {
+	taskID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	now := time.Unix(1_700_000_100, 0).UTC()
+	repo := &taskActivityRepoStub{}
+	refresher := &taskActivityRefresher{
+		repo:  repo,
+		clock: func() time.Time { return now },
+	}
+
+	if err := refresher.ForceRefresh(context.Background(), taskID); err != nil {
+		t.Fatalf("ForceRefresh() error = %v", err)
+	}
+
+	if repo.taskID != taskID {
+		t.Fatalf("task id = %s, want %s", repo.taskID, taskID)
+	}
+	if !repo.at.Equal(now) {
+		t.Fatalf("refresh time = %s, want %s", repo.at, now)
+	}
+	if repo.minInterval != 0 {
+		t.Fatalf("min interval = %s, want 0", repo.minInterval)
+	}
+}
+
+type taskActivityRepoStub struct {
+	taskID      uuid.UUID
+	at          time.Time
+	minInterval time.Duration
+}
+
+func (s *taskActivityRepoStub) RefreshLastActiveAt(_ context.Context, taskID uuid.UUID, at time.Time, minInterval time.Duration) error {
+	s.taskID = taskID
+	s.at = at
+	s.minInterval = minInterval
+	return nil
+}

--- a/backend/biz/task/usecase/task.go
+++ b/backend/biz/task/usecase/task.go
@@ -19,6 +19,8 @@ import (
 	"github.com/samber/do"
 
 	gituc "github.com/chaitin/MonkeyCode/backend/biz/git/usecase"
+	"github.com/chaitin/MonkeyCode/backend/biz/task/service"
+	vmidle "github.com/chaitin/MonkeyCode/backend/biz/vmidle/usecase"
 	"github.com/chaitin/MonkeyCode/backend/config"
 	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/db"
@@ -36,40 +38,44 @@ import (
 
 // TaskUsecase 任务业务逻辑实现
 type TaskUsecase struct {
-	cfg              *config.Config
-	repo             domain.TaskRepo
-	modelRepo        domain.ModelRepo
-	logger           *slog.Logger
-	taskflow         taskflow.Clienter
-	loki             *loki.Client
-	redis            *redis.Client
-	notifyDispatcher *dispatcher.Dispatcher
-	taskHook         domain.TaskHook
-	privilegeChecker domain.PrivilegeChecker
-	modelHook        domain.ModelHook
-	taskLifecycle    *lifecycle.Manager[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata]
-	vmLifecycle      *lifecycle.Manager[string, lifecycle.VMState, lifecycle.VMMetadata]
-	girepo           domain.GitIdentityRepo
-	tokenProvider    *gituc.TokenProvider
-	projectRepo      domain.ProjectRepo
+	cfg                   *config.Config
+	repo                  domain.TaskRepo
+	modelRepo             domain.ModelRepo
+	logger                *slog.Logger
+	taskflow              taskflow.Clienter
+	loki                  *loki.Client
+	redis                 *redis.Client
+	notifyDispatcher      *dispatcher.Dispatcher
+	taskHook              domain.TaskHook
+	privilegeChecker      domain.PrivilegeChecker
+	modelHook             domain.ModelHook
+	taskLifecycle         *lifecycle.Manager[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata]
+	vmLifecycle           *lifecycle.Manager[string, lifecycle.VMState, lifecycle.VMMetadata]
+	girepo                domain.GitIdentityRepo
+	tokenProvider         *gituc.TokenProvider
+	projectRepo           domain.ProjectRepo
+	taskActivityRefresher service.TaskActivityRefresher
+	idleRefresher         vmidle.VMIdleRefresher
 }
 
 // NewTaskUsecase 创建任务业务逻辑实例
 func NewTaskUsecase(i *do.Injector) (domain.TaskUsecase, error) {
 	u := &TaskUsecase{
-		cfg:              do.MustInvoke[*config.Config](i),
-		repo:             do.MustInvoke[domain.TaskRepo](i),
-		modelRepo:        do.MustInvoke[domain.ModelRepo](i),
-		logger:           do.MustInvoke[*slog.Logger](i).With("module", "usecase.TaskUsecase"),
-		taskflow:         do.MustInvoke[taskflow.Clienter](i),
-		loki:             do.MustInvoke[*loki.Client](i),
-		redis:            do.MustInvoke[*redis.Client](i),
-		notifyDispatcher: do.MustInvoke[*dispatcher.Dispatcher](i),
-		taskLifecycle:    do.MustInvoke[*lifecycle.Manager[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata]](i),
-		vmLifecycle:      do.MustInvoke[*lifecycle.Manager[string, lifecycle.VMState, lifecycle.VMMetadata]](i),
-		girepo:           do.MustInvoke[domain.GitIdentityRepo](i),
-		tokenProvider:    do.MustInvoke[*gituc.TokenProvider](i),
-		projectRepo:      do.MustInvoke[domain.ProjectRepo](i),
+		cfg:                   do.MustInvoke[*config.Config](i),
+		repo:                  do.MustInvoke[domain.TaskRepo](i),
+		modelRepo:             do.MustInvoke[domain.ModelRepo](i),
+		logger:                do.MustInvoke[*slog.Logger](i).With("module", "usecase.TaskUsecase"),
+		taskflow:              do.MustInvoke[taskflow.Clienter](i),
+		loki:                  do.MustInvoke[*loki.Client](i),
+		redis:                 do.MustInvoke[*redis.Client](i),
+		notifyDispatcher:      do.MustInvoke[*dispatcher.Dispatcher](i),
+		taskLifecycle:         do.MustInvoke[*lifecycle.Manager[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata]](i),
+		vmLifecycle:           do.MustInvoke[*lifecycle.Manager[string, lifecycle.VMState, lifecycle.VMMetadata]](i),
+		girepo:                do.MustInvoke[domain.GitIdentityRepo](i),
+		tokenProvider:         do.MustInvoke[*gituc.TokenProvider](i),
+		projectRepo:           do.MustInvoke[domain.ProjectRepo](i),
+		taskActivityRefresher: do.MustInvoke[service.TaskActivityRefresher](i),
+		idleRefresher:         do.MustInvoke[vmidle.VMIdleRefresher](i),
 	}
 
 	// 可选注入 TaskHook
@@ -450,6 +456,11 @@ func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.
 	if err := a.IncrUserInputCount(ctx, user.ID, pt.Edges.Task.ID); err != nil {
 		a.logger.WarnContext(ctx, "failed to incr user input count on create", "error", err)
 	}
+	vmID := ""
+	if createdVm != nil {
+		vmID = createdVm.ID
+	}
+	a.refreshCreatedTaskState(ctx, pt.TaskID, vmID)
 
 	result := cvt.From(pt, &domain.ProjectTask{})
 
@@ -461,6 +472,18 @@ func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.
 	}
 
 	return result, nil
+}
+
+func (a *TaskUsecase) refreshCreatedTaskState(ctx context.Context, taskID uuid.UUID, vmID string) {
+	if err := a.taskActivityRefresher.ForceRefresh(ctx, taskID); err != nil {
+		a.logger.WarnContext(ctx, "failed to refresh task last active on create", "task_id", taskID, "error", err)
+	}
+	if vmID == "" {
+		return
+	}
+	if err := a.idleRefresher.Refresh(ctx, vmID); err != nil {
+		a.logger.WarnContext(ctx, "failed to refresh vm idle timers on create", "task_id", taskID, "vm_id", vmID, "error", err)
+	}
 }
 
 func (a *TaskUsecase) buildMCPConfigs(taskID uuid.UUID, token string) []taskflow.McpServerConfig {

--- a/backend/biz/task/usecase/task_activity_test.go
+++ b/backend/biz/task/usecase/task_activity_test.go
@@ -1,0 +1,66 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestRefreshCreatedTaskStateAlwaysRefreshesIdleTimer(t *testing.T) {
+	taskID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	vmID := "vm-1"
+	taskRefresher := &taskActivityRefresherStub{err: errors.New("db write failed")}
+	idleRefresher := &vmIdleRefresherStub{}
+	u := &TaskUsecase{
+		logger:                slog.New(slog.NewTextHandler(io.Discard, nil)),
+		taskActivityRefresher: taskRefresher,
+		idleRefresher:         idleRefresher,
+	}
+
+	u.refreshCreatedTaskState(context.Background(), taskID, vmID)
+
+	if !taskRefresher.forceCalled {
+		t.Fatal("expected task activity refresher to be called")
+	}
+	if taskRefresher.taskID != taskID {
+		t.Fatalf("task id = %s, want %s", taskRefresher.taskID, taskID)
+	}
+	if !idleRefresher.called {
+		t.Fatal("expected vm idle refresher to be called")
+	}
+	if idleRefresher.vmID != vmID {
+		t.Fatalf("vm id = %s, want %s", idleRefresher.vmID, vmID)
+	}
+}
+
+type taskActivityRefresherStub struct {
+	taskID      uuid.UUID
+	forceCalled bool
+	err         error
+}
+
+func (s *taskActivityRefresherStub) Refresh(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (s *taskActivityRefresherStub) ForceRefresh(_ context.Context, taskID uuid.UUID) error {
+	s.taskID = taskID
+	s.forceCalled = true
+	return s.err
+}
+
+type vmIdleRefresherStub struct {
+	vmID   string
+	called bool
+	err    error
+}
+
+func (s *vmIdleRefresherStub) Refresh(_ context.Context, vmID string) error {
+	s.vmID = vmID
+	s.called = true
+	return s.err
+}

--- a/backend/db/migrate/schema.go
+++ b/backend/db/migrate/schema.go
@@ -741,6 +741,7 @@ var (
 		{Name: "summary", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "status", Type: field.TypeString},
 		{Name: "created_at", Type: field.TypeTime},
+		{Name: "last_active_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "completed_at", Type: field.TypeTime, Nullable: true},
 		{Name: "user_id", Type: field.TypeUUID},
@@ -753,7 +754,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "tasks_users_tasks",
-				Columns:    []*schema.Column{TasksColumns[11]},
+				Columns:    []*schema.Column{TasksColumns[12]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},

--- a/backend/db/mutation.go
+++ b/backend/db/mutation.go
@@ -23369,6 +23369,7 @@ type TaskMutation struct {
 	summary              *string
 	status               *consts.TaskStatus
 	created_at           *time.Time
+	last_active_at       *time.Time
 	updated_at           *time.Time
 	completed_at         *time.Time
 	clearedFields        map[string]struct{}
@@ -23871,6 +23872,42 @@ func (m *TaskMutation) ResetCreatedAt() {
 	m.created_at = nil
 }
 
+// SetLastActiveAt sets the "last_active_at" field.
+func (m *TaskMutation) SetLastActiveAt(t time.Time) {
+	m.last_active_at = &t
+}
+
+// LastActiveAt returns the value of the "last_active_at" field in the mutation.
+func (m *TaskMutation) LastActiveAt() (r time.Time, exists bool) {
+	v := m.last_active_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldLastActiveAt returns the old "last_active_at" field's value of the Task entity.
+// If the Task object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TaskMutation) OldLastActiveAt(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldLastActiveAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldLastActiveAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldLastActiveAt: %w", err)
+	}
+	return oldValue.LastActiveAt, nil
+}
+
+// ResetLastActiveAt resets all changes to the "last_active_at" field.
+func (m *TaskMutation) ResetLastActiveAt() {
+	m.last_active_at = nil
+}
+
 // SetUpdatedAt sets the "updated_at" field.
 func (m *TaskMutation) SetUpdatedAt(t time.Time) {
 	m.updated_at = &t
@@ -24233,7 +24270,7 @@ func (m *TaskMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *TaskMutation) Fields() []string {
-	fields := make([]string, 0, 11)
+	fields := make([]string, 0, 12)
 	if m.deleted_at != nil {
 		fields = append(fields, task.FieldDeletedAt)
 	}
@@ -24260,6 +24297,9 @@ func (m *TaskMutation) Fields() []string {
 	}
 	if m.created_at != nil {
 		fields = append(fields, task.FieldCreatedAt)
+	}
+	if m.last_active_at != nil {
+		fields = append(fields, task.FieldLastActiveAt)
 	}
 	if m.updated_at != nil {
 		fields = append(fields, task.FieldUpdatedAt)
@@ -24293,6 +24333,8 @@ func (m *TaskMutation) Field(name string) (ent.Value, bool) {
 		return m.Status()
 	case task.FieldCreatedAt:
 		return m.CreatedAt()
+	case task.FieldLastActiveAt:
+		return m.LastActiveAt()
 	case task.FieldUpdatedAt:
 		return m.UpdatedAt()
 	case task.FieldCompletedAt:
@@ -24324,6 +24366,8 @@ func (m *TaskMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldStatus(ctx)
 	case task.FieldCreatedAt:
 		return m.OldCreatedAt(ctx)
+	case task.FieldLastActiveAt:
+		return m.OldLastActiveAt(ctx)
 	case task.FieldUpdatedAt:
 		return m.OldUpdatedAt(ctx)
 	case task.FieldCompletedAt:
@@ -24399,6 +24443,13 @@ func (m *TaskMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCreatedAt(v)
+		return nil
+	case task.FieldLastActiveAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetLastActiveAt(v)
 		return nil
 	case task.FieldUpdatedAt:
 		v, ok := value.(time.Time)
@@ -24522,6 +24573,9 @@ func (m *TaskMutation) ResetField(name string) error {
 		return nil
 	case task.FieldCreatedAt:
 		m.ResetCreatedAt()
+		return nil
+	case task.FieldLastActiveAt:
+		m.ResetLastActiveAt()
 		return nil
 	case task.FieldUpdatedAt:
 		m.ResetUpdatedAt()

--- a/backend/db/runtime/runtime.go
+++ b/backend/db/runtime/runtime.go
@@ -634,8 +634,12 @@ func init() {
 	taskDescCreatedAt := taskFields[8].Descriptor()
 	// task.DefaultCreatedAt holds the default value on creation for the created_at field.
 	task.DefaultCreatedAt = taskDescCreatedAt.Default.(func() time.Time)
+	// taskDescLastActiveAt is the schema descriptor for last_active_at field.
+	taskDescLastActiveAt := taskFields[9].Descriptor()
+	// task.DefaultLastActiveAt holds the default value on creation for the last_active_at field.
+	task.DefaultLastActiveAt = taskDescLastActiveAt.Default.(func() time.Time)
 	// taskDescUpdatedAt is the schema descriptor for updated_at field.
-	taskDescUpdatedAt := taskFields[9].Descriptor()
+	taskDescUpdatedAt := taskFields[10].Descriptor()
 	// task.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	task.DefaultUpdatedAt = taskDescUpdatedAt.Default.(func() time.Time)
 	// task.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.

--- a/backend/db/task.go
+++ b/backend/db/task.go
@@ -38,6 +38,8 @@ type Task struct {
 	Status consts.TaskStatus `json:"status,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`
+	// LastActiveAt holds the value of the "last_active_at" field.
+	LastActiveAt time.Time `json:"last_active_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 	// CompletedAt holds the value of the "completed_at" field.
@@ -119,7 +121,7 @@ func (*Task) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case task.FieldKind, task.FieldSubType, task.FieldContent, task.FieldTitle, task.FieldSummary, task.FieldStatus:
 			values[i] = new(sql.NullString)
-		case task.FieldDeletedAt, task.FieldCreatedAt, task.FieldUpdatedAt, task.FieldCompletedAt:
+		case task.FieldDeletedAt, task.FieldCreatedAt, task.FieldLastActiveAt, task.FieldUpdatedAt, task.FieldCompletedAt:
 			values[i] = new(sql.NullTime)
 		case task.FieldID, task.FieldUserID:
 			values[i] = new(uuid.UUID)
@@ -197,6 +199,12 @@ func (_m *Task) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field created_at", values[i])
 			} else if value.Valid {
 				_m.CreatedAt = value.Time
+			}
+		case task.FieldLastActiveAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field last_active_at", values[i])
+			} else if value.Valid {
+				_m.LastActiveAt = value.Time
 			}
 		case task.FieldUpdatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -297,6 +305,9 @@ func (_m *Task) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("created_at=")
 	builder.WriteString(_m.CreatedAt.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("last_active_at=")
+	builder.WriteString(_m.LastActiveAt.Format(time.ANSIC))
 	builder.WriteString(", ")
 	builder.WriteString("updated_at=")
 	builder.WriteString(_m.UpdatedAt.Format(time.ANSIC))

--- a/backend/db/task/task.go
+++ b/backend/db/task/task.go
@@ -33,6 +33,8 @@ const (
 	FieldStatus = "status"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
 	FieldCreatedAt = "created_at"
+	// FieldLastActiveAt holds the string denoting the last_active_at field in the database.
+	FieldLastActiveAt = "last_active_at"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
 	FieldUpdatedAt = "updated_at"
 	// FieldCompletedAt holds the string denoting the completed_at field in the database.
@@ -96,6 +98,7 @@ var Columns = []string{
 	FieldSummary,
 	FieldStatus,
 	FieldCreatedAt,
+	FieldLastActiveAt,
 	FieldUpdatedAt,
 	FieldCompletedAt,
 }
@@ -128,6 +131,8 @@ var (
 	ContentValidator func(string) error
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
+	// DefaultLastActiveAt holds the default value on creation for the "last_active_at" field.
+	DefaultLastActiveAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
 	DefaultUpdatedAt func() time.Time
 	// UpdateDefaultUpdatedAt holds the default value on update for the "updated_at" field.
@@ -185,6 +190,11 @@ func ByStatus(opts ...sql.OrderTermOption) OrderOption {
 // ByCreatedAt orders the results by the created_at field.
 func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCreatedAt, opts...).ToFunc()
+}
+
+// ByLastActiveAt orders the results by the last_active_at field.
+func ByLastActiveAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldLastActiveAt, opts...).ToFunc()
 }
 
 // ByUpdatedAt orders the results by the updated_at field.

--- a/backend/db/task/where.go
+++ b/backend/db/task/where.go
@@ -105,6 +105,11 @@ func CreatedAt(v time.Time) predicate.Task {
 	return predicate.Task(sql.FieldEQ(FieldCreatedAt, v))
 }
 
+// LastActiveAt applies equality check predicate on the "last_active_at" field. It's identical to LastActiveAtEQ.
+func LastActiveAt(v time.Time) predicate.Task {
+	return predicate.Task(sql.FieldEQ(FieldLastActiveAt, v))
+}
+
 // UpdatedAt applies equality check predicate on the "updated_at" field. It's identical to UpdatedAtEQ.
 func UpdatedAt(v time.Time) predicate.Task {
 	return predicate.Task(sql.FieldEQ(FieldUpdatedAt, v))
@@ -700,6 +705,46 @@ func CreatedAtLT(v time.Time) predicate.Task {
 // CreatedAtLTE applies the LTE predicate on the "created_at" field.
 func CreatedAtLTE(v time.Time) predicate.Task {
 	return predicate.Task(sql.FieldLTE(FieldCreatedAt, v))
+}
+
+// LastActiveAtEQ applies the EQ predicate on the "last_active_at" field.
+func LastActiveAtEQ(v time.Time) predicate.Task {
+	return predicate.Task(sql.FieldEQ(FieldLastActiveAt, v))
+}
+
+// LastActiveAtNEQ applies the NEQ predicate on the "last_active_at" field.
+func LastActiveAtNEQ(v time.Time) predicate.Task {
+	return predicate.Task(sql.FieldNEQ(FieldLastActiveAt, v))
+}
+
+// LastActiveAtIn applies the In predicate on the "last_active_at" field.
+func LastActiveAtIn(vs ...time.Time) predicate.Task {
+	return predicate.Task(sql.FieldIn(FieldLastActiveAt, vs...))
+}
+
+// LastActiveAtNotIn applies the NotIn predicate on the "last_active_at" field.
+func LastActiveAtNotIn(vs ...time.Time) predicate.Task {
+	return predicate.Task(sql.FieldNotIn(FieldLastActiveAt, vs...))
+}
+
+// LastActiveAtGT applies the GT predicate on the "last_active_at" field.
+func LastActiveAtGT(v time.Time) predicate.Task {
+	return predicate.Task(sql.FieldGT(FieldLastActiveAt, v))
+}
+
+// LastActiveAtGTE applies the GTE predicate on the "last_active_at" field.
+func LastActiveAtGTE(v time.Time) predicate.Task {
+	return predicate.Task(sql.FieldGTE(FieldLastActiveAt, v))
+}
+
+// LastActiveAtLT applies the LT predicate on the "last_active_at" field.
+func LastActiveAtLT(v time.Time) predicate.Task {
+	return predicate.Task(sql.FieldLT(FieldLastActiveAt, v))
+}
+
+// LastActiveAtLTE applies the LTE predicate on the "last_active_at" field.
+func LastActiveAtLTE(v time.Time) predicate.Task {
+	return predicate.Task(sql.FieldLTE(FieldLastActiveAt, v))
 }
 
 // UpdatedAtEQ applies the EQ predicate on the "updated_at" field.

--- a/backend/db/task_create.go
+++ b/backend/db/task_create.go
@@ -124,6 +124,20 @@ func (_c *TaskCreate) SetNillableCreatedAt(v *time.Time) *TaskCreate {
 	return _c
 }
 
+// SetLastActiveAt sets the "last_active_at" field.
+func (_c *TaskCreate) SetLastActiveAt(v time.Time) *TaskCreate {
+	_c.mutation.SetLastActiveAt(v)
+	return _c
+}
+
+// SetNillableLastActiveAt sets the "last_active_at" field if the given value is not nil.
+func (_c *TaskCreate) SetNillableLastActiveAt(v *time.Time) *TaskCreate {
+	if v != nil {
+		_c.SetLastActiveAt(*v)
+	}
+	return _c
+}
+
 // SetUpdatedAt sets the "updated_at" field.
 func (_c *TaskCreate) SetUpdatedAt(v time.Time) *TaskCreate {
 	_c.mutation.SetUpdatedAt(v)
@@ -267,6 +281,13 @@ func (_c *TaskCreate) defaults() error {
 		v := task.DefaultCreatedAt()
 		_c.mutation.SetCreatedAt(v)
 	}
+	if _, ok := _c.mutation.LastActiveAt(); !ok {
+		if task.DefaultLastActiveAt == nil {
+			return fmt.Errorf("db: uninitialized task.DefaultLastActiveAt (forgotten import db/runtime?)")
+		}
+		v := task.DefaultLastActiveAt()
+		_c.mutation.SetLastActiveAt(v)
+	}
 	if _, ok := _c.mutation.UpdatedAt(); !ok {
 		if task.DefaultUpdatedAt == nil {
 			return fmt.Errorf("db: uninitialized task.DefaultUpdatedAt (forgotten import db/runtime?)")
@@ -298,6 +319,9 @@ func (_c *TaskCreate) check() error {
 	}
 	if _, ok := _c.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`db: missing required field "Task.created_at"`)}
+	}
+	if _, ok := _c.mutation.LastActiveAt(); !ok {
+		return &ValidationError{Name: "last_active_at", err: errors.New(`db: missing required field "Task.last_active_at"`)}
 	}
 	if _, ok := _c.mutation.UpdatedAt(); !ok {
 		return &ValidationError{Name: "updated_at", err: errors.New(`db: missing required field "Task.updated_at"`)}
@@ -372,6 +396,10 @@ func (_c *TaskCreate) createSpec() (*Task, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.CreatedAt(); ok {
 		_spec.SetField(task.FieldCreatedAt, field.TypeTime, value)
 		_node.CreatedAt = value
+	}
+	if value, ok := _c.mutation.LastActiveAt(); ok {
+		_spec.SetField(task.FieldLastActiveAt, field.TypeTime, value)
+		_node.LastActiveAt = value
 	}
 	if value, ok := _c.mutation.UpdatedAt(); ok {
 		_spec.SetField(task.FieldUpdatedAt, field.TypeTime, value)
@@ -650,6 +678,18 @@ func (u *TaskUpsert) UpdateCreatedAt() *TaskUpsert {
 	return u
 }
 
+// SetLastActiveAt sets the "last_active_at" field.
+func (u *TaskUpsert) SetLastActiveAt(v time.Time) *TaskUpsert {
+	u.Set(task.FieldLastActiveAt, v)
+	return u
+}
+
+// UpdateLastActiveAt sets the "last_active_at" field to the value that was provided on create.
+func (u *TaskUpsert) UpdateLastActiveAt() *TaskUpsert {
+	u.SetExcluded(task.FieldLastActiveAt)
+	return u
+}
+
 // SetUpdatedAt sets the "updated_at" field.
 func (u *TaskUpsert) SetUpdatedAt(v time.Time) *TaskUpsert {
 	u.Set(task.FieldUpdatedAt, v)
@@ -879,6 +919,20 @@ func (u *TaskUpsertOne) SetCreatedAt(v time.Time) *TaskUpsertOne {
 func (u *TaskUpsertOne) UpdateCreatedAt() *TaskUpsertOne {
 	return u.Update(func(s *TaskUpsert) {
 		s.UpdateCreatedAt()
+	})
+}
+
+// SetLastActiveAt sets the "last_active_at" field.
+func (u *TaskUpsertOne) SetLastActiveAt(v time.Time) *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.SetLastActiveAt(v)
+	})
+}
+
+// UpdateLastActiveAt sets the "last_active_at" field to the value that was provided on create.
+func (u *TaskUpsertOne) UpdateLastActiveAt() *TaskUpsertOne {
+	return u.Update(func(s *TaskUpsert) {
+		s.UpdateLastActiveAt()
 	})
 }
 
@@ -1283,6 +1337,20 @@ func (u *TaskUpsertBulk) SetCreatedAt(v time.Time) *TaskUpsertBulk {
 func (u *TaskUpsertBulk) UpdateCreatedAt() *TaskUpsertBulk {
 	return u.Update(func(s *TaskUpsert) {
 		s.UpdateCreatedAt()
+	})
+}
+
+// SetLastActiveAt sets the "last_active_at" field.
+func (u *TaskUpsertBulk) SetLastActiveAt(v time.Time) *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.SetLastActiveAt(v)
+	})
+}
+
+// UpdateLastActiveAt sets the "last_active_at" field to the value that was provided on create.
+func (u *TaskUpsertBulk) UpdateLastActiveAt() *TaskUpsertBulk {
+	return u.Update(func(s *TaskUpsert) {
+		s.UpdateLastActiveAt()
 	})
 }
 

--- a/backend/db/task_update.go
+++ b/backend/db/task_update.go
@@ -186,6 +186,20 @@ func (_u *TaskUpdate) SetNillableCreatedAt(v *time.Time) *TaskUpdate {
 	return _u
 }
 
+// SetLastActiveAt sets the "last_active_at" field.
+func (_u *TaskUpdate) SetLastActiveAt(v time.Time) *TaskUpdate {
+	_u.mutation.SetLastActiveAt(v)
+	return _u
+}
+
+// SetNillableLastActiveAt sets the "last_active_at" field if the given value is not nil.
+func (_u *TaskUpdate) SetNillableLastActiveAt(v *time.Time) *TaskUpdate {
+	if v != nil {
+		_u.SetLastActiveAt(*v)
+	}
+	return _u
+}
+
 // SetUpdatedAt sets the "updated_at" field.
 func (_u *TaskUpdate) SetUpdatedAt(v time.Time) *TaskUpdate {
 	_u.mutation.SetUpdatedAt(v)
@@ -480,6 +494,9 @@ func (_u *TaskUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.CreatedAt(); ok {
 		_spec.SetField(task.FieldCreatedAt, field.TypeTime, value)
+	}
+	if value, ok := _u.mutation.LastActiveAt(); ok {
+		_spec.SetField(task.FieldLastActiveAt, field.TypeTime, value)
 	}
 	if value, ok := _u.mutation.UpdatedAt(); ok {
 		_spec.SetField(task.FieldUpdatedAt, field.TypeTime, value)
@@ -883,6 +900,20 @@ func (_u *TaskUpdateOne) SetNillableCreatedAt(v *time.Time) *TaskUpdateOne {
 	return _u
 }
 
+// SetLastActiveAt sets the "last_active_at" field.
+func (_u *TaskUpdateOne) SetLastActiveAt(v time.Time) *TaskUpdateOne {
+	_u.mutation.SetLastActiveAt(v)
+	return _u
+}
+
+// SetNillableLastActiveAt sets the "last_active_at" field if the given value is not nil.
+func (_u *TaskUpdateOne) SetNillableLastActiveAt(v *time.Time) *TaskUpdateOne {
+	if v != nil {
+		_u.SetLastActiveAt(*v)
+	}
+	return _u
+}
+
 // SetUpdatedAt sets the "updated_at" field.
 func (_u *TaskUpdateOne) SetUpdatedAt(v time.Time) *TaskUpdateOne {
 	_u.mutation.SetUpdatedAt(v)
@@ -1207,6 +1238,9 @@ func (_u *TaskUpdateOne) sqlSave(ctx context.Context) (_node *Task, err error) {
 	}
 	if value, ok := _u.mutation.CreatedAt(); ok {
 		_spec.SetField(task.FieldCreatedAt, field.TypeTime, value)
+	}
+	if value, ok := _u.mutation.LastActiveAt(); ok {
+		_spec.SetField(task.FieldLastActiveAt, field.TypeTime, value)
 	}
 	if value, ok := _u.mutation.UpdatedAt(); ok {
 		_spec.SetField(task.FieldUpdatedAt, field.TypeTime, value)

--- a/backend/domain/task.go
+++ b/backend/domain/task.go
@@ -40,6 +40,7 @@ type TaskRepo interface {
 	List(ctx context.Context, user *User, req TaskListReq) ([]*db.ProjectTask, *db.PageInfo, error)
 	Create(ctx context.Context, user *User, req CreateTaskReq, token string, fn func(*db.ProjectTask, *db.Model, *db.Image) (*taskflow.VirtualMachine, error)) (*db.ProjectTask, error)
 	Update(ctx context.Context, user *User, id uuid.UUID, fn func(up *db.TaskUpdateOne) error) error
+	RefreshLastActiveAt(ctx context.Context, id uuid.UUID, at time.Time, minInterval time.Duration) error
 	Stop(ctx context.Context, user *User, id uuid.UUID, fn func(*db.Task) error) error
 	Delete(ctx context.Context, user *User, id uuid.UUID) error
 }
@@ -179,6 +180,7 @@ type Task struct {
 	Status         consts.TaskStatus  `json:"status"`
 	VirtualMachine *VirtualMachine    `json:"virtualmachine"`
 	CreatedAt      int64              `json:"created_at"`
+	LastActiveAt   int64              `json:"last_active_at"`
 	CompletedAt    int64              `json:"completed_at"`
 	Model          *Model             `json:"model,omitempty"`
 	Image          *Image             `json:"image,omitempty"`
@@ -214,6 +216,7 @@ func (t *Task) From(src *db.Task) *Task {
 	t.Summary = src.Summary
 	t.Status = src.Status
 	t.CreatedAt = src.CreatedAt.Unix()
+	t.LastActiveAt = src.LastActiveAt.Unix()
 	t.CompletedAt = src.CompletedAt.Unix()
 	if vms := src.Edges.Vms; len(vms) > 0 {
 		t.VirtualMachine = cvt.From(vms[0], &VirtualMachine{})

--- a/backend/ent/schema/task.go
+++ b/backend/ent/schema/task.go
@@ -44,6 +44,7 @@ func (Task) Fields() []ent.Field {
 		field.Text("summary").Optional(),
 		field.String("status").GoType(consts.TaskStatus("")),
 		field.Time("created_at").Default(time.Now),
+		field.Time("last_active_at").Default(time.Now),
 		field.Time("updated_at").Default(time.Now).UpdateDefault(time.Now),
 		field.Time("completed_at").Optional(),
 	}

--- a/backend/migration/000008_add_task_last_active_at.down.sql
+++ b/backend/migration/000008_add_task_last_active_at.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tasks
+    DROP COLUMN IF EXISTS last_active_at;

--- a/backend/migration/000008_add_task_last_active_at.up.sql
+++ b/backend/migration/000008_add_task_last_active_at.up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE tasks
+    ADD COLUMN IF NOT EXISTS last_active_at TIMESTAMPTZ;
+
+UPDATE tasks
+SET last_active_at = COALESCE(last_active_at, created_at, CURRENT_TIMESTAMP);
+
+ALTER TABLE tasks
+    ALTER COLUMN last_active_at SET DEFAULT CURRENT_TIMESTAMP,
+    ALTER COLUMN last_active_at SET NOT NULL;


### PR DESCRIPTION
## 变更说明
- 给 tasks 增加 last_active_at 字段，并通过迁移回填历史数据
- 新增任务活跃时间刷新器，control 建连和长连接保活时按较长间隔写库刷新最近活跃时间
- 任务创建完成后同时刷新任务最近活跃时间和 VM 空闲计时，补充对应后端测试

## 验证
- [x] go test ./biz/task/...
- [ ] go test ./...
  - 当前失败为仓库现有无关用例：pkg/vmstatus TestResolve/hibernated_condition_returns_hibernated
