### PR TITLE
feat: 支持任务对话附件

### DIFF
--- a/backend/biz/task/handler/v1/task.go
+++ b/backend/biz/task/handler/v1/task.go
@@ -236,7 +236,7 @@ func (h *TaskHandler) Info(c *web.Context, req domain.IDReq[uuid.UUID]) error {
 //
 //	@Summary		创建任务
 //	@Description	创建任务
-//	@Description	`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。创建任务后，首轮 user-input 日志会按 `{ "content": "base64文本", "attachment_urls": [] }` 结构返回。
+//	@Description	`attachments` 为可选附件列表，最多 10 个；每项包含 `url` 和 `filename`，URL 需要匹配后端配置的附件白名单前缀。创建任务后，首轮 user-input 日志会按 `{ "content": "base64文本", "attachments": [] }` 结构返回。
 //	@Tags			【用户】任务管理
 //	@Accept			json
 //	@Produce		json
@@ -325,7 +325,7 @@ func (h *TaskHandler) PublicStream(c *web.Context, req domain.IDReq[uuid.UUID]) 
 //	@Description	```
 //	@Description	user-input 上行新格式：
 //	@Description	```json
-//	@Description	{ "type": "user-input", "data": "{\"content\":\"57un57ut5aSE55CG6L+Z5Liq6Zeu6aKY\",\"attachment_urls\":[\"https://example-bucket.oss-cn-hangzhou.aliyuncs.com/temp/a.txt\"]}" }
+//	@Description	{ "type": "user-input", "data": "{\"content\":\"57un57ut5aSE55CG6L+Z5Liq6Zeu6aKY\",\"attachments\":[{\"url\":\"https://example-bucket.oss-cn-hangzhou.aliyuncs.com/temp/a.txt\",\"filename\":\"a.txt\"}]}" }
 //	@Description	```
 //	@Description	user-input 上行旧格式仍兼容：
 //	@Description	```json
@@ -333,9 +333,9 @@ func (h *TaskHandler) PublicStream(c *web.Context, req domain.IDReq[uuid.UUID]) 
 //	@Description	```
 //	@Description	user-input 下行和历史返回统一使用新 JSON payload 字符串：
 //	@Description	```json
-//	@Description	{ "type": "user-input", "data": "{\"content\":\"57un57ut5aSE55CG6L+Z5Liq6Zeu6aKY\",\"attachment_urls\":[]}", "timestamp": 0 }
+//	@Description	{ "type": "user-input", "data": "{\"content\":\"57un57ut5aSE55CG6L+Z5Liq6Zeu6aKY\",\"attachments\":[]}", "timestamp": 0 }
 //	@Description	```
-//	@Description	`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。
+//	@Description	`attachments` 为可选附件列表，最多 10 个；每项包含 `url` 和 `filename`，URL 需要匹配后端配置的附件白名单前缀。
 //	@Description	type 字段说明：
 //	@Description	- task-started: 本轮任务启动
 //	@Description	- task-ended: 本轮任务结束
@@ -480,8 +480,8 @@ func parseUserInputData(data []byte) domain.ContinueTaskReq {
 	var payload domain.TaskUserInputPayload
 	if err := json.Unmarshal(data, &payload); err == nil && strings.TrimSpace(string(payload.Content)) != "" {
 		return domain.ContinueTaskReq{
-			Content:        payload.Content,
-			AttachmentURLs: payload.AttachmentURLs,
+			Content:     payload.Content,
+			Attachments: payload.Attachments,
 		}
 	}
 	return domain.ContinueTaskReq{Content: data}
@@ -490,11 +490,11 @@ func parseUserInputData(data []byte) domain.ContinueTaskReq {
 func normalizeUserInputData(data []byte) []byte {
 	req := parseUserInputData(data)
 	payload := domain.TaskUserInputPayload{
-		Content:        req.Content,
-		AttachmentURLs: req.AttachmentURLs,
+		Content:     req.Content,
+		Attachments: req.Attachments,
 	}
-	if payload.AttachmentURLs == nil {
-		payload.AttachmentURLs = []string{}
+	if payload.Attachments == nil {
+		payload.Attachments = []domain.TaskAttachment{}
 	}
 	out, _ := json.Marshal(payload)
 	return out
@@ -720,7 +720,7 @@ func (h *TaskHandler) writeCursor(wsConn *ws.WebsocketManager, cursor string, ha
 //	@Summary		查询任务历史轮次
 //	@Description	根据 cursor 向前翻页查询任务的历史轮次。limit 为轮次数（非条目数），
 //	@Description	limit=2 表示返回 2 轮的完整消息。返回的 chunks 按时间倒序排列（最新在前）。
-//	@Description	返回的 user-input.data 统一为 JSON payload 字符串，例如 `{"content":"57un57ut5aSE55CG","attachment_urls":[]}`；content 为用户输入文本的 base64 编码，旧历史裸文本也会按该结构包装返回。
+//	@Description	返回的 user-input.data 统一为 JSON payload 字符串，例如 `{"content":"57un57ut5aSE55CG","attachments":[]}`；content 为用户输入文本的 base64 编码，旧历史裸文本也会按该结构包装返回。
 //	@Tags			【用户】任务管理
 //	@Accept			json
 //	@Produce		json

--- a/backend/biz/task/handler/v1/task.go
+++ b/backend/biz/task/handler/v1/task.go
@@ -236,6 +236,7 @@ func (h *TaskHandler) Info(c *web.Context, req domain.IDReq[uuid.UUID]) error {
 //
 //	@Summary		创建任务
 //	@Description	创建任务
+//	@Description	`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。创建任务后，首轮 user-input 日志会按 `{ "content": "...", "attachment_urls": [] }` 结构返回。
 //	@Tags			【用户】任务管理
 //	@Accept			json
 //	@Produce		json
@@ -317,11 +318,24 @@ func (h *TaskHandler) PublicStream(c *web.Context, req domain.IDReq[uuid.UUID]) 
 // Stream 任务数据流 WebSocket
 //
 //	@Summary		任务数据流 WebSocket
-//	@Description	功能定位：该接口通过 WebSocket 仅做 Agent ↔ 前端 的数据代理与转发，不进行任何包体解析或改写。所有数据以原始格式透传并存储。
+//	@Description	功能定位：该接口通过 WebSocket 转发任务运行数据。任务对话继续输入使用 `type=user-input`。
 //	@Description	数据格式约定：当前仅支持文本帧透传。服务端将 Agent 的原始文本数据包装为如下结构返回给前端（对应 domain.TaskStream）：
 //	@Description	```json
 //	@Description	{ "type": "string", "data": "string", "kind": "string", "timestamp": 0 }
 //	@Description	```
+//	@Description	user-input 上行新格式：
+//	@Description	```json
+//	@Description	{ "type": "user-input", "data": "{\"content\":\"继续处理这个问题\",\"attachment_urls\":[\"https://example-bucket.oss-cn-hangzhou.aliyuncs.com/temp/a.txt\"]}" }
+//	@Description	```
+//	@Description	user-input 上行旧格式仍兼容：
+//	@Description	```json
+//	@Description	{ "type": "user-input", "data": "继续处理这个问题" }
+//	@Description	```
+//	@Description	user-input 下行和历史返回统一使用新 JSON payload 字符串：
+//	@Description	```json
+//	@Description	{ "type": "user-input", "data": "{\"content\":\"继续处理这个问题\",\"attachment_urls\":[]}", "timestamp": 0 }
+//	@Description	```
+//	@Description	`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。
 //	@Description	type 字段说明：
 //	@Description	- task-started: 本轮任务启动
 //	@Description	- task-ended: 本轮任务结束
@@ -675,6 +689,7 @@ func (h *TaskHandler) writeCursor(wsConn *ws.WebsocketManager, cursor string, ha
 //	@Summary		查询任务历史轮次
 //	@Description	根据 cursor 向前翻页查询任务的历史轮次。limit 为轮次数（非条目数），
 //	@Description	limit=2 表示返回 2 轮的完整消息。返回的 chunks 按时间倒序排列（最新在前）。
+//	@Description	返回的 user-input.data 统一为 JSON payload 字符串，例如 `{"content":"继续处理","attachment_urls":[]}`；旧历史裸文本也会按该结构包装返回。
 //	@Tags			【用户】任务管理
 //	@Accept			json
 //	@Produce		json

--- a/backend/biz/task/handler/v1/task.go
+++ b/backend/biz/task/handler/v1/task.go
@@ -236,7 +236,7 @@ func (h *TaskHandler) Info(c *web.Context, req domain.IDReq[uuid.UUID]) error {
 //
 //	@Summary		创建任务
 //	@Description	创建任务
-//	@Description	`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。创建任务后，首轮 user-input 日志会按 `{ "content": "...", "attachment_urls": [] }` 结构返回。
+//	@Description	`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。创建任务后，首轮 user-input 日志会按 `{ "content": "base64文本", "attachment_urls": [] }` 结构返回。
 //	@Tags			【用户】任务管理
 //	@Accept			json
 //	@Produce		json
@@ -325,7 +325,7 @@ func (h *TaskHandler) PublicStream(c *web.Context, req domain.IDReq[uuid.UUID]) 
 //	@Description	```
 //	@Description	user-input 上行新格式：
 //	@Description	```json
-//	@Description	{ "type": "user-input", "data": "{\"content\":\"继续处理这个问题\",\"attachment_urls\":[\"https://example-bucket.oss-cn-hangzhou.aliyuncs.com/temp/a.txt\"]}" }
+//	@Description	{ "type": "user-input", "data": "{\"content\":\"57un57ut5aSE55CG6L+Z5Liq6Zeu6aKY\",\"attachment_urls\":[\"https://example-bucket.oss-cn-hangzhou.aliyuncs.com/temp/a.txt\"]}" }
 //	@Description	```
 //	@Description	user-input 上行旧格式仍兼容：
 //	@Description	```json
@@ -333,7 +333,7 @@ func (h *TaskHandler) PublicStream(c *web.Context, req domain.IDReq[uuid.UUID]) 
 //	@Description	```
 //	@Description	user-input 下行和历史返回统一使用新 JSON payload 字符串：
 //	@Description	```json
-//	@Description	{ "type": "user-input", "data": "{\"content\":\"继续处理这个问题\",\"attachment_urls\":[]}", "timestamp": 0 }
+//	@Description	{ "type": "user-input", "data": "{\"content\":\"57un57ut5aSE55CG6L+Z5Liq6Zeu6aKY\",\"attachment_urls\":[]}", "timestamp": 0 }
 //	@Description	```
 //	@Description	`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。
 //	@Description	type 字段说明：
@@ -478,13 +478,13 @@ func buildTaskStreamsFromLogEntries(entries []tasklog.Entry, logger *slog.Logger
 
 func parseUserInputData(data []byte) domain.ContinueTaskReq {
 	var payload domain.TaskUserInputPayload
-	if err := json.Unmarshal(data, &payload); err == nil && strings.TrimSpace(payload.Content) != "" {
+	if err := json.Unmarshal(data, &payload); err == nil && strings.TrimSpace(string(payload.Content)) != "" {
 		return domain.ContinueTaskReq{
 			Content:        payload.Content,
 			AttachmentURLs: payload.AttachmentURLs,
 		}
 	}
-	return domain.ContinueTaskReq{Content: string(data)}
+	return domain.ContinueTaskReq{Content: data}
 }
 
 func normalizeUserInputData(data []byte) []byte {
@@ -720,7 +720,7 @@ func (h *TaskHandler) writeCursor(wsConn *ws.WebsocketManager, cursor string, ha
 //	@Summary		查询任务历史轮次
 //	@Description	根据 cursor 向前翻页查询任务的历史轮次。limit 为轮次数（非条目数），
 //	@Description	limit=2 表示返回 2 轮的完整消息。返回的 chunks 按时间倒序排列（最新在前）。
-//	@Description	返回的 user-input.data 统一为 JSON payload 字符串，例如 `{"content":"继续处理","attachment_urls":[]}`；旧历史裸文本也会按该结构包装返回。
+//	@Description	返回的 user-input.data 统一为 JSON payload 字符串，例如 `{"content":"57un57ut5aSE55CG","attachment_urls":[]}`；content 为用户输入文本的 base64 编码，旧历史裸文本也会按该结构包装返回。
 //	@Tags			【用户】任务管理
 //	@Accept			json
 //	@Produce		json

--- a/backend/biz/task/handler/v1/task.go
+++ b/backend/biz/task/handler/v1/task.go
@@ -464,7 +464,7 @@ func buildTaskStreamsFromLogEntries(entries []tasklog.Entry, logger *slog.Logger
 	for _, entry := range entries {
 		streams = append(streams, domain.TaskStream{
 			Type:      consts.TaskStreamType(entry.Event),
-			Data:      []byte(entry.Data),
+			Data:      normalizeTaskStreamData(entry.Event, []byte(entry.Data)),
 			Kind:      entry.Kind,
 			Timestamp: entry.TS.UnixMilli(),
 		})
@@ -474,6 +474,37 @@ func buildTaskStreamsFromLogEntries(entries []tasklog.Entry, logger *slog.Logger
 	}
 
 	return streams, ended
+}
+
+func parseUserInputData(data []byte) domain.ContinueTaskReq {
+	var payload domain.TaskUserInputPayload
+	if err := json.Unmarshal(data, &payload); err == nil && strings.TrimSpace(payload.Content) != "" {
+		return domain.ContinueTaskReq{
+			Content:        payload.Content,
+			AttachmentURLs: payload.AttachmentURLs,
+		}
+	}
+	return domain.ContinueTaskReq{Content: string(data)}
+}
+
+func normalizeUserInputData(data []byte) []byte {
+	req := parseUserInputData(data)
+	payload := domain.TaskUserInputPayload{
+		Content:        req.Content,
+		AttachmentURLs: req.AttachmentURLs,
+	}
+	if payload.AttachmentURLs == nil {
+		payload.AttachmentURLs = []string{}
+	}
+	out, _ := json.Marshal(payload)
+	return out
+}
+
+func normalizeTaskStreamData(event string, data []byte) []byte {
+	if event == string(consts.TaskStreamTypeUserInput) {
+		return normalizeUserInputData(data)
+	}
+	return data
 }
 
 func (h *TaskHandler) replayLatestTurnHistory(wsConn *ws.WebsocketManager, entries []tasklog.Entry) (bool, error) {
@@ -504,7 +535,7 @@ func (h *TaskHandler) consumeLiveStream(ctx context.Context, cancel context.Canc
 			}
 			if err := wsConn.WriteJSON(domain.TaskStream{
 				Type:      consts.TaskStreamType(chunk.Event),
-				Data:      chunk.Data,
+				Data:      normalizeTaskStreamData(chunk.Event, chunk.Data),
 				Kind:      chunk.Kind,
 				Timestamp: chunk.Timestamp / 1e6,
 			}); err != nil {
@@ -522,7 +553,7 @@ func (h *TaskHandler) subscribeRealtimeStream(ctx context.Context, cancel contex
 	err := h.taskflow.TaskLive(ctx, taskID, false, func(chunk *taskflow.TaskChunk) error {
 		if err := wsConn.WriteJSON(domain.TaskStream{
 			Type:      consts.TaskStreamType(chunk.Event),
-			Data:      chunk.Data,
+			Data:      normalizeTaskStreamData(chunk.Event, chunk.Data),
 			Kind:      chunk.Kind,
 			Timestamp: chunk.Timestamp / 1e6,
 		}); err != nil {
@@ -574,7 +605,7 @@ func (h *TaskHandler) readClientMessages(ctx context.Context, wsConn *ws.Websock
 
 			if err := wsConn.WriteJSON(domain.TaskStream{
 				Type:      consts.TaskStreamTypeUserInput,
-				Data:      m.Data,
+				Data:      normalizeTaskStreamData(string(m.Type), m.Data),
 				Kind:      m.Kind,
 				Timestamp: time.Now().UnixMilli(),
 			}); err != nil {
@@ -595,7 +626,7 @@ func (h *TaskHandler) handleClientMessage(ctx context.Context, logger *slog.Logg
 
 	switch m.Type {
 	case consts.TaskStreamTypeUserInput:
-		if err := h.usecase.Continue(ctx, user, task.ID, string(m.Data)); err != nil {
+		if err := h.usecase.Continue(ctx, user, task.ID, parseUserInputData(m.Data)); err != nil {
 			logger.With("error", err).WarnContext(ctx, "failed to push task content")
 		}
 		if err := h.usecase.IncrUserInputCount(ctx, user.ID, task.ID); err != nil {
@@ -721,7 +752,7 @@ func (h *TaskHandler) TaskTurns(c *web.Context, req domain.TaskRoundsReq) error 
 	chunks := make([]*domain.TaskChunkEntry, 0, len(result.Chunks)+1)
 	for _, c := range result.Chunks {
 		chunks = append(chunks, &domain.TaskChunkEntry{
-			Data:      c.Data,
+			Data:      normalizeTaskStreamData(c.Event, c.Data),
 			Event:     c.Event,
 			Kind:      c.Kind,
 			Timestamp: c.Timestamp,
@@ -731,7 +762,7 @@ func (h *TaskHandler) TaskTurns(c *web.Context, req domain.TaskRoundsReq) error 
 
 	// 兼容逻辑：当拉到最老的数据且第一条不是 user-input 时，从 db content 补充
 	if !result.HasMore && len(chunks) > 0 && chunks[0].Event != "user-input" {
-		contentData, _ := json.Marshal(task.Content)
+		contentData := normalizeUserInputData([]byte(task.Content))
 		chunks = append([]*domain.TaskChunkEntry{{
 			Data:      contentData,
 			Event:     "user-input",

--- a/backend/biz/task/handler/v1/task_attach_test.go
+++ b/backend/biz/task/handler/v1/task_attach_test.go
@@ -44,3 +44,17 @@ func TestBuildTaskStreamsFromLogEntriesKeepsStreamingWhenNotEnded(t *testing.T) 
 		t.Fatalf("len(streams) = %d, want 2", len(streams))
 	}
 }
+
+func TestNormalizeUserInputDataWrapsLegacyText(t *testing.T) {
+	got := normalizeUserInputData([]byte("旧输入"))
+	if string(got) != `{"content":"旧输入","attachment_urls":[]}` {
+		t.Fatalf("normalized = %s", got)
+	}
+}
+
+func TestNormalizeUserInputDataKeepsPayloadShape(t *testing.T) {
+	got := normalizeUserInputData([]byte(`{"content":"新输入","attachment_urls":["https://oss.example.com/temp/a.txt"]}`))
+	if string(got) != `{"content":"新输入","attachment_urls":["https://oss.example.com/temp/a.txt"]}` {
+		t.Fatalf("normalized = %s", got)
+	}
+}

--- a/backend/biz/task/handler/v1/task_attach_test.go
+++ b/backend/biz/task/handler/v1/task_attach_test.go
@@ -47,14 +47,14 @@ func TestBuildTaskStreamsFromLogEntriesKeepsStreamingWhenNotEnded(t *testing.T) 
 
 func TestNormalizeUserInputDataWrapsLegacyText(t *testing.T) {
 	got := normalizeUserInputData([]byte("旧输入"))
-	if string(got) != `{"content":"旧输入","attachment_urls":[]}` {
+	if string(got) != `{"content":"5pen6L6T5YWl","attachment_urls":[]}` {
 		t.Fatalf("normalized = %s", got)
 	}
 }
 
 func TestNormalizeUserInputDataKeepsPayloadShape(t *testing.T) {
-	got := normalizeUserInputData([]byte(`{"content":"新输入","attachment_urls":["https://oss.example.com/temp/a.txt"]}`))
-	if string(got) != `{"content":"新输入","attachment_urls":["https://oss.example.com/temp/a.txt"]}` {
+	got := normalizeUserInputData([]byte(`{"content":"5paw6L6T5YWl","attachment_urls":["https://oss.example.com/temp/a.txt"]}`))
+	if string(got) != `{"content":"5paw6L6T5YWl","attachment_urls":["https://oss.example.com/temp/a.txt"]}` {
 		t.Fatalf("normalized = %s", got)
 	}
 }

--- a/backend/biz/task/handler/v1/task_attach_test.go
+++ b/backend/biz/task/handler/v1/task_attach_test.go
@@ -47,14 +47,14 @@ func TestBuildTaskStreamsFromLogEntriesKeepsStreamingWhenNotEnded(t *testing.T) 
 
 func TestNormalizeUserInputDataWrapsLegacyText(t *testing.T) {
 	got := normalizeUserInputData([]byte("旧输入"))
-	if string(got) != `{"content":"5pen6L6T5YWl","attachment_urls":[]}` {
+	if string(got) != `{"content":"5pen6L6T5YWl","attachments":[]}` {
 		t.Fatalf("normalized = %s", got)
 	}
 }
 
 func TestNormalizeUserInputDataKeepsPayloadShape(t *testing.T) {
-	got := normalizeUserInputData([]byte(`{"content":"5paw6L6T5YWl","attachment_urls":["https://oss.example.com/temp/a.txt"]}`))
-	if string(got) != `{"content":"5paw6L6T5YWl","attachment_urls":["https://oss.example.com/temp/a.txt"]}` {
+	got := normalizeUserInputData([]byte(`{"content":"5paw6L6T5YWl","attachments":[{"url":"https://oss.example.com/temp/a.txt","filename":"a.txt"}]}`))
+	if string(got) != `{"content":"5paw6L6T5YWl","attachments":[{"url":"https://oss.example.com/temp/a.txt","filename":"a.txt"}]}` {
 		t.Fatalf("normalized = %s", got)
 	}
 }

--- a/backend/biz/task/service/tasksummary.go
+++ b/backend/biz/task/service/tasksummary.go
@@ -364,7 +364,18 @@ func buildSummaryConversation(ctx context.Context, logger *slog.Logger, taskID u
 		}
 
 		switch chunk.Event {
-		case "user-input", "reply-question":
+		case "user-input":
+			userInputText := userInputContent(decoded)
+
+			if len(agentMsg) > 0 {
+				agentContent := strings.Join(agentMsg, "")
+				messages = append(messages, llm.Message{Role: "assistant", Content: agentContent})
+				agentMsg = []string{}
+			}
+
+			messages = append(messages, llm.Message{Role: "user", Content: userInputText})
+
+		case "reply-question":
 			var userInputText string
 			var ur userReply
 			if err := json.Unmarshal(decoded, &ur); err != nil {
@@ -405,6 +416,14 @@ func buildSummaryConversation(ctx context.Context, logger *slog.Logger, taskID u
 		logger.DebugContext(ctx, "conversation", "task_id", taskID, "messages_count", len(messages), "messages", messages)
 	}
 	return messages, nil
+}
+
+func userInputContent(decoded []byte) string {
+	var payload userInputPayload
+	if err := json.Unmarshal(decoded, &payload); err == nil && payload.Content != "" {
+		return payload.Content
+	}
+	return string(decoded)
 }
 
 func normalizeSummaryLogStore(store *consts.LogStore) consts.LogStore {

--- a/backend/biz/task/service/tasksummary.go
+++ b/backend/biz/task/service/tasksummary.go
@@ -420,8 +420,8 @@ func buildSummaryConversation(ctx context.Context, logger *slog.Logger, taskID u
 
 func userInputContent(decoded []byte) string {
 	var payload userInputPayload
-	if err := json.Unmarshal(decoded, &payload); err == nil && payload.Content != "" {
-		return payload.Content
+	if err := json.Unmarshal(decoded, &payload); err == nil && len(payload.Content) > 0 {
+		return string(payload.Content)
 	}
 	return string(decoded)
 }

--- a/backend/biz/task/service/tasksummary_test.go
+++ b/backend/biz/task/service/tasksummary_test.go
@@ -76,7 +76,7 @@ func TestNormalizeSummaryLogStoreEmptyMeansLoki(t *testing.T) {
 
 func TestBuildSummaryConversationUsesUserInputPayloadContent(t *testing.T) {
 	taskID := uuid.New()
-	payload := []byte(`{"content":"6K+357un57ut5a6e546w","attachment_urls":["https://oss.example.com/temp/a.txt"]}`)
+	payload := []byte(`{"content":"6K+357un57ut5a6e546w","attachments":[{"url":"https://oss.example.com/temp/a.txt","filename":"a.txt"}]}`)
 	messages, err := buildSummaryConversation(
 		context.Background(),
 		slog.New(slog.NewTextHandler(io.Discard, nil)),

--- a/backend/biz/task/service/tasksummary_test.go
+++ b/backend/biz/task/service/tasksummary_test.go
@@ -74,6 +74,26 @@ func TestNormalizeSummaryLogStoreEmptyMeansLoki(t *testing.T) {
 	}
 }
 
+func TestBuildSummaryConversationUsesUserInputPayloadContent(t *testing.T) {
+	taskID := uuid.New()
+	payload := []byte(`{"content":"请继续实现","attachment_urls":["https://oss.example.com/temp/a.txt"]}`)
+	messages, err := buildSummaryConversation(
+		context.Background(),
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		taskID,
+		[]*tasklog.TurnChunk{{Event: "user-input", Data: []byte(base64.StdEncoding.EncodeToString(payload)), Timestamp: 1}},
+		1,
+		3,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("buildSummaryConversation() error = %v", err)
+	}
+	if len(messages) != 1 || messages[0].Content != "请继续实现" {
+		t.Fatalf("messages = %#v", messages)
+	}
+}
+
 func TestTasklogConversationReaderStopsWhenMaxRoundsReached(t *testing.T) {
 	runningData := mustJSON(t, wsData{Update: wsUpdate{SessionUpdate: "agent_message_chunk", Content: wsContent{Text: "助手回复"}}})
 	gateway := &fakeTasklogGateway{responses: []*tasklog.QueryTurnsResp{

--- a/backend/biz/task/service/tasksummary_test.go
+++ b/backend/biz/task/service/tasksummary_test.go
@@ -76,7 +76,7 @@ func TestNormalizeSummaryLogStoreEmptyMeansLoki(t *testing.T) {
 
 func TestBuildSummaryConversationUsesUserInputPayloadContent(t *testing.T) {
 	taskID := uuid.New()
-	payload := []byte(`{"content":"请继续实现","attachment_urls":["https://oss.example.com/temp/a.txt"]}`)
+	payload := []byte(`{"content":"6K+357un57ut5a6e546w","attachment_urls":["https://oss.example.com/temp/a.txt"]}`)
 	messages, err := buildSummaryConversation(
 		context.Background(),
 		slog.New(slog.NewTextHandler(io.Discard, nil)),

--- a/backend/biz/task/service/types.go
+++ b/backend/biz/task/service/types.go
@@ -12,8 +12,13 @@ type userReply struct {
 }
 
 type userInputPayload struct {
-	Content        []byte   `json:"content"`
-	AttachmentURLs []string `json:"attachment_urls"`
+	Content     []byte           `json:"content"`
+	Attachments []taskAttachment `json:"attachments"`
+}
+
+type taskAttachment struct {
+	URL      string `json:"url"`
+	Filename string `json:"filename"`
 }
 
 // agentMsgChunk agent 消息块

--- a/backend/biz/task/service/types.go
+++ b/backend/biz/task/service/types.go
@@ -12,7 +12,7 @@ type userReply struct {
 }
 
 type userInputPayload struct {
-	Content        string   `json:"content"`
+	Content        []byte   `json:"content"`
 	AttachmentURLs []string `json:"attachment_urls"`
 }
 

--- a/backend/biz/task/service/types.go
+++ b/backend/biz/task/service/types.go
@@ -11,6 +11,11 @@ type userReply struct {
 	AnswersJSON string `json:"answers_json"`
 }
 
+type userInputPayload struct {
+	Content        string   `json:"content"`
+	AttachmentURLs []string `json:"attachment_urls"`
+}
+
 // agentMsgChunk agent 消息块
 type agentMsgChunk struct {
 	Content wsContent `json:"content"`

--- a/backend/biz/task/usecase/attachment.go
+++ b/backend/biz/task/usecase/attachment.go
@@ -1,0 +1,48 @@
+package usecase
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/errcode"
+)
+
+const maxAttachmentURLs = 10
+
+func validateAttachmentURLs(urls []string, cfg config.Attachment) error {
+	if len(urls) == 0 {
+		return nil
+	}
+	if len(urls) > maxAttachmentURLs {
+		return errcode.ErrBadRequest.Wrap(fmt.Errorf("attachment_urls exceeds limit %d", maxAttachmentURLs))
+	}
+	for _, raw := range urls {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			return errcode.ErrBadRequest.Wrap(fmt.Errorf("attachment url is empty"))
+		}
+		u, err := url.Parse(raw)
+		if err != nil || u.Host == "" {
+			return errcode.ErrBadRequest.Wrap(fmt.Errorf("invalid attachment url: %q", raw))
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return errcode.ErrBadRequest.Wrap(fmt.Errorf("unsupported attachment url scheme: %q", u.Scheme))
+		}
+		if !matchAllowedAttachmentPrefix(raw, cfg.AllowedURLPrefixes) {
+			return errcode.ErrBadRequest.Wrap(fmt.Errorf("attachment url is not allowed"))
+		}
+	}
+	return nil
+}
+
+func matchAllowedAttachmentPrefix(raw string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		prefix = strings.TrimSpace(prefix)
+		if prefix != "" && strings.HasPrefix(raw, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/biz/task/usecase/attachment.go
+++ b/backend/biz/task/usecase/attachment.go
@@ -6,22 +6,27 @@ import (
 	"strings"
 
 	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/errcode"
+	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
 )
 
-const maxAttachmentURLs = 10
+const maxAttachments = 10
 
-func validateAttachmentURLs(urls []string, cfg config.Attachment) error {
-	if len(urls) == 0 {
+func validateAttachments(attachments []domain.TaskAttachment, cfg config.Attachment) error {
+	if len(attachments) == 0 {
 		return nil
 	}
-	if len(urls) > maxAttachmentURLs {
-		return errcode.ErrBadRequest.Wrap(fmt.Errorf("attachment_urls exceeds limit %d", maxAttachmentURLs))
+	if len(attachments) > maxAttachments {
+		return errcode.ErrBadRequest.Wrap(fmt.Errorf("attachments exceeds limit %d", maxAttachments))
 	}
-	for _, raw := range urls {
-		raw = strings.TrimSpace(raw)
+	for _, attachment := range attachments {
+		raw := strings.TrimSpace(attachment.URL)
 		if raw == "" {
 			return errcode.ErrBadRequest.Wrap(fmt.Errorf("attachment url is empty"))
+		}
+		if strings.TrimSpace(attachment.Filename) == "" {
+			return errcode.ErrBadRequest.Wrap(fmt.Errorf("attachment filename is empty"))
 		}
 		u, err := url.Parse(raw)
 		if err != nil || u.Host == "" {
@@ -45,4 +50,18 @@ func matchAllowedAttachmentPrefix(raw string, prefixes []string) bool {
 		}
 	}
 	return false
+}
+
+func taskAttachmentsToTaskflow(attachments []domain.TaskAttachment) []taskflow.Attachment {
+	if len(attachments) == 0 {
+		return nil
+	}
+	out := make([]taskflow.Attachment, 0, len(attachments))
+	for _, attachment := range attachments {
+		out = append(out, taskflow.Attachment{
+			URL:      attachment.URL,
+			Filename: attachment.Filename,
+		})
+	}
+	return out
 }

--- a/backend/biz/task/usecase/attachment_test.go
+++ b/backend/biz/task/usecase/attachment_test.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"testing"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+)
+
+func TestValidateAttachmentURLsAllowsEmpty(t *testing.T) {
+	cfg := config.Attachment{AllowedURLPrefixes: []string{"https://oss.example.com/temp/"}}
+	if err := validateAttachmentURLs(nil, cfg); err != nil {
+		t.Fatalf("validateAttachmentURLs(nil) error = %v", err)
+	}
+	if err := validateAttachmentURLs([]string{}, cfg); err != nil {
+		t.Fatalf("validateAttachmentURLs(empty) error = %v", err)
+	}
+}
+
+func TestValidateAttachmentURLsAllowsConfiguredPrefix(t *testing.T) {
+	cfg := config.Attachment{AllowedURLPrefixes: []string{"https://oss.example.com/temp/"}}
+	err := validateAttachmentURLs([]string{"https://oss.example.com/temp/a.txt"}, cfg)
+	if err != nil {
+		t.Fatalf("validateAttachmentURLs() error = %v", err)
+	}
+}
+
+func TestValidateAttachmentURLsRejectsBadInputs(t *testing.T) {
+	cfg := config.Attachment{AllowedURLPrefixes: []string{"https://oss.example.com/temp/"}}
+	cases := [][]string{
+		{""},
+		{"ftp://oss.example.com/temp/a.txt"},
+		{"https://evil.example.com/temp/a.txt"},
+		{
+			"https://oss.example.com/temp/1",
+			"https://oss.example.com/temp/2",
+			"https://oss.example.com/temp/3",
+			"https://oss.example.com/temp/4",
+			"https://oss.example.com/temp/5",
+			"https://oss.example.com/temp/6",
+			"https://oss.example.com/temp/7",
+			"https://oss.example.com/temp/8",
+			"https://oss.example.com/temp/9",
+			"https://oss.example.com/temp/10",
+			"https://oss.example.com/temp/11",
+		},
+	}
+
+	for _, urls := range cases {
+		if err := validateAttachmentURLs(urls, cfg); err == nil {
+			t.Fatalf("validateAttachmentURLs(%#v) error = nil, want error", urls)
+		}
+	}
+}

--- a/backend/biz/task/usecase/attachment_test.go
+++ b/backend/biz/task/usecase/attachment_test.go
@@ -4,50 +4,52 @@ import (
 	"testing"
 
 	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/domain"
 )
 
-func TestValidateAttachmentURLsAllowsEmpty(t *testing.T) {
+func TestValidateAttachmentsAllowsEmpty(t *testing.T) {
 	cfg := config.Attachment{AllowedURLPrefixes: []string{"https://oss.example.com/temp/"}}
-	if err := validateAttachmentURLs(nil, cfg); err != nil {
-		t.Fatalf("validateAttachmentURLs(nil) error = %v", err)
+	if err := validateAttachments(nil, cfg); err != nil {
+		t.Fatalf("validateAttachments(nil) error = %v", err)
 	}
-	if err := validateAttachmentURLs([]string{}, cfg); err != nil {
-		t.Fatalf("validateAttachmentURLs(empty) error = %v", err)
+	if err := validateAttachments([]domain.TaskAttachment{}, cfg); err != nil {
+		t.Fatalf("validateAttachments(empty) error = %v", err)
 	}
 }
 
-func TestValidateAttachmentURLsAllowsConfiguredPrefix(t *testing.T) {
+func TestValidateAttachmentsAllowsConfiguredPrefix(t *testing.T) {
 	cfg := config.Attachment{AllowedURLPrefixes: []string{"https://oss.example.com/temp/"}}
-	err := validateAttachmentURLs([]string{"https://oss.example.com/temp/a.txt"}, cfg)
+	err := validateAttachments([]domain.TaskAttachment{{URL: "https://oss.example.com/temp/a.txt", Filename: "a.txt"}}, cfg)
 	if err != nil {
-		t.Fatalf("validateAttachmentURLs() error = %v", err)
+		t.Fatalf("validateAttachments() error = %v", err)
 	}
 }
 
-func TestValidateAttachmentURLsRejectsBadInputs(t *testing.T) {
+func TestValidateAttachmentsRejectsBadInputs(t *testing.T) {
 	cfg := config.Attachment{AllowedURLPrefixes: []string{"https://oss.example.com/temp/"}}
-	cases := [][]string{
-		{""},
-		{"ftp://oss.example.com/temp/a.txt"},
-		{"https://evil.example.com/temp/a.txt"},
+	cases := [][]domain.TaskAttachment{
+		{{URL: "", Filename: "a.txt"}},
+		{{URL: "https://oss.example.com/temp/a.txt", Filename: ""}},
+		{{URL: "ftp://oss.example.com/temp/a.txt", Filename: "a.txt"}},
+		{{URL: "https://evil.example.com/temp/a.txt", Filename: "a.txt"}},
 		{
-			"https://oss.example.com/temp/1",
-			"https://oss.example.com/temp/2",
-			"https://oss.example.com/temp/3",
-			"https://oss.example.com/temp/4",
-			"https://oss.example.com/temp/5",
-			"https://oss.example.com/temp/6",
-			"https://oss.example.com/temp/7",
-			"https://oss.example.com/temp/8",
-			"https://oss.example.com/temp/9",
-			"https://oss.example.com/temp/10",
-			"https://oss.example.com/temp/11",
+			{URL: "https://oss.example.com/temp/1", Filename: "1"},
+			{URL: "https://oss.example.com/temp/2", Filename: "2"},
+			{URL: "https://oss.example.com/temp/3", Filename: "3"},
+			{URL: "https://oss.example.com/temp/4", Filename: "4"},
+			{URL: "https://oss.example.com/temp/5", Filename: "5"},
+			{URL: "https://oss.example.com/temp/6", Filename: "6"},
+			{URL: "https://oss.example.com/temp/7", Filename: "7"},
+			{URL: "https://oss.example.com/temp/8", Filename: "8"},
+			{URL: "https://oss.example.com/temp/9", Filename: "9"},
+			{URL: "https://oss.example.com/temp/10", Filename: "10"},
+			{URL: "https://oss.example.com/temp/11", Filename: "11"},
 		},
 	}
 
-	for _, urls := range cases {
-		if err := validateAttachmentURLs(urls, cfg); err == nil {
-			t.Fatalf("validateAttachmentURLs(%#v) error = nil, want error", urls)
+	for _, attachments := range cases {
+		if err := validateAttachments(attachments, cfg); err == nil {
+			t.Fatalf("validateAttachments(%#v) error = nil, want error", attachments)
 		}
 	}
 }

--- a/backend/biz/task/usecase/task.go
+++ b/backend/biz/task/usecase/task.go
@@ -352,7 +352,13 @@ func (a *TaskUsecase) Cancel(ctx context.Context, user *domain.User, id uuid.UUI
 }
 
 // Continue implements domain.TaskUsecase.
-func (a *TaskUsecase) Continue(ctx context.Context, user *domain.User, id uuid.UUID, content string) error {
+func (a *TaskUsecase) Continue(ctx context.Context, user *domain.User, id uuid.UUID, req domain.ContinueTaskReq) error {
+	if strings.TrimSpace(req.Content) == "" {
+		return errcode.ErrBadRequest
+	}
+	if err := validateAttachmentURLs(req.AttachmentURLs, a.cfg.Attachment); err != nil {
+		return err
+	}
 	t, err := a.repo.Info(ctx, user, id, false)
 	if err != nil {
 		return err
@@ -365,16 +371,17 @@ func (a *TaskUsecase) Continue(ctx context.Context, user *domain.User, id uuid.U
 			EnvironmentID: tk.VirtualMachine.EnvironmentID,
 		},
 		Task: &taskflow.Task{
-			ID:       id,
-			Text:     content,
-			LogStore: string(tk.LogStore),
+			ID:             id,
+			Text:           req.Content,
+			AttachmentURLs: req.AttachmentURLs,
+			LogStore:       string(tk.LogStore),
 		},
 	}); err != nil {
 		return err
 	}
 
 	// 缓存最近一次 user-input，供通知推送使用
-	a.redis.Set(ctx, fmt.Sprintf("mcai:task:%s:last_input", id.String()), content, 24*time.Hour)
+	a.redis.Set(ctx, fmt.Sprintf("mcai:task:%s:last_input", id.String()), req.Content, 24*time.Hour)
 
 	return nil
 }
@@ -398,6 +405,10 @@ func (a *TaskUsecase) IncrUserInputCount(ctx context.Context, userID, taskID uui
 
 // Create implements domain.TaskUsecase.
 func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.CreateTaskReq) (*domain.ProjectTask, error) {
+	if err := validateAttachmentURLs(req.AttachmentURLs, a.cfg.Attachment); err != nil {
+		return nil, err
+	}
+
 	r, err := a.taskflow.Host().IsOnline(ctx, &taskflow.IsOnlineReq[string]{
 		IDs: []string{req.HostID},
 	})
@@ -535,11 +546,12 @@ func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.
 
 		// 存储 CreateTaskReq 到 Redis（10 分钟过期），供 Lifecycle Manager 消费
 		createTaskReq := &taskflow.CreateTaskReq{
-			ID:           t.ID,
-			VMID:         vm.ID,
-			Text:         req.Content,
-			SystemPrompt: req.SystemPrompt,
-			CodingAgent:  coding,
+			ID:             t.ID,
+			VMID:           vm.ID,
+			Text:           req.Content,
+			AttachmentURLs: req.AttachmentURLs,
+			SystemPrompt:   req.SystemPrompt,
+			CodingAgent:    coding,
 			LLM: taskflow.LLM{
 				ApiKey:  m.APIKey,
 				BaseURL: m.BaseURL,

--- a/backend/biz/task/usecase/task.go
+++ b/backend/biz/task/usecase/task.go
@@ -356,7 +356,7 @@ func (a *TaskUsecase) Continue(ctx context.Context, user *domain.User, id uuid.U
 	if strings.TrimSpace(string(req.Content)) == "" {
 		return errcode.ErrBadRequest
 	}
-	if err := validateAttachmentURLs(req.AttachmentURLs, a.cfg.Attachment); err != nil {
+	if err := validateAttachments(req.Attachments, a.cfg.Attachment); err != nil {
 		return err
 	}
 	t, err := a.repo.Info(ctx, user, id, false)
@@ -371,10 +371,10 @@ func (a *TaskUsecase) Continue(ctx context.Context, user *domain.User, id uuid.U
 			EnvironmentID: tk.VirtualMachine.EnvironmentID,
 		},
 		Task: &taskflow.Task{
-			ID:             id,
-			Text:           string(req.Content),
-			AttachmentURLs: req.AttachmentURLs,
-			LogStore:       string(tk.LogStore),
+			ID:          id,
+			Text:        string(req.Content),
+			Attachments: taskAttachmentsToTaskflow(req.Attachments),
+			LogStore:    string(tk.LogStore),
 		},
 	}); err != nil {
 		return err
@@ -405,7 +405,7 @@ func (a *TaskUsecase) IncrUserInputCount(ctx context.Context, userID, taskID uui
 
 // Create implements domain.TaskUsecase.
 func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.CreateTaskReq) (*domain.ProjectTask, error) {
-	if err := validateAttachmentURLs(req.AttachmentURLs, a.cfg.Attachment); err != nil {
+	if err := validateAttachments(req.Attachments, a.cfg.Attachment); err != nil {
 		return nil, err
 	}
 
@@ -546,12 +546,12 @@ func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.
 
 		// 存储 CreateTaskReq 到 Redis（10 分钟过期），供 Lifecycle Manager 消费
 		createTaskReq := &taskflow.CreateTaskReq{
-			ID:             t.ID,
-			VMID:           vm.ID,
-			Text:           req.Content,
-			AttachmentURLs: req.AttachmentURLs,
-			SystemPrompt:   req.SystemPrompt,
-			CodingAgent:    coding,
+			ID:           t.ID,
+			VMID:         vm.ID,
+			Text:         req.Content,
+			Attachments:  taskAttachmentsToTaskflow(req.Attachments),
+			SystemPrompt: req.SystemPrompt,
+			CodingAgent:  coding,
 			LLM: taskflow.LLM{
 				ApiKey:  m.APIKey,
 				BaseURL: m.BaseURL,

--- a/backend/biz/task/usecase/task.go
+++ b/backend/biz/task/usecase/task.go
@@ -353,7 +353,7 @@ func (a *TaskUsecase) Cancel(ctx context.Context, user *domain.User, id uuid.UUI
 
 // Continue implements domain.TaskUsecase.
 func (a *TaskUsecase) Continue(ctx context.Context, user *domain.User, id uuid.UUID, req domain.ContinueTaskReq) error {
-	if strings.TrimSpace(req.Content) == "" {
+	if strings.TrimSpace(string(req.Content)) == "" {
 		return errcode.ErrBadRequest
 	}
 	if err := validateAttachmentURLs(req.AttachmentURLs, a.cfg.Attachment); err != nil {
@@ -372,7 +372,7 @@ func (a *TaskUsecase) Continue(ctx context.Context, user *domain.User, id uuid.U
 		},
 		Task: &taskflow.Task{
 			ID:             id,
-			Text:           req.Content,
+			Text:           string(req.Content),
 			AttachmentURLs: req.AttachmentURLs,
 			LogStore:       string(tk.LogStore),
 		},
@@ -381,7 +381,7 @@ func (a *TaskUsecase) Continue(ctx context.Context, user *domain.User, id uuid.U
 	}
 
 	// 缓存最近一次 user-input，供通知推送使用
-	a.redis.Set(ctx, fmt.Sprintf("mcai:task:%s:last_input", id.String()), req.Content, 24*time.Hour)
+	a.redis.Set(ctx, fmt.Sprintf("mcai:task:%s:last_input", id.String()), string(req.Content), 24*time.Hour)
 
 	return nil
 }

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	LLM         LLM         `mapstructure:"llm"`
 	Notify      Notify      `mapstructure:"notify"`
 	VMIdle      VMIdle      `mapstructure:"vm_idle"`
+	Attachment  Attachment  `mapstructure:"attachment"`
 
 	// Context7 API 配置
 	Context7ApiKey string `mapstructure:"context7_api_key"`
@@ -98,6 +99,10 @@ type MCPHub struct {
 type PublicHost struct {
 	CountLimit int   `mapstructure:"count_limit"` // 每用户公共主机 VM 数量限制，0 表示不限制
 	TTLLimit   int64 `mapstructure:"ttl_limit"`   // 公共主机 VM 续期上限（秒），0 表示不限制
+}
+
+type Attachment struct {
+	AllowedURLPrefixes []string `mapstructure:"allowed_url_prefixes"`
 }
 
 // Task 任务相关配置
@@ -228,6 +233,7 @@ func Init(dir string) (*Config, error) {
 	v.SetDefault("mcp_hub.enabled", false)
 	v.SetDefault("mcp_hub.url", "")
 	v.SetDefault("mcp_hub.token", "")
+	v.SetDefault("attachment.allowed_url_prefixes", []string{})
 
 	v.SetConfigType("yaml")
 	v.AddConfigPath(dir)

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -6531,6 +6531,60 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "MonkeyCodeAIAuth": []
+                    }
+                ],
+                "description": "删除问题",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "【用户】项目管理"
+                ],
+                "summary": "删除问题",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "项目ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "问题ID",
+                        "name": "issue_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "成功",
+                        "schema": {
+                            "$ref": "#/definitions/web.Resp"
+                        }
+                    },
+                    "401": {
+                        "description": "未授权",
+                        "schema": {
+                            "$ref": "#/definitions/web.Resp"
+                        }
+                    },
+                    "500": {
+                        "description": "服务器内部错误",
+                        "schema": {
+                            "$ref": "#/definitions/web.Resp"
+                        }
+                    }
+                }
             }
         },
         "/api/v1/users/projects/{id}/issues/{issue_id}/comments": {
@@ -7116,7 +7170,7 @@
                         "MonkeyCodeAIAuth": []
                     }
                 ],
-                "description": "创建任务",
+                "description": "创建任务\n`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。创建任务后，首轮 user-input 日志会按 `{ \"content\": \"...\", \"attachment_urls\": [] }` 结构返回。",
                 "consumes": [
                     "application/json"
                 ],
@@ -7173,7 +7227,7 @@
                         "MonkeyCodeAIAuth": []
                     }
                 ],
-                "description": "数据格式约定：当前仅支持文本帧透传。服务端将 Agent 的原始文本数据包装为如下结构返回给前端（对应 domain.TaskStream）：\n```json\n{ \"type\": \"string\", \"data\": \"string\", \"kind\": \"string\", \"timestamp\": 0 }\n```\n独立于 stream 的长生命周期 WebSocket 连接，用于处理 call/call-response（文件浏览、diff 查看等同步请求）。\ntask 结束后连接不断开，仍可用于文件操作。\n支持同一 taskID 多 tab 并发连接。\n\n## 上行消息\n\n### Type=call, Kind=repo_file_diff — 获取文件 diff\n请求 Data:\n```json\n{\"request_id\":\"string\",\"path\":\"string\",\"unified\":true,\"context_lines\":3}\n```\n响应 Data:\n```json\n{\"request_id\":\"string\",\"path\":\"string\",\"diff\":\"string\",\"success\":true,\"error\":\"string?\"}\n```\n\n### Type=call, Kind=repo_file_list — 列出目录文件\n请求 Data:\n```json\n{\"request_id\":\"string\",\"path\":\"string\",\"glob_pattern\":\"string?\",\"include_hidden\":false}\n```\n响应 Data:\n```json\n{\"request_id\":\"string\",\"path\":\"string\",\"files\":[{\"name\":\"string\",\"path\":\"string\",\"entry_mode\":0,\"size\":0,\"modified_at\":0}],\"success\":true,\"error\":\"string?\"}\n```\n\n### Type=call, Kind=repo_read_file — 读取文件内容\n请求 Data:\n```json\n{\"request_id\":\"string\",\"path\":\"string\",\"offset\":0,\"length\":0}\n```\n响应 Data:\n```json\n{\"request_id\":\"string\",\"path\":\"string\",\"content\":\"bytes\",\"total_size\":0,\"offset\":0,\"length\":0,\"is_truncated\":false,\"success\":true,\"error\":\"string?\"}\n```\n\n### Type=call, Kind=repo_file_changes — 查询变更文件列表\n请求 Data:\n```json\n{\"request_id\":\"string\"}\n```\n响应 Data:\n```json\n{\"request_id\":\"string\",\"changes\":[{\"path\":\"string\",\"status\":\"string\",\"additions\":0,\"deletions\":0,\"old_path\":\"string?\"}],\"branch\":\"string?\",\"commit_hash\":\"string?\",\"success\":true,\"error\":\"string?\"}\n```\n\n### Type=call, Kind=port_forward_list — 获取端口转发列表\n请求 Data:\n```json\n{\"request_id\":\"string\"}\n```\n响应 Data:\n```json\n{\"request_id\":\"string\",\"ports\":[{\"port\":0,\"status\":\"string\",\"process\":\"string\",\"forward_id\":\"string?\",\"access_url\":\"string?\",\"label\":\"string?\",\"error_message\":\"string?\",\"whitelist_ips\":[\"string\"]}]}\n```\n\n### Type=call, Kind=restart — 重启任务\n请求 Data:\n```json\n{\"request_id\":\"string\",\"load_session\":true}\n```\n响应 Data:\n```json\n{\"id\":\"uuid\",\"request_id\":\"string?\",\"success\":true,\"message\":\"string\",\"session_id\":\"string\"}\n```\n\n### Type=sync-my-ip — 同步 Web 客户端真实 IP\n请求 Data:\n```json\n{\"client_ip\":\"string\"}\n```\n\n## 下行消息\n\n- Type=call-response: 同步请求响应（Kind 与请求一致）。失败时 Data 为:\n```json\n{\"request_id\":\"string\",\"success\":false,\"error\":\"string\"}\n```\n- Type=task-event: 任务事件（从 TaskLive 订阅转发）\n- Type=ping: 心跳（无 Data）",
+                "description": "数据格式约定：当前仅支持文本帧透传。服务端将 Agent 的原始文本数据包装为如下结构返回给前端（对应 domain.TaskStream）：\n```json\n{ \"type\": \"string\", \"data\": \"string\", \"kind\": \"string\", \"timestamp\": 0 }\n```\n独立于 stream 的长生命周期 WebSocket 连接，用于处理 call/call-response（文件浏览、diff 查看等同步请求）。\ntask 结束后连接不断开，仍可用于文件操作。\n支持同一 taskID 多 tab 并发连接。\n\n## 上行消息\n\n### Type=call, Kind=repo_file_diff — 获取文件 diff\n请求 Data:\n```json\n{\"request_id\":\"string\",\"path\":\"string\",\"unified\":true,\"context_lines\":3}\n```\n响应 Data:\n```json\n{\"request_id\":\"string\",\"path\":\"string\",\"diff\":\"string\",\"success\":true,\"error\":\"string?\"}\n```\n\n### Type=call, Kind=repo_file_list — 列出目录文件\n请求 Data:\n```json\n{\"request_id\":\"string\",\"path\":\"string\",\"glob_pattern\":\"string?\",\"include_hidden\":false}\n```\n响应 Data:\n```json\n{\"request_id\":\"string\",\"path\":\"string\",\"files\":[{\"name\":\"string\",\"path\":\"string\",\"entry_mode\":0,\"size\":0,\"modified_at\":0}],\"success\":true,\"error\":\"string?\"}\n```\n\n### Type=call, Kind=repo_read_file — 读取文件内容\n请求 Data:\n```json\n{\"request_id\":\"string\",\"path\":\"string\",\"offset\":0,\"length\":0}\n```\n响应 Data:\n```json\n{\"request_id\":\"string\",\"path\":\"string\",\"content\":\"bytes\",\"total_size\":0,\"offset\":0,\"length\":0,\"is_truncated\":false,\"success\":true,\"error\":\"string?\"}\n```\n\n### Type=call, Kind=repo_file_changes — 查询变更文件列表\n请求 Data:\n```json\n{\"request_id\":\"string\"}\n```\n响应 Data:\n```json\n{\"request_id\":\"string\",\"changes\":[{\"path\":\"string\",\"status\":\"string\",\"additions\":0,\"deletions\":0,\"old_path\":\"string?\"}],\"branch\":\"string?\",\"commit_hash\":\"string?\",\"success\":true,\"error\":\"string?\"}\n```\n\n### Type=call, Kind=port_forward_list — 获取端口转发列表\n请求 Data:\n```json\n{\"request_id\":\"string\"}\n```\n响应 Data:\n```json\n{\"request_id\":\"string\",\"ports\":[{\"port\":0,\"status\":\"string\",\"process\":\"string\",\"forward_id\":\"string?\",\"access_url\":\"string?\",\"label\":\"string?\",\"error_message\":\"string?\",\"whitelist_ips\":[\"string\"]}]}\n```\n\n### Type=call, Kind=restart — 重启任务\n请求 Data:\n```json\n{\"request_id\":\"string\",\"load_session\":true}\n```\n响应 Data:\n```json\n{\"id\":\"uuid\",\"request_id\":\"string?\",\"success\":true,\"message\":\"string\",\"session_id\":\"string\"}\n```\n\n### Type=call, Kind=switch_model — 切换运行中任务模型\n请求 Data:\n```json\n{\"request_id\":\"string\",\"model_id\":\"uuid\",\"load_session\":true}\n```\n响应 Data:\n```json\n{\"id\":\"uuid\",\"request_id\":\"string?\",\"success\":true,\"message\":\"string\",\"session_id\":\"string\",\"model\":{}}\n```\n\n### Type=sync-my-ip — 同步 Web 客户端真实 IP\n请求 Data:\n```json\n{\"client_ip\":\"string\"}\n```\n\n## 下行消息\n\n- Type=call-response: 同步请求响应（Kind 与请求一致）。失败时 Data 为:\n```json\n{\"request_id\":\"string\",\"success\":false,\"error\":\"string\"}\n```\n- Type=task-event: 任务事件（从 TaskLive 订阅转发）\n- Type=ping: 心跳（无 Data）",
                 "consumes": [
                     "application/json"
                 ],
@@ -7259,7 +7313,7 @@
                         "MonkeyCodeAIAuth": []
                     }
                 ],
-                "description": "根据 cursor 向前翻页查询任务的历史轮次。limit 为轮次数（非条目数），\nlimit=2 表示返回 2 轮的完整消息。返回的 chunks 按时间倒序排列（最新在前）。",
+                "description": "根据 cursor 向前翻页查询任务的历史轮次。limit 为轮次数（非条目数），\nlimit=2 表示返回 2 轮的完整消息。返回的 chunks 按时间倒序排列（最新在前）。\n返回的 user-input.data 统一为 JSON payload 字符串，例如 `{\"content\":\"继续处理\",\"attachment_urls\":[]}`；旧历史裸文本也会按该结构包装返回。",
                 "consumes": [
                     "application/json"
                 ],
@@ -7405,7 +7459,7 @@
                         "MonkeyCodeAIAuth": []
                     }
                 ],
-                "description": "功能定位：该接口通过 WebSocket 仅做 Agent ↔ 前端 的数据代理与转发，不进行任何包体解析或改写。所有数据以原始格式透传并存储。\n数据格式约定：当前仅支持文本帧透传。服务端将 Agent 的原始文本数据包装为如下结构返回给前端（对应 domain.TaskStream）：\n```json\n{ \"type\": \"string\", \"data\": \"string\", \"kind\": \"string\", \"timestamp\": 0 }\n```\ntype 字段说明：\n- task-started: 本轮任务启动\n- task-ended: 本轮任务结束\n- task-error: 本轮任务发生错误\n- task-running: 任务正在运行\n- task-event: 任务临时事件, 不持久化\n- file-change: 文件变动事件\n- permission-resp: 用户的权限响应\n- auto-approve: 开启自动批准\n- disable-auto-approve: 关闭自动批准\n- user-input: 用户输入\n- user-cancel: 取消当前操作，不会终止任务\n- reply-question: 回复 AI 的提问\n- cursor: 历史游标，用于通过 /rounds 接口加载更早的轮次\n\ncursor 消息结构：\n```json\n{ \"type\": \"cursor\", \"data\": { \"cursor\": \"\u003cnextCursor\u003e\", \"has_more\": true }, \"timestamp\": 0 }\n```\n- cursor: 当前分页游标，作为 GET /rounds 接口的 cursor 参数向前翻页\n- has_more: 是否存在更早的轮次。为 false 时表示当前轮次即为第一轮，无需再翻页",
+                "description": "功能定位：该接口通过 WebSocket 转发任务运行数据。任务对话继续输入使用 `type=user-input`。\n数据格式约定：当前仅支持文本帧透传。服务端将 Agent 的原始文本数据包装为如下结构返回给前端（对应 domain.TaskStream）：\n```json\n{ \"type\": \"string\", \"data\": \"string\", \"kind\": \"string\", \"timestamp\": 0 }\n```\nuser-input 上行新格式：\n```json\n{ \"type\": \"user-input\", \"data\": \"{\\\"content\\\":\\\"继续处理这个问题\\\",\\\"attachment_urls\\\":[\\\"https://example-bucket.oss-cn-hangzhou.aliyuncs.com/temp/a.txt\\\"]}\" }\n```\nuser-input 上行旧格式仍兼容：\n```json\n{ \"type\": \"user-input\", \"data\": \"继续处理这个问题\" }\n```\nuser-input 下行和历史返回统一使用新 JSON payload 字符串：\n```json\n{ \"type\": \"user-input\", \"data\": \"{\\\"content\\\":\\\"继续处理这个问题\\\",\\\"attachment_urls\\\":[]}\", \"timestamp\": 0 }\n```\n`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。\ntype 字段说明：\n- task-started: 本轮任务启动\n- task-ended: 本轮任务结束\n- task-error: 本轮任务发生错误\n- task-running: 任务正在运行\n- task-event: 任务临时事件, 不持久化\n- file-change: 文件变动事件\n- permission-resp: 用户的权限响应\n- auto-approve: 开启自动批准\n- disable-auto-approve: 关闭自动批准\n- user-input: 用户输入\n- user-cancel: 取消当前操作，不会终止任务\n- reply-question: 回复 AI 的提问\n- cursor: 历史游标，用于通过 /rounds 接口加载更早的轮次\n\ncursor 消息结构：\n```json\n{ \"type\": \"cursor\", \"data\": { \"cursor\": \"\u003cnextCursor\u003e\", \"has_more\": true }, \"timestamp\": 0 }\n```\n- cursor: 当前分页游标，作为 GET /rounds 接口的 cursor 参数向前翻页\n- has_more: 是否存在更早的轮次。为 false 时表示当前轮次即为第一轮，无需再翻页",
                 "consumes": [
                     "application/json"
                 ],
@@ -8390,6 +8444,9 @@
                 "base_url": {
                     "type": "string"
                 },
+                "context_limit": {
+                    "type": "integer"
+                },
                 "interface_type": {
                     "enum": [
                         "openai_chat",
@@ -8408,11 +8465,17 @@
                 "model": {
                     "type": "string"
                 },
+                "output_limit": {
+                    "type": "integer"
+                },
                 "provider": {
                     "type": "string"
                 },
                 "temperature": {
                     "type": "number"
+                },
+                "thinking_enabled": {
+                    "type": "boolean"
                 }
             }
         },
@@ -8501,6 +8564,13 @@
                 "resource"
             ],
             "properties": {
+                "attachment_urls": {
+                    "description": "附件访问 URL 列表，最多 10 个；URL 必须匹配后端配置的附件白名单前缀",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "cli_name": {
                     "$ref": "#/definitions/consts.CliName"
                 },
@@ -9236,6 +9306,9 @@
                 "base_url": {
                     "type": "string"
                 },
+                "context_limit": {
+                    "type": "integer"
+                },
                 "created_at": {
                     "type": "integer"
                 },
@@ -9263,6 +9336,9 @@
                 "model": {
                     "type": "string"
                 },
+                "output_limit": {
+                    "type": "integer"
+                },
                 "owner": {
                     "$ref": "#/definitions/domain.Owner"
                 },
@@ -9271,6 +9347,9 @@
                 },
                 "temperature": {
                     "type": "number"
+                },
+                "thinking_enabled": {
+                    "type": "boolean"
                 },
                 "updated_at": {
                     "type": "integer"
@@ -10314,6 +10393,9 @@
                 "base_url": {
                     "type": "string"
                 },
+                "context_limit": {
+                    "type": "integer"
+                },
                 "interface_type": {
                     "enum": [
                         "openai_chat",
@@ -10332,11 +10414,17 @@
                 "model": {
                     "type": "string"
                 },
+                "output_limit": {
+                    "type": "integer"
+                },
                 "provider": {
                     "type": "string"
                 },
                 "temperature": {
                     "type": "number"
+                },
+                "thinking_enabled": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -7170,7 +7170,7 @@
                         "MonkeyCodeAIAuth": []
                     }
                 ],
-                "description": "创建任务\n`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。创建任务后，首轮 user-input 日志会按 `{ \"content\": \"...\", \"attachment_urls\": [] }` 结构返回。",
+                "description": "创建任务\n`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。创建任务后，首轮 user-input 日志会按 `{ \"content\": \"base64文本\", \"attachment_urls\": [] }` 结构返回。",
                 "consumes": [
                     "application/json"
                 ],
@@ -7313,7 +7313,7 @@
                         "MonkeyCodeAIAuth": []
                     }
                 ],
-                "description": "根据 cursor 向前翻页查询任务的历史轮次。limit 为轮次数（非条目数），\nlimit=2 表示返回 2 轮的完整消息。返回的 chunks 按时间倒序排列（最新在前）。\n返回的 user-input.data 统一为 JSON payload 字符串，例如 `{\"content\":\"继续处理\",\"attachment_urls\":[]}`；旧历史裸文本也会按该结构包装返回。",
+                "description": "根据 cursor 向前翻页查询任务的历史轮次。limit 为轮次数（非条目数），\nlimit=2 表示返回 2 轮的完整消息。返回的 chunks 按时间倒序排列（最新在前）。\n返回的 user-input.data 统一为 JSON payload 字符串，例如 `{\"content\":\"57un57ut5aSE55CG\",\"attachment_urls\":[]}`；content 为用户输入文本的 base64 编码，旧历史裸文本也会按该结构包装返回。",
                 "consumes": [
                     "application/json"
                 ],
@@ -7459,7 +7459,7 @@
                         "MonkeyCodeAIAuth": []
                     }
                 ],
-                "description": "功能定位：该接口通过 WebSocket 转发任务运行数据。任务对话继续输入使用 `type=user-input`。\n数据格式约定：当前仅支持文本帧透传。服务端将 Agent 的原始文本数据包装为如下结构返回给前端（对应 domain.TaskStream）：\n```json\n{ \"type\": \"string\", \"data\": \"string\", \"kind\": \"string\", \"timestamp\": 0 }\n```\nuser-input 上行新格式：\n```json\n{ \"type\": \"user-input\", \"data\": \"{\\\"content\\\":\\\"继续处理这个问题\\\",\\\"attachment_urls\\\":[\\\"https://example-bucket.oss-cn-hangzhou.aliyuncs.com/temp/a.txt\\\"]}\" }\n```\nuser-input 上行旧格式仍兼容：\n```json\n{ \"type\": \"user-input\", \"data\": \"继续处理这个问题\" }\n```\nuser-input 下行和历史返回统一使用新 JSON payload 字符串：\n```json\n{ \"type\": \"user-input\", \"data\": \"{\\\"content\\\":\\\"继续处理这个问题\\\",\\\"attachment_urls\\\":[]}\", \"timestamp\": 0 }\n```\n`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。\ntype 字段说明：\n- task-started: 本轮任务启动\n- task-ended: 本轮任务结束\n- task-error: 本轮任务发生错误\n- task-running: 任务正在运行\n- task-event: 任务临时事件, 不持久化\n- file-change: 文件变动事件\n- permission-resp: 用户的权限响应\n- auto-approve: 开启自动批准\n- disable-auto-approve: 关闭自动批准\n- user-input: 用户输入\n- user-cancel: 取消当前操作，不会终止任务\n- reply-question: 回复 AI 的提问\n- cursor: 历史游标，用于通过 /rounds 接口加载更早的轮次\n\ncursor 消息结构：\n```json\n{ \"type\": \"cursor\", \"data\": { \"cursor\": \"\u003cnextCursor\u003e\", \"has_more\": true }, \"timestamp\": 0 }\n```\n- cursor: 当前分页游标，作为 GET /rounds 接口的 cursor 参数向前翻页\n- has_more: 是否存在更早的轮次。为 false 时表示当前轮次即为第一轮，无需再翻页",
+                "description": "功能定位：该接口通过 WebSocket 转发任务运行数据。任务对话继续输入使用 `type=user-input`。\n数据格式约定：当前仅支持文本帧透传。服务端将 Agent 的原始文本数据包装为如下结构返回给前端（对应 domain.TaskStream）：\n```json\n{ \"type\": \"string\", \"data\": \"string\", \"kind\": \"string\", \"timestamp\": 0 }\n```\nuser-input 上行新格式：\n```json\n{ \"type\": \"user-input\", \"data\": \"{\\\"content\\\":\\\"57un57ut5aSE55CG6L+Z5Liq6Zeu6aKY\\\",\\\"attachment_urls\\\":[\\\"https://example-bucket.oss-cn-hangzhou.aliyuncs.com/temp/a.txt\\\"]}\" }\n```\nuser-input 上行旧格式仍兼容：\n```json\n{ \"type\": \"user-input\", \"data\": \"继续处理这个问题\" }\n```\nuser-input 下行和历史返回统一使用新 JSON payload 字符串：\n```json\n{ \"type\": \"user-input\", \"data\": \"{\\\"content\\\":\\\"57un57ut5aSE55CG6L+Z5Liq6Zeu6aKY\\\",\\\"attachment_urls\\\":[]}\", \"timestamp\": 0 }\n```\n`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。\ntype 字段说明：\n- task-started: 本轮任务启动\n- task-ended: 本轮任务结束\n- task-error: 本轮任务发生错误\n- task-running: 任务正在运行\n- task-event: 任务临时事件, 不持久化\n- file-change: 文件变动事件\n- permission-resp: 用户的权限响应\n- auto-approve: 开启自动批准\n- disable-auto-approve: 关闭自动批准\n- user-input: 用户输入\n- user-cancel: 取消当前操作，不会终止任务\n- reply-question: 回复 AI 的提问\n- cursor: 历史游标，用于通过 /rounds 接口加载更早的轮次\n\ncursor 消息结构：\n```json\n{ \"type\": \"cursor\", \"data\": { \"cursor\": \"\u003cnextCursor\u003e\", \"has_more\": true }, \"timestamp\": 0 }\n```\n- cursor: 当前分页游标，作为 GET /rounds 接口的 cursor 参数向前翻页\n- has_more: 是否存在更早的轮次。为 false 时表示当前轮次即为第一轮，无需再翻页",
                 "consumes": [
                     "application/json"
                 ],

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -7170,7 +7170,7 @@
                         "MonkeyCodeAIAuth": []
                     }
                 ],
-                "description": "创建任务\n`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。创建任务后，首轮 user-input 日志会按 `{ \"content\": \"base64文本\", \"attachment_urls\": [] }` 结构返回。",
+                "description": "创建任务\n`attachments` 为可选附件列表，最多 10 个；每项包含 `url` 和 `filename`，URL 需要匹配后端配置的附件白名单前缀。创建任务后，首轮 user-input 日志会按 `{ \"content\": \"base64文本\", \"attachments\": [] }` 结构返回。",
                 "consumes": [
                     "application/json"
                 ],
@@ -7313,7 +7313,7 @@
                         "MonkeyCodeAIAuth": []
                     }
                 ],
-                "description": "根据 cursor 向前翻页查询任务的历史轮次。limit 为轮次数（非条目数），\nlimit=2 表示返回 2 轮的完整消息。返回的 chunks 按时间倒序排列（最新在前）。\n返回的 user-input.data 统一为 JSON payload 字符串，例如 `{\"content\":\"57un57ut5aSE55CG\",\"attachment_urls\":[]}`；content 为用户输入文本的 base64 编码，旧历史裸文本也会按该结构包装返回。",
+                "description": "根据 cursor 向前翻页查询任务的历史轮次。limit 为轮次数（非条目数），\nlimit=2 表示返回 2 轮的完整消息。返回的 chunks 按时间倒序排列（最新在前）。\n返回的 user-input.data 统一为 JSON payload 字符串，例如 `{\"content\":\"57un57ut5aSE55CG\",\"attachments\":[]}`；content 为用户输入文本的 base64 编码，旧历史裸文本也会按该结构包装返回。",
                 "consumes": [
                     "application/json"
                 ],
@@ -7459,7 +7459,7 @@
                         "MonkeyCodeAIAuth": []
                     }
                 ],
-                "description": "功能定位：该接口通过 WebSocket 转发任务运行数据。任务对话继续输入使用 `type=user-input`。\n数据格式约定：当前仅支持文本帧透传。服务端将 Agent 的原始文本数据包装为如下结构返回给前端（对应 domain.TaskStream）：\n```json\n{ \"type\": \"string\", \"data\": \"string\", \"kind\": \"string\", \"timestamp\": 0 }\n```\nuser-input 上行新格式：\n```json\n{ \"type\": \"user-input\", \"data\": \"{\\\"content\\\":\\\"57un57ut5aSE55CG6L+Z5Liq6Zeu6aKY\\\",\\\"attachment_urls\\\":[\\\"https://example-bucket.oss-cn-hangzhou.aliyuncs.com/temp/a.txt\\\"]}\" }\n```\nuser-input 上行旧格式仍兼容：\n```json\n{ \"type\": \"user-input\", \"data\": \"继续处理这个问题\" }\n```\nuser-input 下行和历史返回统一使用新 JSON payload 字符串：\n```json\n{ \"type\": \"user-input\", \"data\": \"{\\\"content\\\":\\\"57un57ut5aSE55CG6L+Z5Liq6Zeu6aKY\\\",\\\"attachment_urls\\\":[]}\", \"timestamp\": 0 }\n```\n`attachment_urls` 为可选附件访问 URL 列表，最多 10 个；URL 需要匹配后端配置的附件白名单前缀。\ntype 字段说明：\n- task-started: 本轮任务启动\n- task-ended: 本轮任务结束\n- task-error: 本轮任务发生错误\n- task-running: 任务正在运行\n- task-event: 任务临时事件, 不持久化\n- file-change: 文件变动事件\n- permission-resp: 用户的权限响应\n- auto-approve: 开启自动批准\n- disable-auto-approve: 关闭自动批准\n- user-input: 用户输入\n- user-cancel: 取消当前操作，不会终止任务\n- reply-question: 回复 AI 的提问\n- cursor: 历史游标，用于通过 /rounds 接口加载更早的轮次\n\ncursor 消息结构：\n```json\n{ \"type\": \"cursor\", \"data\": { \"cursor\": \"\u003cnextCursor\u003e\", \"has_more\": true }, \"timestamp\": 0 }\n```\n- cursor: 当前分页游标，作为 GET /rounds 接口的 cursor 参数向前翻页\n- has_more: 是否存在更早的轮次。为 false 时表示当前轮次即为第一轮，无需再翻页",
+                "description": "功能定位：该接口通过 WebSocket 转发任务运行数据。任务对话继续输入使用 `type=user-input`。\n数据格式约定：当前仅支持文本帧透传。服务端将 Agent 的原始文本数据包装为如下结构返回给前端（对应 domain.TaskStream）：\n```json\n{ \"type\": \"string\", \"data\": \"string\", \"kind\": \"string\", \"timestamp\": 0 }\n```\nuser-input 上行新格式：\n```json\n{ \"type\": \"user-input\", \"data\": \"{\\\"content\\\":\\\"57un57ut5aSE55CG6L+Z5Liq6Zeu6aKY\\\",\\\"attachments\\\":[{\\\"url\\\":\\\"https://example-bucket.oss-cn-hangzhou.aliyuncs.com/temp/a.txt\\\",\\\"filename\\\":\\\"a.txt\\\"}]}\" }\n```\nuser-input 上行旧格式仍兼容：\n```json\n{ \"type\": \"user-input\", \"data\": \"继续处理这个问题\" }\n```\nuser-input 下行和历史返回统一使用新 JSON payload 字符串：\n```json\n{ \"type\": \"user-input\", \"data\": \"{\\\"content\\\":\\\"57un57ut5aSE55CG6L+Z5Liq6Zeu6aKY\\\",\\\"attachments\\\":[]}\", \"timestamp\": 0 }\n```\n`attachments` 为可选附件列表，最多 10 个；每项包含 `url` 和 `filename`，URL 需要匹配后端配置的附件白名单前缀。\ntype 字段说明：\n- task-started: 本轮任务启动\n- task-ended: 本轮任务结束\n- task-error: 本轮任务发生错误\n- task-running: 任务正在运行\n- task-event: 任务临时事件, 不持久化\n- file-change: 文件变动事件\n- permission-resp: 用户的权限响应\n- auto-approve: 开启自动批准\n- disable-auto-approve: 关闭自动批准\n- user-input: 用户输入\n- user-cancel: 取消当前操作，不会终止任务\n- reply-question: 回复 AI 的提问\n- cursor: 历史游标，用于通过 /rounds 接口加载更早的轮次\n\ncursor 消息结构：\n```json\n{ \"type\": \"cursor\", \"data\": { \"cursor\": \"\u003cnextCursor\u003e\", \"has_more\": true }, \"timestamp\": 0 }\n```\n- cursor: 当前分页游标，作为 GET /rounds 接口的 cursor 参数向前翻页\n- has_more: 是否存在更早的轮次。为 false 时表示当前轮次即为第一轮，无需再翻页",
                 "consumes": [
                     "application/json"
                 ],
@@ -8564,11 +8564,11 @@
                 "resource"
             ],
             "properties": {
-                "attachment_urls": {
-                    "description": "附件访问 URL 列表，最多 10 个；URL 必须匹配后端配置的附件白名单前缀",
+                "attachments": {
+                    "description": "附件列表，最多 10 个；URL 必须匹配后端配置的附件白名单前缀",
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/domain.TaskAttachment"
                     }
                 },
                 "cli_name": {
@@ -9984,6 +9984,17 @@
                 },
                 "virtualmachine": {
                     "$ref": "#/definitions/domain.VirtualMachine"
+                }
+            }
+        },
+        "domain.TaskAttachment": {
+            "type": "object",
+            "properties": {
+                "filename": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
                 }
             }
         },

--- a/backend/domain/task.go
+++ b/backend/domain/task.go
@@ -81,26 +81,31 @@ type TaskExtraConfig struct {
 
 // CreateTaskReq 创建任务请求
 type CreateTaskReq struct {
-	Content        string             `json:"content" validate:"required"`
-	HostID         string             `json:"host_id" validate:"required"`
-	ImageID        uuid.UUID          `json:"image_id" validate:"required"`
-	ModelID        string             `json:"model_id" validate:"required"`
-	GitIdentityID  uuid.UUID          `json:"git_identity_id" validate:"omitempty"`
-	RepoReq        TaskRepoReq        `json:"repo" validate:"required"`
-	CliName        consts.CliName     `json:"cli_name"`
-	Resource       *VMResource        `json:"resource" validate:"required"`
-	Extra          TaskExtraConfig    `json:"extra" validate:"omitempty"`
-	SystemPrompt   string             `json:"system_prompt"`
-	Type           consts.TaskType    `json:"task_type"`
-	SubType        consts.TaskSubType `json:"sub_type"`
-	AttachmentURLs []string           `json:"attachment_urls" validate:"omitempty"` // 附件访问 URL 列表，最多 10 个；URL 必须匹配后端配置的附件白名单前缀
-	Now            time.Time          `json:"-"`
-	UsePublicHost  bool               `json:"-"`
+	Content       string             `json:"content" validate:"required"`
+	HostID        string             `json:"host_id" validate:"required"`
+	ImageID       uuid.UUID          `json:"image_id" validate:"required"`
+	ModelID       string             `json:"model_id" validate:"required"`
+	GitIdentityID uuid.UUID          `json:"git_identity_id" validate:"omitempty"`
+	RepoReq       TaskRepoReq        `json:"repo" validate:"required"`
+	CliName       consts.CliName     `json:"cli_name"`
+	Resource      *VMResource        `json:"resource" validate:"required"`
+	Extra         TaskExtraConfig    `json:"extra" validate:"omitempty"`
+	SystemPrompt  string             `json:"system_prompt"`
+	Type          consts.TaskType    `json:"task_type"`
+	SubType       consts.TaskSubType `json:"sub_type"`
+	Attachments   []TaskAttachment   `json:"attachments" validate:"omitempty"` // 附件列表，最多 10 个；URL 必须匹配后端配置的附件白名单前缀
+	Now           time.Time          `json:"-"`
+	UsePublicHost bool               `json:"-"`
 }
 
 type ContinueTaskReq struct {
-	Content        []byte   `json:"content"`
-	AttachmentURLs []string `json:"attachment_urls"`
+	Content     []byte           `json:"content"`
+	Attachments []TaskAttachment `json:"attachments"`
+}
+
+type TaskAttachment struct {
+	URL      string `json:"url"`
+	Filename string `json:"filename"`
 }
 
 // Validate 验证请求参数
@@ -306,8 +311,8 @@ type TaskStream struct {
 
 // TaskUserInputPayload user-input 事件 data 字段的 JSON 结构
 type TaskUserInputPayload struct {
-	Content        []byte   `json:"content"`         // 用户输入文本，JSON 中按 base64 字符串传输
-	AttachmentURLs []string `json:"attachment_urls"` // 附件访问 URL 列表，缺省或空数组表示无附件
+	Content     []byte           `json:"content"`     // 用户输入文本，JSON 中按 base64 字符串传输
+	Attachments []TaskAttachment `json:"attachments"` // 附件列表，缺省或空数组表示无附件
 }
 
 // TaskStreamReq 任务数据流请求

--- a/backend/domain/task.go
+++ b/backend/domain/task.go
@@ -81,20 +81,21 @@ type TaskExtraConfig struct {
 
 // CreateTaskReq 创建任务请求
 type CreateTaskReq struct {
-	Content       string             `json:"content" validate:"required"`
-	HostID        string             `json:"host_id" validate:"required"`
-	ImageID       uuid.UUID          `json:"image_id" validate:"required"`
-	ModelID       string             `json:"model_id" validate:"required"`
-	GitIdentityID uuid.UUID          `json:"git_identity_id" validate:"omitempty"`
-	RepoReq       TaskRepoReq        `json:"repo" validate:"required"`
-	CliName       consts.CliName     `json:"cli_name"`
-	Resource      *VMResource        `json:"resource" validate:"required"`
-	Extra         TaskExtraConfig    `json:"extra" validate:"omitempty"`
-	SystemPrompt  string             `json:"system_prompt"`
-	Type          consts.TaskType    `json:"task_type"`
-	SubType       consts.TaskSubType `json:"sub_type"`
-	Now           time.Time          `json:"-"`
-	UsePublicHost bool               `json:"-"`
+	Content        string             `json:"content" validate:"required"`
+	HostID         string             `json:"host_id" validate:"required"`
+	ImageID        uuid.UUID          `json:"image_id" validate:"required"`
+	ModelID        string             `json:"model_id" validate:"required"`
+	GitIdentityID  uuid.UUID          `json:"git_identity_id" validate:"omitempty"`
+	RepoReq        TaskRepoReq        `json:"repo" validate:"required"`
+	CliName        consts.CliName     `json:"cli_name"`
+	Resource       *VMResource        `json:"resource" validate:"required"`
+	Extra          TaskExtraConfig    `json:"extra" validate:"omitempty"`
+	SystemPrompt   string             `json:"system_prompt"`
+	Type           consts.TaskType    `json:"task_type"`
+	SubType        consts.TaskSubType `json:"sub_type"`
+	AttachmentURLs []string           `json:"attachment_urls" validate:"omitempty"` // 附件访问 URL 列表，最多 10 个；URL 必须匹配后端配置的附件白名单前缀
+	Now            time.Time          `json:"-"`
+	UsePublicHost  bool               `json:"-"`
 }
 
 // Validate 验证请求参数
@@ -293,9 +294,15 @@ type TaskSession struct {
 // TaskStream 任务 WebSocket 流消息
 type TaskStream struct {
 	Type      consts.TaskStreamType `json:"type"`
-	Data      []byte                `json:"data"`
+	Data      []byte                `json:"data"` // user-input 事件使用 TaskUserInputPayload 的 JSON 字符串
 	Kind      string                `json:"kind"`
 	Timestamp int64                 `json:"timestamp"`
+}
+
+// TaskUserInputPayload user-input 事件 data 字段的 JSON 结构
+type TaskUserInputPayload struct {
+	Content        string   `json:"content"`         // 用户输入文本
+	AttachmentURLs []string `json:"attachment_urls"` // 附件访问 URL 列表，缺省或空数组表示无附件
 }
 
 // TaskStreamReq 任务数据流请求

--- a/backend/domain/task.go
+++ b/backend/domain/task.go
@@ -99,7 +99,7 @@ type CreateTaskReq struct {
 }
 
 type ContinueTaskReq struct {
-	Content        string   `json:"content"`
+	Content        []byte   `json:"content"`
 	AttachmentURLs []string `json:"attachment_urls"`
 }
 
@@ -306,7 +306,7 @@ type TaskStream struct {
 
 // TaskUserInputPayload user-input 事件 data 字段的 JSON 结构
 type TaskUserInputPayload struct {
-	Content        string   `json:"content"`         // 用户输入文本
+	Content        []byte   `json:"content"`         // 用户输入文本，JSON 中按 base64 字符串传输
 	AttachmentURLs []string `json:"attachment_urls"` // 附件访问 URL 列表，缺省或空数组表示无附件
 }
 

--- a/backend/domain/task.go
+++ b/backend/domain/task.go
@@ -20,7 +20,7 @@ type TaskUsecase interface {
 	GetPublic(ctx context.Context, user *User, id uuid.UUID) (*Task, error)
 	Info(ctx context.Context, user *User, id uuid.UUID) (*Task, bool, error)
 	List(ctx context.Context, user *User, req TaskListReq) (*ListTaskResp, error)
-	Continue(ctx context.Context, user *User, id uuid.UUID, content string) error
+	Continue(ctx context.Context, user *User, id uuid.UUID, req ContinueTaskReq) error
 	Create(ctx context.Context, user *User, req CreateTaskReq) (*ProjectTask, error)
 	Stop(ctx context.Context, user *User, id uuid.UUID) error
 	Cancel(ctx context.Context, user *User, id uuid.UUID) error
@@ -96,6 +96,11 @@ type CreateTaskReq struct {
 	AttachmentURLs []string           `json:"attachment_urls" validate:"omitempty"` // 附件访问 URL 列表，最多 10 个；URL 必须匹配后端配置的附件白名单前缀
 	Now            time.Time          `json:"-"`
 	UsePublicHost  bool               `json:"-"`
+}
+
+type ContinueTaskReq struct {
+	Content        string   `json:"content"`
+	AttachmentURLs []string `json:"attachment_urls"`
 }
 
 // Validate 验证请求参数

--- a/backend/pkg/taskflow/types.go
+++ b/backend/pkg/taskflow/types.go
@@ -530,10 +530,11 @@ type TaskReq struct {
 
 // Task 任务信息
 type Task struct {
-	ID       uuid.UUID `json:"id"`
-	Text     string    `json:"text"`
-	Image    string    `json:"image"`
-	LogStore string    `json:"log_store,omitempty"`
+	ID             uuid.UUID `json:"id"`
+	Text           string    `json:"text"`
+	AttachmentURLs []string  `json:"attachment_urls,omitempty"`
+	Image          string    `json:"image"`
+	LogStore       string    `json:"log_store,omitempty"`
 }
 
 // ==================== CreateTask 类型 ====================
@@ -590,16 +591,17 @@ type McpServerConfig struct {
 
 // CreateTaskReq 创建任务请求
 type CreateTaskReq struct {
-	ID           uuid.UUID         `json:"id"`
-	VMID         string            `json:"vm_id"`
-	SystemPrompt string            `json:"system_prompt,omitempty"`
-	Text         string            `json:"text,omitempty"`
-	LLM          LLM               `json:"llm,omitzero"`
-	CodingAgent  CodingAgent       `json:"coding_agent,omitempty"`
-	Configs      []ConfigFile      `json:"configs,omitzero"`
-	McpConfigs   []McpServerConfig `json:"mcp_configs,omitzero"`
-	Env          map[string]string `json:"env,omitempty"`
-	LogStore     string            `json:"log_store,omitempty"`
+	ID             uuid.UUID         `json:"id"`
+	VMID           string            `json:"vm_id"`
+	SystemPrompt   string            `json:"system_prompt,omitempty"`
+	Text           string            `json:"text,omitempty"`
+	AttachmentURLs []string          `json:"attachment_urls,omitempty"`
+	LLM            LLM               `json:"llm,omitzero"`
+	CodingAgent    CodingAgent       `json:"coding_agent,omitempty"`
+	Configs        []ConfigFile      `json:"configs,omitzero"`
+	McpConfigs     []McpServerConfig `json:"mcp_configs,omitzero"`
+	Env            map[string]string `json:"env,omitempty"`
+	LogStore       string            `json:"log_store,omitempty"`
 }
 
 // ==================== VirtualMachine 查询类型 ====================

--- a/backend/pkg/taskflow/types.go
+++ b/backend/pkg/taskflow/types.go
@@ -530,11 +530,16 @@ type TaskReq struct {
 
 // Task 任务信息
 type Task struct {
-	ID             uuid.UUID `json:"id"`
-	Text           string    `json:"text"`
-	AttachmentURLs []string  `json:"attachment_urls,omitempty"`
-	Image          string    `json:"image"`
-	LogStore       string    `json:"log_store,omitempty"`
+	ID          uuid.UUID    `json:"id"`
+	Text        string       `json:"text"`
+	Attachments []Attachment `json:"attachments,omitempty"`
+	Image       string       `json:"image"`
+	LogStore    string       `json:"log_store,omitempty"`
+}
+
+type Attachment struct {
+	URL      string `json:"url"`
+	Filename string `json:"filename"`
 }
 
 // ==================== CreateTask 类型 ====================
@@ -591,17 +596,17 @@ type McpServerConfig struct {
 
 // CreateTaskReq 创建任务请求
 type CreateTaskReq struct {
-	ID             uuid.UUID         `json:"id"`
-	VMID           string            `json:"vm_id"`
-	SystemPrompt   string            `json:"system_prompt,omitempty"`
-	Text           string            `json:"text,omitempty"`
-	AttachmentURLs []string          `json:"attachment_urls,omitempty"`
-	LLM            LLM               `json:"llm,omitzero"`
-	CodingAgent    CodingAgent       `json:"coding_agent,omitempty"`
-	Configs        []ConfigFile      `json:"configs,omitzero"`
-	McpConfigs     []McpServerConfig `json:"mcp_configs,omitzero"`
-	Env            map[string]string `json:"env,omitempty"`
-	LogStore       string            `json:"log_store,omitempty"`
+	ID           uuid.UUID         `json:"id"`
+	VMID         string            `json:"vm_id"`
+	SystemPrompt string            `json:"system_prompt,omitempty"`
+	Text         string            `json:"text,omitempty"`
+	Attachments  []Attachment      `json:"attachments,omitempty"`
+	LLM          LLM               `json:"llm,omitzero"`
+	CodingAgent  CodingAgent       `json:"coding_agent,omitempty"`
+	Configs      []ConfigFile      `json:"configs,omitzero"`
+	McpConfigs   []McpServerConfig `json:"mcp_configs,omitzero"`
+	Env          map[string]string `json:"env,omitempty"`
+	LogStore     string            `json:"log_store,omitempty"`
 }
 
 // ==================== VirtualMachine 查询类型 ====================

--- a/backend/pkg/taskflow/types_test.go
+++ b/backend/pkg/taskflow/types_test.go
@@ -130,3 +130,18 @@ func TestTaskReqIncludesLogStore(t *testing.T) {
 		t.Fatalf("marshaled request missing log_store: %s", string(b))
 	}
 }
+
+func TestTaskAttachmentURLsSerialize(t *testing.T) {
+	req := TaskReq{
+		Task: &Task{
+			AttachmentURLs: []string{"https://oss.example.com/temp/a.txt"},
+		},
+	}
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if !strings.Contains(string(b), `"attachment_urls":["https://oss.example.com/temp/a.txt"]`) {
+		t.Fatalf("json = %s", b)
+	}
+}

--- a/backend/pkg/taskflow/types_test.go
+++ b/backend/pkg/taskflow/types_test.go
@@ -131,17 +131,19 @@ func TestTaskReqIncludesLogStore(t *testing.T) {
 	}
 }
 
-func TestTaskAttachmentURLsSerialize(t *testing.T) {
+func TestTaskAttachmentsSerialize(t *testing.T) {
 	req := TaskReq{
 		Task: &Task{
-			AttachmentURLs: []string{"https://oss.example.com/temp/a.txt"},
+			Attachments: []Attachment{
+				{URL: "https://oss.example.com/temp/a.txt", Filename: "a.txt"},
+			},
 		},
 	}
 	b, err := json.Marshal(req)
 	if err != nil {
 		t.Fatalf("Marshal() error = %v", err)
 	}
-	if !strings.Contains(string(b), `"attachment_urls":["https://oss.example.com/temp/a.txt"]`) {
+	if !strings.Contains(string(b), `"attachments":[{"url":"https://oss.example.com/temp/a.txt","filename":"a.txt"}]`) {
 		t.Fatalf("json = %s", b)
 	}
 }


### PR DESCRIPTION
## 变更内容
- 任务创建和 user-input 支持 attachments 对象列表，包含 url 和 filename
- user-input 日志 payload 使用 base64 content 和 attachments 新格式
- 增加附件数量、URL 白名单和 filename 非空校验
- 更新 Swagger 文档

## 验证
- make swag
- go test ./biz/task/handler/v1 ./biz/task/usecase ./biz/task/service ./pkg/taskflow ./domain -count=1