### PR TITLE
fix: prevent task plan scrollbar flicker

### DIFF
--- a/frontend/src/components/console/task/chat-panel.tsx
+++ b/frontend/src/components/console/task/chat-panel.tsx
@@ -77,7 +77,14 @@ export function PlanStepsBlock({ plan, streamStatus }: PlanStepsBlockProps) {
           {planOpened ? <ChevronsDownUp className="size-4" /> : <ChevronsUpDown className="size-4" />}
         </Button>
       </div>
-      <div className="flex flex-col gap-2 max-h-48 overflow-y-auto">{renderPlan()}</div>
+      <div
+        className={cn(
+          "flex flex-col gap-2",
+          planOpened ? "max-h-48 overflow-y-auto overscroll-contain" : "overflow-hidden"
+        )}
+      >
+        {renderPlan()}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Avoid creating a scroll container for the collapsed task plan state so the running spinner does not repeatedly wake the overlay scrollbar. Keep normal vertical scrolling when the plan is expanded.