### PR TITLE
fix: 修复 VM 回收后任务状态未收口

### DIFF
--- a/backend/biz/host/usecase/host.go
+++ b/backend/biz/host/usecase/host.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"log/slog"
@@ -38,6 +39,7 @@ type HostUsecase struct {
 	taskflow         taskflow.Clienter
 	logger           *slog.Logger
 	repo             domain.HostRepo
+	taskRepo         domain.TaskRepo
 	userRepo         domain.UserRepo
 	girepo           domain.GitIdentityRepo
 	vmexpireQueue    *delayqueue.VMExpireQueue
@@ -52,6 +54,7 @@ func NewHostUsecase(i *do.Injector) (domain.HostUsecase, error) {
 		taskflow:      do.MustInvoke[taskflow.Clienter](i),
 		logger:        do.MustInvoke[*slog.Logger](i).With("module", "HostUsecase"),
 		repo:          do.MustInvoke[domain.HostRepo](i),
+		taskRepo:      do.MustInvoke[domain.TaskRepo](i),
 		userRepo:      do.MustInvoke[domain.UserRepo](i),
 		girepo:        do.MustInvoke[domain.GitIdentityRepo](i),
 		vmexpireQueue: do.MustInvoke[*delayqueue.VMExpireQueue](i),
@@ -129,6 +132,11 @@ func (h *HostUsecase) vmexpireConsumer() {
 				return err
 			}
 
+			if err := h.markRecycledTasksFinished(ctx, vm); err != nil {
+				innerLogger.ErrorContext(ctx, "failed to finish recycled tasks", "error", err)
+				return err
+			}
+
 			return nil
 		})
 
@@ -136,6 +144,27 @@ func (h *HostUsecase) vmexpireConsumer() {
 		index++
 		time.Sleep(10 * time.Second)
 	}
