### PR TITLE
fix: 为所有模型创建模型访问凭证

### DIFF
--- a/backend/biz/task/repo/task.go
+++ b/backend/biz/task/repo/task.go
@@ -327,19 +327,17 @@ func (t *TaskRepo) Create(ctx context.Context, u *domain.User, req domain.Create
 			return err
 		}
 
-		var mak *db.ModelApiKey
-		if p := m.Edges.Pricing; p != nil {
-			apikey := uuid.NewString()
-			mak, err = tx.ModelApiKey.Create().
-				SetAPIKey(apikey).
-				SetUserID(u.ID).
-				SetModelID(m.ID).
-				Save(ctx)
-			if err != nil {
-				return err
-			}
-			m.Edges.Apikeys = append(m.Edges.Apikeys, mak)
+		apikey := uuid.NewString()
+		mak, err := tx.ModelApiKey.Create().
+			SetID(uuid.New()).
+			SetAPIKey(apikey).
+			SetUserID(u.ID).
+			SetModelID(m.ID).
+			Save(ctx)
+		if err != nil {
+			return err
 		}
+		m.Edges.Apikeys = append(m.Edges.Apikeys, mak)
 
 		img, err := tx.Image.Query().Where(image.ID(req.ImageID)).First(ctx)
 		if err != nil {
@@ -364,6 +362,7 @@ func (t *TaskRepo) Create(ctx context.Context, u *domain.User, req domain.Create
 		}
 
 		crt := tx.ProjectTask.Create().
+			SetID(uuid.New()).
 			SetImageID(img.ID).
 			SetModelID(m.ID).
 			SetTaskID(tk.ID).
@@ -418,18 +417,17 @@ func (t *TaskRepo) Create(ctx context.Context, u *domain.User, req domain.Create
 		}
 
 		tvm := tx.TaskVirtualMachine.Create().
+			SetID(uuid.New()).
 			SetTaskID(tk.ID).
 			SetVirtualmachineID(vm.ID)
 		if err := tvm.Exec(ctx); err != nil {
 			return err
 		}
 
-		if mak != nil {
-			if err := tx.ModelApiKey.UpdateOneID(mak.ID).
-				SetVirtualmachineID(vm.ID).
-				Exec(ctx); err != nil {
-				return err
-			}
+		if err := tx.ModelApiKey.UpdateOneID(mak.ID).
+			SetVirtualmachineID(vm.ID).
+			Exec(ctx); err != nil {
+			return err
 		}
 
 		return nil

--- a/backend/biz/task/repo/task_create_test.go
+++ b/backend/biz/task/repo/task_create_test.go
@@ -1,0 +1,81 @@
+package repo
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/db/enttest"
+	"github.com/chaitin/MonkeyCode/backend/db/modelapikey"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
+)
+
+func TestTaskRepoCreateCreatesModelApiKeyWithoutPricing(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:task-repo-create-model-apikey?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	userID := uuid.New()
+	modelID := uuid.New()
+	imageID := uuid.New()
+	hostID := "host-task-create"
+	vmID := "vm-task-create"
+
+	if _, err := client.User.Create().SetID(userID).SetName("user").SetRole(consts.UserRoleIndividual).SetStatus(consts.UserStatusActive).Save(ctx); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if _, err := client.Host.Create().SetID(hostID).SetUserID(userID).Save(ctx); err != nil {
+		t.Fatalf("create host: %v", err)
+	}
+	if _, err := client.Model.Create().SetID(modelID).SetUserID(userID).SetProvider("OpenAI").SetAPIKey("secret").SetBaseURL("https://api.example.com").SetModel("gpt-4o").Save(ctx); err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+	if _, err := client.Image.Create().SetID(imageID).SetUserID(userID).SetName("image").Save(ctx); err != nil {
+		t.Fatalf("create image: %v", err)
+	}
+
+	repo := &TaskRepo{
+		cfg:    &config.Config{},
+		db:     client,
+		logger: slog.Default(),
+	}
+	req := domain.CreateTaskReq{
+		Content: "content",
+		HostID:  hostID,
+		ImageID: imageID,
+		ModelID: modelID.String(),
+		Resource: &domain.VMResource{
+			Core:   1,
+			Memory: 1024,
+		},
+		Type: consts.TaskTypeDevelop,
+		Now:  time.Now(),
+	}
+
+	_, err := repo.Create(ctx, &domain.User{ID: userID}, req, "", func(*db.ProjectTask, *db.Model, *db.Image) (*taskflow.VirtualMachine, error) {
+		return &taskflow.VirtualMachine{ID: vmID, EnvironmentID: "env-task-create"}, nil
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	keys, err := client.ModelApiKey.Query().Where(modelapikey.ModelID(modelID), modelapikey.UserID(userID)).All(ctx)
+	if err != nil {
+		t.Fatalf("query model api keys: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("model api key count = %d, want 1", len(keys))
+	}
+	if keys[0].VirtualmachineID != vmID {
+		t.Fatalf("virtualmachine id = %q, want %q", keys[0].VirtualmachineID, vmID)
+	}
+}


### PR DESCRIPTION
## Summary
- 任务创建时不再仅对内置定价模型创建 ModelApiKey，所有模型都会生成代理/MCP 认证凭证
- 手动创建虚拟机路径同步创建 ModelApiKey，保持模型鉴权行为一致
- 增加无 pricing 模型创建任务的回归测试

## Test Plan
- [x] cd backend && go test ./biz/task/repo ./biz/host/repo