### PR TITLE
fix: 预签名上传不发送 Content-Type

### DIFF
--- a/frontend/src/components/console/task/create-default-task-dialog.tsx
+++ b/frontend/src/components/console/task/create-default-task-dialog.tsx
@@ -468,9 +468,6 @@ export default function CreateDefaultTaskDialog({
         const uploadResponse = await fetch(upload_url, {
           method: "PUT",
           body: selectedZipFile,
-          headers: {
-            "Content-Type": "application/zip",
-          },
         })
 
         if (!uploadResponse.ok) {

--- a/frontend/src/components/console/task/task-file-upload.tsx
+++ b/frontend/src/components/console/task/task-file-upload.tsx
@@ -90,9 +90,6 @@ export function TaskFileUploadDialog({ open, file, onOpenChange, onUploaded }: T
       const uploadResponse = await fetch(upload_url, {
         method: "PUT",
         body: file,
-        headers: {
-          "Content-Type": file.type || "application/octet-stream",
-        },
       })
 
       if (!uploadResponse.ok) {

--- a/frontend/src/components/console/task/task-input.tsx
+++ b/frontend/src/components/console/task/task-input.tsx
@@ -400,9 +400,6 @@ export function TaskInput({ repos, onTaskCreated }: TaskInputProps) {
       const uploadResponse = await fetch(upload_url, {
         method: 'PUT',
         body: selectedZipFile,
-        headers: {
-          'Content-Type': 'application/zip',
-        },
       });
 
       if (!uploadResponse.ok) {

--- a/frontend/src/utils/common.tsx
+++ b/frontend/src/utils/common.tsx
@@ -580,9 +580,6 @@ export async function packAndUploadFilesAsZip(
   const uploadResponse = await fetch(upload_url, {
     method: 'PUT',
     body: zipFile,
-    headers: {
-      'Content-Type': 'application/zip',
-    },
   })
 
   if (!uploadResponse.ok) {


### PR DESCRIPTION
## 变更
- 移除任务相关 OSS 预签名直传请求中的 Content-Type Header
- 避免前端显式 Header 与后端未绑定 Content-Type 的预签名 URL 验签不一致导致 403

## 验证
- pnpm build
- pnpm lint 未通过：项目现有 ESLint flat config 使用 plugins 字符串数组，ESLint 9 在读取配置阶段报错，未进入源码检查

## 关联
- 后端需配合移除预签名 URL 的 Content-Type 约束