+}
+
+func (h *HostUsecase) markRecycledTasksFinished(ctx context.Context, vm *db.VirtualMachine) error {
+	var errs []error
+	for _, tk := range vm.Edges.Tasks {
+		if tk == nil {
+			continue
+		}
+		if tk.Status == consts.TaskStatusFinished || tk.Status == consts.TaskStatusError {
+			continue
+		}
+		err := h.taskRepo.Update(ctx, nil, tk.ID, func(up *db.TaskUpdateOne) error {
+			up.SetStatus(consts.TaskStatusFinished)
+			up.SetCompletedAt(time.Now())
+			return nil
+		})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("update task %s: %w", tk.ID, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // GetInstallCommand implements domain.HostUsecase.

--- a/backend/biz/host/usecase/host_test.go
+++ b/backend/biz/host/usecase/host_test.go
@@ -1,0 +1,158 @@
+package usecase
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/db/enttest"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
+)
+
+func TestHostUsecase_markRecycledTasksFinished(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:host-usecase-task-finish-test?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	userID := uuid.New()
+	if _, err := client.User.Create().
+		SetID(userID).
+		SetName("tester").
+		SetRole(consts.UserRoleIndividual).
+		SetStatus(consts.UserStatusActive).
+		Save(ctx); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	createTask := func(status consts.TaskStatus) *db.Task {
+		taskID := uuid.New()
+		tk, err := client.Task.Create().
+			SetID(taskID).
+			SetUserID(userID).
+			SetKind(consts.TaskTypeDevelop).
+			SetContent(string(status)).
+			SetStatus(status).
+			Save(ctx)
+		if err != nil {
+			t.Fatalf("create task(%s): %v", status, err)
+		}
+		return tk
+	}
+
+	processingTask := createTask(consts.TaskStatusProcessing)
+	finishedTask := createTask(consts.TaskStatusFinished)
+	errorTask := createTask(consts.TaskStatusError)
+
+	taskRepo := &hostTaskRepoStub{client: client}
+	u := &HostUsecase{
+		taskRepo: taskRepo,
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	vm := &db.VirtualMachine{
+		ID: "vm-1",
+		Edges: db.VirtualMachineEdges{
+			Tasks: []*db.Task{
+				processingTask,
+				finishedTask,
+				errorTask,
+				nil,
+			},
+		},
+	}
+
+	if err := u.markRecycledTasksFinished(ctx, vm); err != nil {
+		t.Fatalf("markRecycledTasksFinished() error = %v", err)
+	}
+
+	gotProcessing, err := client.Task.Get(ctx, processingTask.ID)
+	if err != nil {
+		t.Fatalf("query processing task: %v", err)
+	}
+	if gotProcessing.Status != consts.TaskStatusFinished {
+		t.Fatalf("processing task status = %s, want %s", gotProcessing.Status, consts.TaskStatusFinished)
+	}
+	if gotProcessing.CompletedAt.IsZero() {
+		t.Fatal("expected processing task completed_at to be set")
+	}
+
+	gotFinished, err := client.Task.Get(ctx, finishedTask.ID)
+	if err != nil {
+		t.Fatalf("query finished task: %v", err)
+	}
+	if !gotFinished.CompletedAt.IsZero() {
+		t.Fatal("expected already finished task completed_at to remain unchanged")
+	}
+
+	gotError, err := client.Task.Get(ctx, errorTask.ID)
+	if err != nil {
+		t.Fatalf("query error task: %v", err)
+	}
+	if gotError.Status != consts.TaskStatusError {
+		t.Fatalf("error task status = %s, want %s", gotError.Status, consts.TaskStatusError)
+	}
+
+	if len(taskRepo.updatedIDs) != 1 || taskRepo.updatedIDs[0] != processingTask.ID {
+		t.Fatalf("updated task ids = %v, want only %s", taskRepo.updatedIDs, processingTask.ID)
+	}
+}
+
+type hostTaskRepoStub struct {
+	client     *db.Client
+	updatedIDs []uuid.UUID
+}
+
+func (s *hostTaskRepoStub) GetByID(ctx context.Context, id uuid.UUID) (*db.Task, error) {
+	return s.client.Task.Get(ctx, id)
+}
+
+func (s *hostTaskRepoStub) Stat(context.Context, uuid.UUID) (*domain.TaskStats, error) {
+	panic("unexpected call to Stat")
+}
+
+func (s *hostTaskRepoStub) StatByIDs(context.Context, []uuid.UUID) (map[uuid.UUID]*domain.TaskStats, error) {
+	panic("unexpected call to StatByIDs")
+}
+
+func (s *hostTaskRepoStub) Info(context.Context, *domain.User, uuid.UUID, bool) (*db.Task, error) {
+	panic("unexpected call to Info")
+}
+
+func (s *hostTaskRepoStub) List(context.Context, *domain.User, domain.TaskListReq) ([]*db.ProjectTask, *db.PageInfo, error) {
+	panic("unexpected call to List")
+}
+
+func (s *hostTaskRepoStub) Create(context.Context, *domain.User, domain.CreateTaskReq, string, func(*db.ProjectTask, *db.Model, *db.Image) (*taskflow.VirtualMachine, error)) (*db.ProjectTask, error) {
+	panic("unexpected call to Create")
+}
+
+func (s *hostTaskRepoStub) Update(ctx context.Context, _ *domain.User, id uuid.UUID, fn func(up *db.TaskUpdateOne) error) error {
+	s.updatedIDs = append(s.updatedIDs, id)
+	up := s.client.Task.UpdateOneID(id)
+	if err := fn(up); err != nil {
+		return err
+	}
+	return up.Exec(ctx)
+}
+
+func (s *hostTaskRepoStub) RefreshLastActiveAt(context.Context, uuid.UUID, time.Time, time.Duration) error {
+	panic("unexpected call to RefreshLastActiveAt")
+}
+
+func (s *hostTaskRepoStub) Stop(context.Context, *domain.User, uuid.UUID, func(*db.Task) error) error {
+	panic("unexpected call to Stop")
+}
+
+func (s *hostTaskRepoStub) Delete(context.Context, *domain.User, uuid.UUID) error {
+	panic("unexpected call to Delete")
+}

--- a/backend/pkg/lifecycle/taskhook.go
+++ b/backend/pkg/lifecycle/taskhook.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
@@ -51,6 +52,8 @@ func (h *TaskHook) OnStateChange(ctx context.Context, id uuid.UUID, from, to con
 		return h.handleProcessing(ctx, id, metadata)
 	case consts.TaskStatusError:
 		return h.handleError(ctx, id, metadata.UserID)
+	case consts.TaskStatusFinished:
+		return h.handleFinished(ctx, id, metadata.UserID)
 	}
 
 	return nil
@@ -73,6 +76,15 @@ func (h *TaskHook) handleError(ctx context.Context, id, uid uuid.UUID) error {
 	u := domain.User{ID: uid}
 	return h.repo.Update(ctx, &u, id, func(up *db.TaskUpdateOne) error {
 		up.SetStatus(consts.TaskStatusError)
+		return nil
+	})
+}
+
+func (h *TaskHook) handleFinished(ctx context.Context, id, uid uuid.UUID) error {
+	u := domain.User{ID: uid}
+	return h.repo.Update(ctx, &u, id, func(up *db.TaskUpdateOne) error {
+		up.SetStatus(consts.TaskStatusFinished)
+		up.SetCompletedAt(time.Now())
 		return nil
 	})
 }

--- a/backend/pkg/lifecycle/taskhook_test.go
+++ b/backend/pkg/lifecycle/taskhook_test.go
@@ -1,0 +1,128 @@
+package lifecycle
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "github.com/mattn/go-sqlite3"
+
+	taskrepo "github.com/chaitin/MonkeyCode/backend/biz/task/repo"
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/db/enttest"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
+)
+
+func TestTaskHook_OnStateChange_FinishedUpdatesTaskStatusAndCompletedAt(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:task-hook-finished-test?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	repo := &taskHookRepoStub{
+		taskRepo: &taskrepo.TaskRepo{},
+		client:   client,
+	}
+
+	userID := uuid.New()
+	if _, err := client.User.Create().
+		SetID(userID).
+		SetName("tester").
+		SetRole(consts.UserRoleIndividual).
+		SetStatus(consts.UserStatusActive).
+		Save(ctx); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	taskID := uuid.New()
+	if _, err := client.Task.Create().
+		SetID(taskID).
+		SetUserID(userID).
+		SetKind(consts.TaskTypeDevelop).
+		SetContent("demo").
+		SetStatus(consts.TaskStatusProcessing).
+		Save(ctx); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	hook := &TaskHook{
+		repo:   repo,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	if err := hook.OnStateChange(ctx, taskID, consts.TaskStatusProcessing, consts.TaskStatusFinished, TaskMetadata{
+		TaskID: taskID,
+		UserID: userID,
+	}); err != nil {
+		t.Fatalf("OnStateChange() error = %v", err)
+	}
+
+	got, err := client.Task.Get(ctx, taskID)
+	if err != nil {
+		t.Fatalf("query task: %v", err)
+	}
+	if got.Status != consts.TaskStatusFinished {
+		t.Fatalf("task status = %s, want %s", got.Status, consts.TaskStatusFinished)
+	}
+	if got.CompletedAt.IsZero() {
+		t.Fatal("expected completed_at to be set")
+	}
+	if time.Since(got.CompletedAt) > time.Minute {
+		t.Fatalf("completed_at = %v, looks stale", got.CompletedAt)
+	}
+}
+
+type taskHookRepoStub struct {
+	taskRepo *taskrepo.TaskRepo
+	client   *db.Client
+}
+
+func (s *taskHookRepoStub) GetByID(ctx context.Context, id uuid.UUID) (*db.Task, error) {
+	return s.client.Task.Get(ctx, id)
+}
+
+func (s *taskHookRepoStub) Stat(context.Context, uuid.UUID) (*domain.TaskStats, error) {
+	panic("unexpected call to Stat")
+}
+
+func (s *taskHookRepoStub) StatByIDs(context.Context, []uuid.UUID) (map[uuid.UUID]*domain.TaskStats, error) {
+	panic("unexpected call to StatByIDs")
+}
+
+func (s *taskHookRepoStub) Info(context.Context, *domain.User, uuid.UUID, bool) (*db.Task, error) {
+	panic("unexpected call to Info")
+}
+
+func (s *taskHookRepoStub) List(context.Context, *domain.User, domain.TaskListReq) ([]*db.ProjectTask, *db.PageInfo, error) {
+	panic("unexpected call to List")
+}
+
+func (s *taskHookRepoStub) Create(context.Context, *domain.User, domain.CreateTaskReq, string, func(*db.ProjectTask, *db.Model, *db.Image) (*taskflow.VirtualMachine, error)) (*db.ProjectTask, error) {
+	panic("unexpected call to Create")
+}
+
+func (s *taskHookRepoStub) Update(ctx context.Context, _ *domain.User, id uuid.UUID, fn func(up *db.TaskUpdateOne) error) error {
+	up := s.client.Task.UpdateOneID(id)
+	if err := fn(up); err != nil {
+		return err
+	}
+	return up.Exec(ctx)
+}
+
+func (s *taskHookRepoStub) RefreshLastActiveAt(context.Context, uuid.UUID, time.Time, time.Duration) error {
+	panic("unexpected call to RefreshLastActiveAt")
+}
+
+func (s *taskHookRepoStub) Stop(context.Context, *domain.User, uuid.UUID, func(*db.Task) error) error {
+	panic("unexpected call to Stop")
+}
+
+func (s *taskHookRepoStub) Delete(context.Context, *domain.User, uuid.UUID) error {
+	panic("unexpected call to Delete")
+}

--- a/backend/pkg/lifecycle/vmtaskhook.go
+++ b/backend/pkg/lifecycle/vmtaskhook.go
@@ -38,6 +38,8 @@ func (h *VMTaskHook) OnStateChange(ctx context.Context, _ string, _ VMState, to 
 		target = consts.TaskStatusProcessing
 	case VMStateFailed:
 		target = consts.TaskStatusError
+	case VMStateRecycled:
+		target = consts.TaskStatusFinished
 	default:
 		return nil
 	}

--- a/backend/pkg/lifecycle/vmtaskhook_test.go
+++ b/backend/pkg/lifecycle/vmtaskhook_test.go
@@ -57,3 +57,51 @@ func TestVMTaskHook_OnStateChange_FailedTransitionsTaskToError(t *testing.T) {
 		t.Fatalf("task state = %s, want %s", state, consts.TaskStatusError)
 	}
 }
+
+func TestVMTaskHook_OnStateChange_RecycledTransitionsTaskToFinished(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run() error = %v", err)
+	}
+	defer mr.Close()
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	taskLifecycle := NewManager[uuid.UUID, consts.TaskStatus, TaskMetadata](
+		rdb,
+		WithLogger[uuid.UUID, consts.TaskStatus, TaskMetadata](slog.New(slog.NewTextHandler(io.Discard, nil))),
+		WithTransitions[uuid.UUID, consts.TaskStatus, TaskMetadata](TaskTransitions()),
+	)
+
+	taskID := uuid.New()
+	userID := uuid.New()
+	meta := TaskMetadata{TaskID: taskID, UserID: userID}
+	if err := taskLifecycle.Transition(context.Background(), taskID, consts.TaskStatusPending, meta); err != nil {
+		t.Fatalf("taskLifecycle.Transition(pending) error = %v", err)
+	}
+	if err := taskLifecycle.Transition(context.Background(), taskID, consts.TaskStatusProcessing, meta); err != nil {
+		t.Fatalf("taskLifecycle.Transition(processing) error = %v", err)
+	}
+
+	hook := &VMTaskHook{
+		taskLifecycle: taskLifecycle,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	if err := hook.OnStateChange(context.Background(), "vm-1", VMStateRunning, VMStateRecycled, VMMetadata{
+		VMID:   "vm-1",
+		TaskID: &taskID,
+		UserID: userID,
+	}); err != nil {
+		t.Fatalf("OnStateChange() error = %v", err)
+	}
+
+	state, err := taskLifecycle.GetState(context.Background(), taskID)
+	if err != nil {
+		t.Fatalf("taskLifecycle.GetState() error = %v", err)
+	}
+	if state != consts.TaskStatusFinished {
+		t.Fatalf("task state = %s, want %s", state, consts.TaskStatusFinished)
+	}
+}


### PR DESCRIPTION
## Summary
- 补齐 VM lifecycle 在 recycled 状态下对任务 finished 的收口
- 补齐任务 lifecycle finished 状态的数据库持久化与 completed_at 写入
- 补齐 vmexpire 旧回收路径的任务收口，并新增对应回归测试

## Test Plan
- [x] go test ./pkg/lifecycle ./biz/host/usecase