### PR TITLE
fix: 兼容 user-input 明文日志

### DIFF
--- a/backend/biz/task/handler/v1/task.go
+++ b/backend/biz/task/handler/v1/task.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/GoYoko/web"
 	"github.com/google/uuid"
@@ -236,7 +238,7 @@ func (h *TaskHandler) Info(c *web.Context, req domain.IDReq[uuid.UUID]) error {
 //
 //	@Summary		创建任务
 //	@Description	创建任务
-//	@Description	`attachments` 为可选附件列表，最多 10 个；每项包含 `url` 和 `filename`，URL 需要匹配后端配置的附件白名单前缀。创建任务后，首轮 user-input 日志会按 `{ "content": "base64文本", "attachments": [] }` 结构返回。
+//	@Description	`attachments` 为可选附件列表，最多 10 个；每项包含 `url` 和 `filename`，URL 需要匹配后端配置的附件白名单前缀。创建任务后，首轮 user-input 接口返回会按 `{ "content": "base64文本", "attachments": [] }` 结构保持兼容，taskflow 日志存储为明文。
 //	@Tags			【用户】任务管理
 //	@Accept			json
 //	@Produce		json
@@ -478,18 +480,33 @@ func buildTaskStreamsFromLogEntries(entries []tasklog.Entry, logger *slog.Logger
 
 func parseUserInputData(data []byte) domain.ContinueTaskReq {
 	var payload domain.TaskUserInputPayload
-	if err := json.Unmarshal(data, &payload); err == nil && strings.TrimSpace(string(payload.Content)) != "" {
+	if err := json.Unmarshal(data, &payload); err == nil && strings.TrimSpace(payload.Content) != "" {
 		return domain.ContinueTaskReq{
-			Content:     payload.Content,
+			Content:     []byte(normalizeLegacyUserInputContent(payload.Content)),
 			Attachments: payload.Attachments,
 		}
 	}
 	return domain.ContinueTaskReq{Content: data}
 }
 
+func normalizeLegacyUserInputContent(content string) string {
+	decoded, err := base64.StdEncoding.DecodeString(content)
+	if err != nil || !utf8.Valid(decoded) {
+		return content
+	}
+	text := string(decoded)
+	if strings.TrimSpace(text) == "" {
+		return content
+	}
+	return text
+}
+
 func normalizeUserInputData(data []byte) []byte {
 	req := parseUserInputData(data)
-	payload := domain.TaskUserInputPayload{
+	payload := struct {
+		Content     []byte                  `json:"content"`
+		Attachments []domain.TaskAttachment `json:"attachments"`
+	}{
 		Content:     req.Content,
 		Attachments: req.Attachments,
 	}
@@ -720,7 +737,7 @@ func (h *TaskHandler) writeCursor(wsConn *ws.WebsocketManager, cursor string, ha
 //	@Summary		查询任务历史轮次
 //	@Description	根据 cursor 向前翻页查询任务的历史轮次。limit 为轮次数（非条目数），
 //	@Description	limit=2 表示返回 2 轮的完整消息。返回的 chunks 按时间倒序排列（最新在前）。
-//	@Description	返回的 user-input.data 统一为 JSON payload 字符串，例如 `{"content":"57un57ut5aSE55CG","attachments":[]}`；content 为用户输入文本的 base64 编码，旧历史裸文本也会按该结构包装返回。
+//	@Description	返回的 user-input.data 统一为 JSON payload 字符串，例如 `{"content":"57un57ut5aSE55CG","attachments":[]}`；content 为用户输入文本的 base64 编码，旧历史裸文本也会按该结构包装返回；taskflow 日志存储为明文。
 //	@Tags			【用户】任务管理
 //	@Accept			json
 //	@Produce		json

--- a/backend/biz/task/handler/v1/task_attach_test.go
+++ b/backend/biz/task/handler/v1/task_attach_test.go
@@ -52,8 +52,25 @@ func TestNormalizeUserInputDataWrapsLegacyText(t *testing.T) {
 	}
 }
 
-func TestNormalizeUserInputDataKeepsPayloadShape(t *testing.T) {
+func TestNormalizeUserInputDataDecodesLegacyPayloadContent(t *testing.T) {
 	got := normalizeUserInputData([]byte(`{"content":"5paw6L6T5YWl","attachments":[{"url":"https://oss.example.com/temp/a.txt","filename":"a.txt"}]}`))
+	if string(got) != `{"content":"5paw6L6T5YWl","attachments":[{"url":"https://oss.example.com/temp/a.txt","filename":"a.txt"}]}` {
+		t.Fatalf("normalized = %s", got)
+	}
+}
+
+func TestParseUserInputDataDecodesFrontendPayloadContent(t *testing.T) {
+	got := parseUserInputData([]byte(`{"content":"5paw6L6T5YWl","attachments":[{"url":"https://oss.example.com/temp/a.txt","filename":"a.txt"}]}`))
+	if string(got.Content) != "新输入" {
+		t.Fatalf("content = %q, want 新输入", string(got.Content))
+	}
+	if len(got.Attachments) != 1 || got.Attachments[0].URL != "https://oss.example.com/temp/a.txt" {
+		t.Fatalf("attachments = %#v", got.Attachments)
+	}
+}
+
+func TestNormalizeUserInputDataEncodesPlainStoredPayloadForFrontend(t *testing.T) {
+	got := normalizeUserInputData([]byte(`{"content":"新输入","attachments":[{"url":"https://oss.example.com/temp/a.txt","filename":"a.txt"}]}`))
 	if string(got) != `{"content":"5paw6L6T5YWl","attachments":[{"url":"https://oss.example.com/temp/a.txt","filename":"a.txt"}]}` {
 		t.Fatalf("normalized = %s", got)
 	}

--- a/backend/biz/task/service/tasksummary.go
+++ b/backend/biz/task/service/tasksummary.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/samber/do"
@@ -427,10 +428,22 @@ func buildSummaryConversation(ctx context.Context, logger *slog.Logger, taskID u
 
 func userInputContent(decoded []byte) string {
 	var payload userInputPayload
-	if err := json.Unmarshal(decoded, &payload); err == nil && len(payload.Content) > 0 {
-		return string(payload.Content)
+	if err := json.Unmarshal(decoded, &payload); err == nil && strings.TrimSpace(payload.Content) != "" {
+		return normalizeLegacyUserInputContent(payload.Content)
 	}
 	return string(decoded)
+}
+
+func normalizeLegacyUserInputContent(content string) string {
+	decoded, err := base64.StdEncoding.DecodeString(content)
+	if err != nil || !utf8.Valid(decoded) {
+		return content
+	}
+	text := string(decoded)
+	if strings.TrimSpace(text) == "" {
+		return content
+	}
+	return text
 }
 
 func normalizeSummaryLogStore(store *consts.LogStore) consts.LogStore {

--- a/backend/biz/task/service/types.go
+++ b/backend/biz/task/service/types.go
@@ -12,7 +12,7 @@ type userReply struct {
 }
 
 type userInputPayload struct {
-	Content     []byte           `json:"content"`
+	Content     string           `json:"content"`
 	Attachments []taskAttachment `json:"attachments"`
 }
 

--- a/backend/domain/task.go
+++ b/backend/domain/task.go
@@ -311,7 +311,7 @@ type TaskStream struct {
 
 // TaskUserInputPayload user-input 事件 data 字段的 JSON 结构
 type TaskUserInputPayload struct {
-	Content     []byte           `json:"content"`     // 用户输入文本，JSON 中按 base64 字符串传输
+	Content     string           `json:"content"`     // 用户输入文本；旧前端上行为 base64，taskflow 日志可为明文
 	Attachments []TaskAttachment `json:"attachments"` // 附件列表，缺省或空数组表示无附件
 }
 

--- a/backend/pkg/tasklog/clickhouse_provider.go
+++ b/backend/pkg/tasklog/clickhouse_provider.go
@@ -128,7 +128,7 @@ ORDER BY turn_seq DESC, ts ASC, msg_seq_start ASC, ingest_id ASC
 			continue
 		}
 		chunks = append(chunks, &TurnChunk{
-			Data:      []byte(data),
+			Data:      []byte(normalizeUserInputLogData(event, data)),
 			Event:     event,
 			Kind:      kind,
 			Timestamp: ts.UTC().UnixNano(),
@@ -219,7 +219,7 @@ SELECT task_id, ts, event, kind, turn_seq, data, msg_seq_start, msg_seq_end
 			Event:   event,
 			Kind:    kind,
 			TurnSeq: seq,
-			Data:    data,
+			Data:    normalizeUserInputLogData(event, data),
 			MsgSeq:  formatMsgSeqRange(msgSeqStart, msgSeqEnd),
 		})
 	}

--- a/backend/pkg/tasklog/clickhouse_provider_test.go
+++ b/backend/pkg/tasklog/clickhouse_provider_test.go
@@ -2,6 +2,7 @@ package tasklog_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -64,6 +65,47 @@ func TestClickHouseProviderQueryLatestTurnUsesTurnSeqCursor(t *testing.T) {
 	}
 }
 
+func TestClickHouseProviderNormalizesLegacyUserInputContent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	taskID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	start := time.Unix(1_710_000_000, 0).UTC()
+	end := start.Add(time.Minute)
+	legacyPayload := `{"content":"5paw6L6T5YWl","attachments":[{"url":"https://oss.example.com/temp/a.txt","filename":"a.txt"}]}`
+
+	mock.ExpectQuery("SELECT max\\(turn_seq\\)[\\s\\S]*WHERE task_id = \\? AND ts >= \\? AND ts <= \\?\\s*$").
+		WithArgs(taskID, start, end).
+		WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(2))
+
+	rows := sqlmock.NewRows([]string{"task_id", "ts", "event", "kind", "turn_seq", "data", "msg_seq_start", "msg_seq_end"}).
+		AddRow(taskID.String(), start.Add(10*time.Second), "user-input", "", 2, legacyPayload, uint64(0), uint64(0))
+
+	mock.ExpectQuery("SELECT task_id, ts, event, kind, turn_seq, data, msg_seq_start, msg_seq_end[\\s\\S]*ORDER BY turn_seq ASC, ts ASC, msg_seq_start ASC, ingest_id ASC\\s*$").
+		WithArgs(taskID, 2, start, end).
+		WillReturnRows(rows)
+
+	mock.ExpectQuery("SELECT turn_seq[\\s\\S]*turn_seq < \\?[\\s\\S]*LIMIT \\?\\s*$").
+		WithArgs(taskID, uint32(2), 1).
+		WillReturnRows(sqlmock.NewRows([]string{"turn_seq"}))
+
+	provider := tasklog.NewClickHouseProvider(clickhouse.NewWithDBAndTable(db, "task_logs_test"))
+	resp, err := provider.QueryLatestTurn(context.Background(), taskID, start, end)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(resp.Entries))
+	}
+	assertUserInputContent(t, []byte(resp.Entries[0].Data), "新输入")
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestClickHouseProviderQueryLatestTurnHandlesSparseTurnsWithoutMore(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -106,6 +148,19 @@ func TestClickHouseProviderQueryLatestTurnHandlesSparseTurnsWithoutMore(t *testi
 	}
 }
 
+func assertUserInputContent(t *testing.T, data []byte, want string) {
+	t.Helper()
+	var payload struct {
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal user-input payload: %v, data=%s", err, data)
+	}
+	if payload.Content != want {
+		t.Fatalf("content = %q, want %q, data=%s", payload.Content, want, data)
+	}
+}
+
 func TestClickHouseProviderQueryTurnsUsesSparseTurnCursor(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -114,8 +169,9 @@ func TestClickHouseProviderQueryTurnsUsesSparseTurnCursor(t *testing.T) {
 	defer db.Close()
 
 	taskID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	legacyPayload := `{"content":"5paw6L6T5YWl","attachments":[]}`
 	chunkRows := sqlmock.NewRows([]string{"ts", "event", "kind", "data", "turn_seq"}).
-		AddRow(time.Unix(1_710_000_010, 0).UTC(), "user-input", "", "latest", uint32(1))
+		AddRow(time.Unix(1_710_000_010, 0).UTC(), "user-input", "", legacyPayload, uint32(1))
 
 	mock.ExpectQuery("SELECT ts, event, kind, data, turn_seq[\\s\\S]*FROM task_logs_test[\\s\\S]*turn_seq IN \\([\\s\\S]*SELECT DISTINCT turn_seq[\\s\\S]*FROM task_logs_test[\\s\\S]*turn_seq < \\?[\\s\\S]*LIMIT \\?[\\s\\S]*ORDER BY turn_seq DESC, ts ASC, msg_seq_start ASC, ingest_id ASC\\s*$").
 		WithArgs(taskID, taskID, uint32(2), 2).
@@ -129,6 +185,7 @@ func TestClickHouseProviderQueryTurnsUsesSparseTurnCursor(t *testing.T) {
 	if len(resp.Chunks) != 1 {
 		t.Fatalf("len(chunks) = %d, want 1", len(resp.Chunks))
 	}
+	assertUserInputContent(t, resp.Chunks[0].Data, "新输入")
 	if resp.HasMore {
 		t.Fatal("expected has_more=false")
 	}

--- a/backend/pkg/tasklog/compat.go
+++ b/backend/pkg/tasklog/compat.go
@@ -1,0 +1,45 @@
+package tasklog
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"unicode/utf8"
+)
+
+func normalizeUserInputLogData(event, data string) string {
+	if event != "user-input" {
+		return data
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(data), &payload); err != nil {
+		return data
+	}
+
+	var content string
+	if err := json.Unmarshal(payload["content"], &content); err != nil || strings.TrimSpace(content) == "" {
+		return data
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(content)
+	if err != nil || !utf8.Valid(decoded) {
+		return data
+	}
+	text := string(decoded)
+	if strings.TrimSpace(text) == "" {
+		return data
+	}
+
+	contentBytes, err := json.Marshal(text)
+	if err != nil {
+		return data
+	}
+	payload["content"] = contentBytes
+
+	out, err := json.Marshal(payload)
+	if err != nil {
+		return data
+	}
+	return string(out)
+}

--- a/backend/pkg/tasklog/loki_provider.go
+++ b/backend/pkg/tasklog/loki_provider.go
@@ -44,7 +44,7 @@ func (p *LokiProvider) QueryWindow(ctx context.Context, taskID uuid.UUID, start,
 			TS:     entry.Timestamp.UTC(),
 			Event:  chunk.Event,
 			Kind:   chunk.Kind,
-			Data:   string(chunk.Data),
+			Data:   normalizeUserInputLogData(chunk.Event, string(chunk.Data)),
 			MsgSeq: entry.Labels["msg_seq"],
 			Labels: entry.Labels,
 		})
@@ -99,7 +99,7 @@ func (p *LokiProvider) QueryTurns(ctx context.Context, taskID uuid.UUID, taskCre
 	}
 	for _, chunk := range resp.Chunks {
 		out.Chunks = append(out.Chunks, &TurnChunk{
-			Data:      chunk.Data,
+			Data:      []byte(normalizeUserInputLogData(chunk.Event, string(chunk.Data))),
 			Event:     chunk.Event,
 			Kind:      chunk.Kind,
 			Timestamp: chunk.Timestamp,


### PR DESCRIPTION
## 变更
- 后端接收旧前端 user-input payload 时解码 content，再以明文继续传给 taskflow。
- tasklog provider 读取 ClickHouse/Loki 历史 user-input 日志时，将旧的 payload.content base64 归一为明文 payload，兼容已入库历史数据。
- 历史接口返回给现有前端时仍保持 user-input content base64 形态，避免破坏展示协议。
- 摘要构造兼容旧 base64 与新明文 user-input 日志。

## 验证
- go test ./pkg/tasklog ./biz/task/handler/v1 ./biz/task/service
- git diff --check