### PR TITLE
fix: 收敛模型响应敏感信息

### DIFF
--- a/backend/biz/setting/usecase/model.go
+++ b/backend/biz/setting/usecase/model.go
@@ -75,6 +75,7 @@ func (u *modelUsecase) List(ctx context.Context, uid uuid.UUID, cursor domain.Cu
 	models := cvt.Iter(ms, func(_ int, m *db.Model) *domain.Model {
 		j := cvt.From(m, &domain.Model{})
 		j.IsDefault = j.GetIsDefault(user)
+		j.HideSharedCredentials()
 		return j
 	})
 
@@ -83,6 +84,9 @@ func (u *modelUsecase) List(ctx context.Context, uid uuid.UUID, cursor domain.Cu
 		if err != nil {
 			u.logger.ErrorContext(ctx, "failed to list additional models from hook", "error", err, "user_id", uid)
 			return nil, fmt.Errorf("failed to list additional models: %w", err)
+		}
+		for _, model := range additionalModels {
+			model.HideSharedCredentials()
 		}
 		models = append(models, additionalModels...)
 	}

--- a/backend/biz/task/usecase/task.go
+++ b/backend/biz/task/usecase/task.go
@@ -233,8 +233,7 @@ func (a *TaskUsecase) SwitchModel(ctx context.Context, user *domain.User, taskID
 		}
 	}
 
