### PR TITLE
修复虚拟机回收状态流转

### DIFF
--- a/backend/biz/host/handler/v1/internal.go
+++ b/backend/biz/host/handler/v1/internal.go
@@ -40,6 +40,7 @@ type InternalHostHandler struct {
 	skipSoftDelete func(context.Context) context.Context
 	cache          *cache.Cache
 	taskLifecycle  *lifecycle.Manager[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata]
+	vmLifecycle    *lifecycle.Manager[string, lifecycle.VMState, lifecycle.VMMetadata]
 	hostUsecase    domain.HostUsecase
 	taskConns      *ws.TaskConn
 	projectUsecase domain.ProjectUsecase
@@ -62,6 +63,7 @@ func NewInternalHostHandler(i *do.Injector) (*InternalHostHandler, error) {
 		skipSoftDelete: entx.SkipSoftDelete,
 		cache:          cache.New(15*time.Minute, 10*time.Minute),
 		taskLifecycle:  do.MustInvoke[*lifecycle.Manager[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata]](i),
+		vmLifecycle:    do.MustInvoke[*lifecycle.Manager[string, lifecycle.VMState, lifecycle.VMMetadata]](i),
 		hostUsecase:    do.MustInvoke[domain.HostUsecase](i),
 		taskConns:      do.MustInvoke[*ws.TaskConn](i),
 		projectUsecase: do.MustInvoke[domain.ProjectUsecase](i),
@@ -342,15 +344,27 @@ func (h *InternalHostHandler) VmReady(c *web.Context, req taskflow.VirtualMachin
 
 	for _, t := range vm.Edges.Tasks {
 		h.logger.With("task", t).DebugContext(c.Request().Context(), "vm-ready")
+		var taskID *uuid.UUID
 		if t.Status == consts.TaskStatusProcessing {
+			if h.vmLifecycle != nil {
+				if err := h.vmLifecycle.Transition(c.Request().Context(), vm.ID, lifecycle.VMStateRunning, lifecycle.VMMetadata{
+					VMID:   vm.ID,
+					TaskID: taskID,
+					UserID: t.UserID,
+				}); err != nil {
+					h.logger.With("task", t, "error", err).ErrorContext(c.Request().Context(), "failed to transition vm to running")
+				}
+			}
 			continue
 		}
+		taskID = &t.ID
 
-		if err := h.taskLifecycle.Transition(c.Request().Context(), t.ID, consts.TaskStatusProcessing, lifecycle.TaskMetadata{
-			TaskID: t.ID,
+		if err := h.vmLifecycle.Transition(c.Request().Context(), vm.ID, lifecycle.VMStateRunning, lifecycle.VMMetadata{
+			VMID:   vm.ID,
+			TaskID: taskID,
 			UserID: t.UserID,
 		}); err != nil {
-			h.logger.With("task", t, "error", err).ErrorContext(c.Request().Context(), "failed to transition task to processing")
+			h.logger.With("task", t, "error", err).ErrorContext(c.Request().Context(), "failed to transition vm to running")
 		}
 	}
 
@@ -380,11 +394,12 @@ func (h *InternalHostHandler) VmConditions(c *web.Context, req taskflow.VirtualM
 		t := ts[0]
 		for _, cond := range req.Conditions {
 			if cond.Type == string(etypes.ConditionTypeFailed) {
-				if err := h.taskLifecycle.Transition(c.Request().Context(), t.ID, consts.TaskStatusError, lifecycle.TaskMetadata{
-					TaskID: t.ID,
+				if err := h.vmLifecycle.Transition(c.Request().Context(), vm.ID, lifecycle.VMStateFailed, lifecycle.VMMetadata{
+					VMID:   vm.ID,
+					TaskID: &t.ID,
 					UserID: t.UserID,
 				}); err != nil {
-					h.logger.With("task", t, "error", err).ErrorContext(c.Request().Context(), "failed to transition task to processing")
+					h.logger.With("task", t, "error", err).ErrorContext(c.Request().Context(), "failed to transition vm to failed")
 				}
 				break
 			}

--- a/backend/biz/host/handler/v1/internal_auth_test.go
+++ b/backend/biz/host/handler/v1/internal_auth_test.go
@@ -171,7 +171,10 @@ func (s *internalHostRepoStub) GetByID(context.Context, string) (*db.Host, error
 	return nil, errors.New("host not found")
 }
 
-func (s *internalHostRepoStub) GetVirtualMachineByEnvID(context.Context, string) (*db.VirtualMachine, error) {
+func (s *internalHostRepoStub) GetVirtualMachineByEnvID(_ context.Context, envID string) (*db.VirtualMachine, error) {
+	if s.vm != nil && s.vm.EnvironmentID == envID {
+		return s.vm, nil
+	}
 	return nil, errors.New("vm not found")
 }
 

--- a/backend/biz/host/handler/v1/internal_lifecycle_test.go
+++ b/backend/biz/host/handler/v1/internal_lifecycle_test.go
@@ -1,0 +1,118 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoYoko/web"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/patrickmn/go-cache"
+
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db"
+	etypes "github.com/chaitin/MonkeyCode/backend/ent/types"
+	"github.com/chaitin/MonkeyCode/backend/pkg/lifecycle"
+	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
+)
+
+func TestVmReadyTransitionsVMLifecycleToRunning(t *testing.T) {
+	rdb := newTestRedis(t)
+	userID := uuid.New()
+	taskID := uuid.New()
+	vmID := "vm-ready"
+	repo := &internalHostRepoStub{
+		vm: &db.VirtualMachine{
+			ID:     vmID,
+			UserID: userID,
+			Edges:  db.VirtualMachineEdges{Tasks: []*db.Task{{ID: taskID, UserID: userID, Status: consts.TaskStatusPending}}},
+		},
+	}
+	vmLifecycle := lifecycle.NewManager[string, lifecycle.VMState, lifecycle.VMMetadata](
+		rdb,
+		lifecycle.WithLogger[string, lifecycle.VMState, lifecycle.VMMetadata](slog.New(slog.NewTextHandler(io.Discard, nil))),
+		lifecycle.WithTransitions[string, lifecycle.VMState, lifecycle.VMMetadata](lifecycle.VMTransitions()),
+	)
+	handler := &InternalHostHandler{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		repo:        repo,
+		vmLifecycle: vmLifecycle,
+	}
+
+	if err := handler.VmReady(testWebContext(), taskflow.VirtualMachine{ID: vmID}); err != nil {
+		t.Fatalf("VmReady() error = %v", err)
+	}
+
+	state, err := vmLifecycle.GetState(context.Background(), vmID)
+	if err != nil {
+		t.Fatalf("vmLifecycle.GetState() error = %v", err)
+	}
+	if state != lifecycle.VMStateRunning {
+		t.Fatalf("vm state = %s, want %s", state, lifecycle.VMStateRunning)
+	}
+}
+
+func TestVmConditionsTransitionsVMLifecycleToFailed(t *testing.T) {
+	rdb := newTestRedis(t)
+	userID := uuid.New()
+	taskID := uuid.New()
+	vmID := "vm-failed"
+	envID := "env-failed"
+	repo := &internalHostRepoStub{
+		vm: &db.VirtualMachine{
+			ID:            vmID,
+			EnvironmentID: envID,
+			UserID:        userID,
+			Edges:         db.VirtualMachineEdges{Tasks: []*db.Task{{ID: taskID, UserID: userID, Status: consts.TaskStatusProcessing}}},
+		},
+	}
+	vmLifecycle := lifecycle.NewManager[string, lifecycle.VMState, lifecycle.VMMetadata](
+		rdb,
+		lifecycle.WithLogger[string, lifecycle.VMState, lifecycle.VMMetadata](slog.New(slog.NewTextHandler(io.Discard, nil))),
+		lifecycle.WithTransitions[string, lifecycle.VMState, lifecycle.VMMetadata](lifecycle.VMTransitions()),
+	)
+	if err := vmLifecycle.Transition(context.Background(), vmID, lifecycle.VMStatePending, lifecycle.VMMetadata{VMID: vmID, TaskID: &taskID, UserID: userID}); err != nil {
+		t.Fatalf("vmLifecycle.Transition(pending) error = %v", err)
+	}
+	handler := &InternalHostHandler{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		repo:        repo,
+		cache:       cacheForTest(),
+		vmLifecycle: vmLifecycle,
+	}
+
+	if err := handler.VmConditions(testWebContext(), taskflow.VirtualMachineCondition{
+		EnvID: envID,
+		Conditions: []*taskflow.Condition{{
+			Type:               string(etypes.ConditionTypeFailed),
+			LastTransitionTime: 1,
+		}},
+	}); err != nil {
+		t.Fatalf("VmConditions() error = %v", err)
+	}
+
+	state, err := vmLifecycle.GetState(context.Background(), vmID)
+	if err != nil {
+		t.Fatalf("vmLifecycle.GetState() error = %v", err)
+	}
+	if state != lifecycle.VMStateFailed {
+		t.Fatalf("vm state = %s, want %s", state, lifecycle.VMStateFailed)
+	}
+}
+
+func testWebContext() *web.Context {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	rec := httptest.NewRecorder()
+	return &web.Context{Context: e.NewContext(req, rec)}
+}
+
+func cacheForTest() *cache.Cache {
+	return cache.New(15*time.Minute, 10*time.Minute)
+}

--- a/backend/biz/host/usecase/host.go
+++ b/backend/biz/host/usecase/host.go
@@ -477,7 +477,7 @@ func (h *HostUsecase) DeleteVM(ctx context.Context, uid uuid.UUID, hostID, vmID 
 		// 清理 TTL 过期队列中的残留任务
 		_ = h.vmexpireQueue.Remove(ctx, VM_EXPIRE_QUEUE_KEY, vm.ID)
 
-		return nil
+		return h.markRecycledTasksFinished(ctx, vm)
 	})
 }
 

--- a/backend/biz/host/usecase/host_test.go
+++ b/backend/biz/host/usecase/host_test.go
@@ -2,18 +2,22 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/google/uuid"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/db/enttest"
 	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/pkg/delayqueue"
 	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
 )
 
@@ -107,6 +111,45 @@ func TestHostUsecase_markRecycledTasksFinished(t *testing.T) {
 	}
 }
 
+func TestHostUsecase_DeleteVMMarksLinkedTasksFinished(t *testing.T) {
+	ctx := context.Background()
+	userID := uuid.New()
+	taskID := uuid.New()
+	vm := &db.VirtualMachine{
+		ID:            "vm-delete",
+		HostID:        "host-delete",
+		EnvironmentID: "env-delete",
+		UserID:        userID,
+		Edges: db.VirtualMachineEdges{Tasks: []*db.Task{{
+			ID:     taskID,
+			UserID: userID,
+			Status: consts.TaskStatusProcessing,
+		}}},
+	}
+	taskRepo := &hostTaskRepoStub{}
+	repo := &hostRepoDeleteStub{vm: vm}
+	rdb := newHostTestRedis(t)
+	u := &HostUsecase{
+		repo:             repo,
+		taskRepo:         taskRepo,
+		taskflow:         &hostTaskflowStub{vm: &hostVMDeleterStub{}},
+		vmexpireQueue:    delayqueue.NewVMExpireQueue(rdb, slog.New(slog.NewTextHandler(io.Discard, nil))),
+		logger:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		privilegeChecker: nil,
+	}
+
+	if err := u.DeleteVM(ctx, userID, vm.HostID, vm.ID); err != nil {
+		t.Fatalf("DeleteVM() error = %v", err)
+	}
+
+	if !repo.deleted {
+		t.Fatal("expected vm to be deleted")
+	}
+	if len(taskRepo.updatedIDs) != 1 || taskRepo.updatedIDs[0] != taskID {
+		t.Fatalf("updated task ids = %v, want %s", taskRepo.updatedIDs, taskID)
+	}
+}
+
 type hostTaskRepoStub struct {
 	client     *db.Client
 	updatedIDs []uuid.UUID
@@ -138,6 +181,9 @@ func (s *hostTaskRepoStub) Create(context.Context, *domain.User, domain.CreateTa
 
 func (s *hostTaskRepoStub) Update(ctx context.Context, _ *domain.User, id uuid.UUID, fn func(up *db.TaskUpdateOne) error) error {
 	s.updatedIDs = append(s.updatedIDs, id)
+	if s.client == nil {
+		return nil
+	}
 	up := s.client.Task.UpdateOneID(id)
 	if err := fn(up); err != nil {
 		return err
@@ -155,4 +201,120 @@ func (s *hostTaskRepoStub) Stop(context.Context, *domain.User, uuid.UUID, func(*
 
 func (s *hostTaskRepoStub) Delete(context.Context, *domain.User, uuid.UUID) error {
 	panic("unexpected call to Delete")
+}
+
+type hostRepoDeleteStub struct {
+	vm      *db.VirtualMachine
+	deleted bool
+}
+
+func (s *hostRepoDeleteStub) DeleteVirtualMachine(_ context.Context, _ uuid.UUID, _, _ string, fn func(*db.VirtualMachine) error) error {
+	if err := fn(s.vm); err != nil {
+		return err
+	}
+	s.deleted = true
+	return nil
+}
+
+func (s *hostRepoDeleteStub) List(context.Context, uuid.UUID) ([]*db.Host, error) { return nil, nil }
+func (s *hostRepoDeleteStub) GetHost(context.Context, uuid.UUID, string) (*domain.Host, error) {
+	return nil, nil
+}
+func (s *hostRepoDeleteStub) GetByID(context.Context, string) (*db.Host, error) { return nil, nil }
+func (s *hostRepoDeleteStub) GetVirtualMachine(context.Context, string) (*db.VirtualMachine, error) {
+	return s.vm, nil
+}
+func (s *hostRepoDeleteStub) GetVirtualMachineByEnvID(context.Context, string) (*db.VirtualMachine, error) {
+	return s.vm, nil
+}
+func (s *hostRepoDeleteStub) GetVirtualMachineWithUser(context.Context, uuid.UUID, string) (*db.VirtualMachine, error) {
+	return s.vm, nil
+}
+func (s *hostRepoDeleteStub) CreateVirtualMachine(context.Context, *domain.User, *domain.CreateVMReq, func(context.Context) (string, error), func(*db.Model, *db.Image) (*domain.VirtualMachine, error)) (*domain.VirtualMachine, error) {
+	return nil, nil
+}
+func (s *hostRepoDeleteStub) PastHourVirtualMachine(context.Context) ([]*db.VirtualMachine, error) {
+	return nil, nil
+}
+func (s *hostRepoDeleteStub) AllCountDownVirtualMachine(context.Context) ([]*db.VirtualMachine, error) {
+	return nil, nil
+}
+func (s *hostRepoDeleteStub) UpsertVirtualMachine(context.Context, *taskflow.VirtualMachine) error {
+	return nil
+}
+func (s *hostRepoDeleteStub) UpdateVirtualMachine(context.Context, string, func(*db.VirtualMachineUpdateOne) error) error {
+	return nil
+}
+func (s *hostRepoDeleteStub) UpsertHost(context.Context, *taskflow.Host) error    { return nil }
+func (s *hostRepoDeleteStub) DeleteHost(context.Context, uuid.UUID, string) error { return nil }
+func (s *hostRepoDeleteStub) UpdateHost(context.Context, uuid.UUID, *domain.UpdateHostReq) error {
+	return nil
+}
+func (s *hostRepoDeleteStub) UpdateVM(context.Context, domain.UpdateVMReq, func(*db.VirtualMachine) error) (*db.VirtualMachine, int64, error) {
+	return nil, 0, nil
+}
+func (s *hostRepoDeleteStub) GetGitCredentialByTask(context.Context, string) (*domain.GitCredentialInfo, error) {
+	return nil, nil
+}
+
+type hostTaskflowStub struct {
+	vm taskflow.VirtualMachiner
+}
+
+func (s *hostTaskflowStub) VirtualMachiner() taskflow.VirtualMachiner      { return s.vm }
+func (s *hostTaskflowStub) Host() taskflow.Hoster                          { return nil }
+func (s *hostTaskflowStub) FileManager() taskflow.FileManager              { return nil }
+func (s *hostTaskflowStub) TaskManager() taskflow.TaskManager              { return nil }
+func (s *hostTaskflowStub) PortForwarder() taskflow.PortForwarder          { return nil }
+func (s *hostTaskflowStub) Stats(context.Context) (*taskflow.Stats, error) { return nil, nil }
+func (s *hostTaskflowStub) TaskLive(context.Context, string, bool, func(*taskflow.TaskChunk) error) error {
+	return nil
+}
+
+type hostVMDeleterStub struct{}
+
+func (s *hostVMDeleterStub) Delete(context.Context, *taskflow.DeleteVirtualMachineReq) error {
+	return nil
+}
+func (s *hostVMDeleterStub) Create(context.Context, *taskflow.CreateVirtualMachineReq) (*taskflow.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *hostVMDeleterStub) Hibernate(context.Context, *taskflow.HibernateVirtualMachineReq) error {
+	return errors.New("not implemented")
+}
+func (s *hostVMDeleterStub) Resume(context.Context, *taskflow.ResumeVirtualMachineReq) error {
+	return errors.New("not implemented")
+}
+func (s *hostVMDeleterStub) List(context.Context, string) ([]*taskflow.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *hostVMDeleterStub) Info(context.Context, taskflow.VirtualMachineInfoReq) (*taskflow.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *hostVMDeleterStub) Terminal(context.Context, *taskflow.TerminalReq) (taskflow.Sheller, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *hostVMDeleterStub) Reports(context.Context, taskflow.ReportSubscribeReq) (taskflow.Reporter, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *hostVMDeleterStub) TerminalList(context.Context, string) ([]*taskflow.Terminal, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *hostVMDeleterStub) CloseTerminal(context.Context, *taskflow.CloseTerminalReq) error {
+	return errors.New("not implemented")
+}
+func (s *hostVMDeleterStub) IsOnline(context.Context, *taskflow.IsOnlineReq[string]) (*taskflow.IsOnlineResp, error) {
+	return nil, errors.New("not implemented")
+}
+
+func newHostTestRedis(t *testing.T) *redis.Client {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run() error = %v", err)
+	}
+	t.Cleanup(mr.Close)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	return rdb
 }

--- a/backend/pkg/lifecycle/manager.go
+++ b/backend/pkg/lifecycle/manager.go
@@ -2,6 +2,7 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -105,19 +106,20 @@ func (m *Manager[I, S, M]) Transition(ctx context.Context, id I, to S, metadata 
 	hooks := m.hooks
 	m.mu.RUnlock()
 
+	var errs []error
 	for _, hook := range hooks {
 		if hook.Async() {
 			go m.execHook(ctx, hook, id, from, to, metadata)
 		} else {
 			if err := m.execHook(ctx, hook, id, from, to, metadata); err != nil {
 				m.logger.Error("hook failed", "hook", hook.Name(), "error", err)
-				return fmt.Errorf("hook %s failed: %w", hook.Name(), err)
+				errs = append(errs, fmt.Errorf("hook %s failed: %w", hook.Name(), err))
 			}
 		}
 	}
 
 	m.logger.Info("state transitioned", "id", id, "from", from, "to", to)
-	return nil
+	return errors.Join(errs...)
 }
 
 // GetState 获取当前状态
@@ -169,8 +171,8 @@ func (m *Manager[I, S, M]) isValidTransition(from, to S) bool {
 // TaskTransitions 任务的默认状态转换规则
 func TaskTransitions() map[consts.TaskStatus][]consts.TaskStatus {
 	return map[consts.TaskStatus][]consts.TaskStatus{
-		"":                          {consts.TaskStatusPending},
-		consts.TaskStatusPending:    {consts.TaskStatusProcessing, consts.TaskStatusError},
+		"":                          {consts.TaskStatusPending, consts.TaskStatusFinished},
+		consts.TaskStatusPending:    {consts.TaskStatusProcessing, consts.TaskStatusFinished, consts.TaskStatusError},
 		consts.TaskStatusProcessing: {consts.TaskStatusFinished, consts.TaskStatusError},
 		consts.TaskStatusError:      {consts.TaskStatusProcessing},
 	}
@@ -179,7 +181,7 @@ func TaskTransitions() map[consts.TaskStatus][]consts.TaskStatus {
 // VMTransitions VM 的默认状态转换规则
 func VMTransitions() map[VMState][]VMState {
 	return map[VMState][]VMState{
-		"":               {VMStatePending, VMStateCreating, VMStateRecycled},
+		"":               {VMStatePending, VMStateCreating, VMStateRunning, VMStateFailed, VMStateRecycled},
 		VMStatePending:   {VMStateCreating, VMStateFailed, VMStateRecycled},
 		VMStateCreating:  {VMStateRunning, VMStateFailed, VMStateRecycled},
 		VMStateRunning:   {VMStateSucceeded, VMStateFailed, VMStateRecycled},

--- a/backend/pkg/lifecycle/manager_test.go
+++ b/backend/pkg/lifecycle/manager_test.go
@@ -1,0 +1,60 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestManagerTransitionContinuesAfterHookError(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run() error = %v", err)
+	}
+	defer mr.Close()
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	mgr := NewManager[string, VMState, VMMetadata](
+		rdb,
+		WithLogger[string, VMState, VMMetadata](slog.New(slog.NewTextHandler(io.Discard, nil))),
+		WithTransitions[string, VMState, VMMetadata](VMTransitions()),
+	)
+	second := &recordHook{}
+	mgr.Register(&errorHook{}, second)
+
+	err = mgr.Transition(context.Background(), "vm-1", VMStateRecycled, VMMetadata{VMID: "vm-1"})
+	if err == nil {
+		t.Fatal("expected Transition() to return hook error")
+	}
+	if !second.called {
+		t.Fatal("expected later hook to run after earlier hook error")
+	}
+}
+
+type errorHook struct{}
+
+func (h *errorHook) Name() string  { return "error-hook" }
+func (h *errorHook) Priority() int { return 100 }
+func (h *errorHook) Async() bool   { return false }
+func (h *errorHook) OnStateChange(context.Context, string, VMState, VMState, VMMetadata) error {
+	return errors.New("boom")
+}
+
+type recordHook struct {
+	called bool
+}
+
+func (h *recordHook) Name() string  { return "record-hook" }
+func (h *recordHook) Priority() int { return 90 }
+func (h *recordHook) Async() bool   { return false }
+func (h *recordHook) OnStateChange(context.Context, string, VMState, VMState, VMMetadata) error {
+	h.called = true
+	return nil
+}

--- a/backend/pkg/lifecycle/vmrecyclehook.go
+++ b/backend/pkg/lifecycle/vmrecyclehook.go
@@ -50,7 +50,7 @@ func NewVMRecycleHook(i *do.Injector) *VMRecycleHook {
 }
 
 func (h *VMRecycleHook) Name() string  { return "vm-recycle-hook" }
-func (h *VMRecycleHook) Priority() int { return 100 }
+func (h *VMRecycleHook) Priority() int { return 110 }
 func (h *VMRecycleHook) Async() bool   { return false }
 
 func (h *VMRecycleHook) OnStateChange(ctx context.Context, vmID string, from, to VMState, metadata VMMetadata) error {

--- a/backend/pkg/lifecycle/vmtaskhook_test.go
+++ b/backend/pkg/lifecycle/vmtaskhook_test.go
@@ -105,3 +105,94 @@ func TestVMTaskHook_OnStateChange_RecycledTransitionsTaskToFinished(t *testing.T
 		t.Fatalf("task state = %s, want %s", state, consts.TaskStatusFinished)
 	}
 }
+
+func TestVMTaskHook_OnStateChange_RecycledTransitionsTaskWithoutCachedState(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run() error = %v", err)
+	}
+	defer mr.Close()
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	taskLifecycle := NewManager[uuid.UUID, consts.TaskStatus, TaskMetadata](
+		rdb,
+		WithLogger[uuid.UUID, consts.TaskStatus, TaskMetadata](slog.New(slog.NewTextHandler(io.Discard, nil))),
+		WithTransitions[uuid.UUID, consts.TaskStatus, TaskMetadata](TaskTransitions()),
+	)
+
+	taskID := uuid.New()
+	userID := uuid.New()
+	hook := &VMTaskHook{
+		taskLifecycle: taskLifecycle,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	if err := hook.OnStateChange(context.Background(), "vm-1", VMStateRunning, VMStateRecycled, VMMetadata{
+		VMID:   "vm-1",
+		TaskID: &taskID,
+		UserID: userID,
+	}); err != nil {
+		t.Fatalf("OnStateChange() error = %v", err)
+	}
+
+	state, err := taskLifecycle.GetState(context.Background(), taskID)
+	if err != nil {
+		t.Fatalf("taskLifecycle.GetState() error = %v", err)
+	}
+	if state != consts.TaskStatusFinished {
+		t.Fatalf("task state = %s, want %s", state, consts.TaskStatusFinished)
+	}
+}
+
+func TestVMTaskHook_OnStateChange_RecycledTransitionsPendingTaskToFinished(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run() error = %v", err)
+	}
+	defer mr.Close()
+
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	taskLifecycle := NewManager[uuid.UUID, consts.TaskStatus, TaskMetadata](
+		rdb,
+		WithLogger[uuid.UUID, consts.TaskStatus, TaskMetadata](slog.New(slog.NewTextHandler(io.Discard, nil))),
+		WithTransitions[uuid.UUID, consts.TaskStatus, TaskMetadata](TaskTransitions()),
+	)
+
+	taskID := uuid.New()
+	userID := uuid.New()
+	meta := TaskMetadata{TaskID: taskID, UserID: userID}
+	if err := taskLifecycle.Transition(context.Background(), taskID, consts.TaskStatusPending, meta); err != nil {
+		t.Fatalf("taskLifecycle.Transition(pending) error = %v", err)
+	}
+
+	hook := &VMTaskHook{
+		taskLifecycle: taskLifecycle,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	if err := hook.OnStateChange(context.Background(), "vm-1", VMStatePending, VMStateRecycled, VMMetadata{
+		VMID:   "vm-1",
+		TaskID: &taskID,
+		UserID: userID,
+	}); err != nil {
+		t.Fatalf("OnStateChange() error = %v", err)
+	}
+
+	state, err := taskLifecycle.GetState(context.Background(), taskID)
+	if err != nil {
+		t.Fatalf("taskLifecycle.GetState() error = %v", err)
+	}
+	if state != consts.TaskStatusFinished {
+		t.Fatalf("task state = %s, want %s", state, consts.TaskStatusFinished)
+	}
+}
+
+func TestVMRecycleHookRunsBeforeVMTaskHook(t *testing.T) {
+	if got, want := (&VMRecycleHook{}).Priority() > (&VMTaskHook{}).Priority(), true; got != want {
+		t.Fatalf("VMRecycleHook should run before VMTaskHook")
+	}
+}


### PR DESCRIPTION
## Summary
- 统一 VM ready/failed 回调走 VM lifecycle，再由 VMTaskHook 同步任务状态
- 提升 VMRecycleHook 优先级，并让 lifecycle manager 在 hook 失败后继续执行后续 hook
- 手动删除 VM 时同步结束关联非终态任务，补充回归测试

## Test Plan
- [x] go test ./pkg/lifecycle ./biz/host/handler/v1 ./biz/host/usecase ./biz/host/repo ./biz/task/usecase -count=1
- [ ] go test ./...（当前失败在未改动的 pkg/vmstatus: TestResolve/hibernated_condition_returns_hibernated，实际 offline，期望 hibernated）