-	respModel := cvt.From(model, &domain.Model{})
-	respModel.APIKey = ""
+	respModel := cvt.From(model, &domain.ModelBrief{})
 	return &domain.SwitchTaskModelResp{
 		ID:        item.ID,
 		RequestID: resp.RequestId,

--- a/backend/biz/task/usecase/task_switch_model_test.go
+++ b/backend/biz/task/usecase/task_switch_model_test.go
@@ -116,9 +116,6 @@ func TestSwitchModelRestartsWithExecutionConfigAndUpdatesModel(t *testing.T) {
 	if resp.Model == nil || resp.Model.ID != toModelID {
 		t.Fatalf("resp.Model = %+v, want target model", resp.Model)
 	}
-	if resp.Model.APIKey != "" {
-		t.Fatalf("resp.Model.APIKey = %q, want empty response api key", resp.Model.APIKey)
-	}
 
 	if repo.created == nil {
 		t.Fatal("CreateModelSwitch was not called")

--- a/backend/domain/model.go
+++ b/backend/domain/model.go
@@ -77,11 +77,6 @@ func (m *Model) From(src *db.Model) *Model {
 	m.UpdatedAt = src.UpdatedAt.Unix()
 	m.LastCheckAt = src.LastCheckAt.Unix()
 
-	if src.Remark == "economy" {
-		m.APIKey = ""
-		m.BaseURL = ""
-	}
-
 	if src.Edges.User == nil {
 		return m
 	}
@@ -99,7 +94,6 @@ func (m *Model) From(src *db.Model) *Model {
 			Type: consts.OwnerTypeTeam,
 			Name: team.Name,
 		}
-		m.APIKey = ""
 		return m
 	}
 	if src.Edges.User.Role == consts.UserRoleAdmin {
@@ -108,10 +102,69 @@ func (m *Model) From(src *db.Model) *Model {
 			Type: consts.OwnerTypePublic,
 			Name: consts.MonkeyCodeAITeamName,
 		}
-		m.APIKey = ""
-		m.BaseURL = ""
 		return m
 	}
+	return m
+}
+
+func (m *Model) HideCredentials() *Model {
+	if m == nil {
+		return m
+	}
+	m.APIKey = ""
+	m.BaseURL = ""
+	return m
+}
+
+func (m *Model) HideSharedCredentials() *Model {
+	if m == nil || m.Owner == nil || m.Owner.Type == consts.OwnerTypePrivate {
+		return m
+	}
+	return m.HideCredentials()
+}
+
+type ModelBrief struct {
+	ID               uuid.UUID            `json:"id"`
+	Provider         string               `json:"provider"`
+	Model            string               `json:"model"`
+	Temperature      float64              `json:"temperature"`
+	CreatedAt        int64                `json:"created_at"`
+	UpdatedAt        int64                `json:"updated_at"`
+	Weight           int                  `json:"weight"`
+	Owner            *Owner               `json:"owner,omitempty"`
+	InterfaceType    consts.InterfaceType `json:"interface_type"`
+	IsFree           bool                 `json:"is_free"`
+	AccessLevel      string               `json:"access_level"`
+	LastCheckAt      int64                `json:"last_check_at"`
+	LastCheckSuccess bool                 `json:"last_check_success"`
+	LastCheckError   string               `json:"last_check_error"`
+	ThinkingEnabled  bool                 `json:"thinking_enabled"`
+	ContextLimit     int                  `json:"context_limit"`
+	OutputLimit      int                  `json:"output_limit"`
+}
+
+func (m *ModelBrief) From(src *db.Model) *ModelBrief {
+	if src == nil {
+		return m
+	}
+	full := (&Model{}).From(src)
+	m.ID = full.ID
+	m.Provider = full.Provider
+	m.Model = full.Model
+	m.Temperature = full.Temperature
+	m.CreatedAt = full.CreatedAt
+	m.UpdatedAt = full.UpdatedAt
+	m.Weight = full.Weight
+	m.Owner = full.Owner
+	m.InterfaceType = full.InterfaceType
+	m.IsFree = full.IsFree
+	m.AccessLevel = full.AccessLevel
+	m.LastCheckAt = full.LastCheckAt
+	m.LastCheckSuccess = full.LastCheckSuccess
+	m.LastCheckError = full.LastCheckError
+	m.ThinkingEnabled = full.ThinkingEnabled
+	m.ContextLimit = full.ContextLimit
+	m.OutputLimit = full.OutputLimit
 	return m
 }
 

--- a/backend/domain/model_response_test.go
+++ b/backend/domain/model_response_test.go
@@ -1,0 +1,122 @@
+package domain_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+func TestModelFromPreservesCredentialsForPureConversion(t *testing.T) {
+	modelID := uuid.New()
+	src := &db.Model{
+		ID:        modelID,
+		Provider:  "OpenAI",
+		APIKey:    "sk-admin-secret",
+		BaseURL:   "https://api.example.com/v1",
+		Model:     "gpt-4o",
+		CreatedAt: time.Unix(100, 0),
+		UpdatedAt: time.Unix(200, 0),
+		Edges: db.ModelEdges{
+			User: &db.User{
+				ID:   uuid.New(),
+				Role: consts.UserRoleAdmin,
+				Name: "admin",
+			},
+		},
+	}
+
+	got := (&domain.Model{}).From(src)
+
+	if got.APIKey != src.APIKey {
+		t.Fatalf("APIKey = %q, want %q", got.APIKey, src.APIKey)
+	}
+	if got.BaseURL != src.BaseURL {
+		t.Fatalf("BaseURL = %q, want %q", got.BaseURL, src.BaseURL)
+	}
+	if got.Owner == nil || got.Owner.Type != consts.OwnerTypePublic {
+		t.Fatalf("Owner = %#v, want public owner", got.Owner)
+	}
+}
+
+func TestProjectTaskFromDoesNotExposeModelCredentials(t *testing.T) {
+	pt := (&domain.ProjectTask{}).From(&db.ProjectTask{
+		Branch: "main",
+		Edges: db.ProjectTaskEdges{
+			Model: privateModelWithCredentials(),
+			Task: &db.Task{
+				ID:        uuid.New(),
+				UserID:    uuid.New(),
+				CreatedAt: time.Unix(100, 0),
+				UpdatedAt: time.Unix(200, 0),
+			},
+		},
+	})
+
+	payload, err := json.Marshal(pt)
+	if err != nil {
+		t.Fatalf("marshal project task: %v", err)
+	}
+
+	assertNoModelCredentials(t, string(payload))
+}
+
+func TestTaskFromDoesNotExposeModelCredentials(t *testing.T) {
+	task := (&domain.Task{}).From(&db.Task{
+		ID:        uuid.New(),
+		UserID:    uuid.New(),
+		CreatedAt: time.Unix(100, 0),
+		UpdatedAt: time.Unix(200, 0),
+		Edges: db.TaskEdges{
+			ProjectTasks: []*db.ProjectTask{
+				{
+					Edges: db.ProjectTaskEdges{
+						Model: privateModelWithCredentials(),
+					},
+				},
+			},
+		},
+	})
+
+	payload, err := json.Marshal(task)
+	if err != nil {
+		t.Fatalf("marshal task: %v", err)
+	}
+
+	assertNoModelCredentials(t, string(payload))
+}
+
+func privateModelWithCredentials() *db.Model {
+	return &db.Model{
+		ID:        uuid.New(),
+		Provider:  "OpenAI",
+		APIKey:    "sk-private-secret",
+		BaseURL:   "https://private.example.com/v1",
+		Model:     "gpt-4o",
+		CreatedAt: time.Unix(100, 0),
+		UpdatedAt: time.Unix(200, 0),
+		Edges: db.ModelEdges{
+			User: &db.User{
+				ID:   uuid.New(),
+				Role: consts.UserRoleIndividual,
+				Name: "user",
+			},
+		},
+	}
+}
+
+func assertNoModelCredentials(t *testing.T, payload string) {
+	t.Helper()
+
+	for _, forbidden := range []string{"api_key", "sk-private-secret", "https://private.example.com/v1"} {
+		if strings.Contains(payload, forbidden) {
+			t.Fatalf("payload exposes %q: %s", forbidden, payload)
+		}
+	}
+}

--- a/backend/domain/task.go
+++ b/backend/domain/task.go
@@ -124,12 +124,12 @@ type SwitchTaskModelReq struct {
 
 // SwitchTaskModelResp 切换任务运行模型响应
 type SwitchTaskModelResp struct {
-	ID        uuid.UUID `json:"id"`
-	RequestID string    `json:"request_id,omitempty"`
-	Success   bool      `json:"success"`
-	Message   string    `json:"message"`
-	SessionID string    `json:"session_id"`
-	Model     *Model    `json:"model,omitempty"`
+	ID        uuid.UUID   `json:"id"`
+	RequestID string      `json:"request_id,omitempty"`
+	Success   bool        `json:"success"`
+	Message   string      `json:"message"`
+	SessionID string      `json:"session_id"`
+	Model     *ModelBrief `json:"model,omitempty"`
 }
 
 // TaskModelSwitch 任务模型切换记录
@@ -160,7 +160,7 @@ type TaskListReq struct {
 // ProjectTask 项目任务
 type ProjectTask struct {
 	ID           uuid.UUID        `json:"id" validate:"required"`
-	Model        *Model           `json:"model,omitempty"`
+	Model        *ModelBrief      `json:"model,omitempty"`
 	Image        *Image           `json:"image,omitempty"`
 	Branch       string           `json:"branch,omitempty"`
 	CliName      consts.CliName   `json:"cli_name,omitempty"`
@@ -180,7 +180,7 @@ func (pt *ProjectTask) From(src *db.ProjectTask) *ProjectTask {
 	if src.Edges.Task != nil {
 		pt.ID = src.Edges.Task.ID
 	}
-	pt.Model = cvt.From(src.Edges.Model, &Model{})
+	pt.Model = cvt.From(src.Edges.Model, &ModelBrief{})
 	pt.Task = cvt.From(src.Edges.Task, &Task{})
 	pt.CliName = src.CliName
 	pt.RepoURL = src.RepoURL
@@ -217,7 +217,7 @@ type Task struct {
 	CreatedAt      int64              `json:"created_at"`
 	LastActiveAt   int64              `json:"last_active_at"`
 	CompletedAt    int64              `json:"completed_at"`
-	Model          *Model             `json:"model,omitempty"`
+	Model          *ModelBrief        `json:"model,omitempty"`
 	Image          *Image             `json:"image,omitempty"`
 	Branch         string             `json:"branch,omitempty"`
 	CliName        consts.CliName     `json:"cli_name,omitempty"`
@@ -264,7 +264,7 @@ func (t *Task) From(src *db.Task) *Task {
 	}
 	if pts := src.Edges.ProjectTasks; len(pts) > 0 {
 		pt := pts[0]
-		t.Model = cvt.From(pt.Edges.Model, &Model{})
+		t.Model = cvt.From(pt.Edges.Model, &ModelBrief{})
 		t.Image = cvt.From(pt.Edges.Image, &Image{})
 		t.Branch = pt.Branch
 		t.RepoURL = pt.RepoURL


### PR DESCRIPTION
## 概要
- 调整模型响应脱敏边界，避免在 From 转换层统一清空凭证
- 新增 ModelBrief 用于任务详情、任务列表和切换模型响应，避免任务相关接口暴露 api_key/base_url
- 用户模型列表对团队/内置共享模型显式脱敏，个人模型保留自身凭证

## 测试
- go test ./domain ./biz/setting/usecase ./biz/team/usecase ./biz/task/usecase ./biz/task/handler/v1 ./biz/project/usecase