### PR TITLE
支持 monkeycode-ultra 强制推理配置

### DIFF
--- a/backend/biz/task/usecase/task.go
+++ b/backend/biz/task/usecase/task.go
@@ -750,6 +750,7 @@ func (a *TaskUsecase) getCodingConfigs(cli consts.CliName, m *db.Model, skillIDs
 		"api_key":          m.APIKey,
 		"npm_package":      npmPackage,
 		"thinking_enabled": thinkingEnabled,
+		"force_reasoning":  strings.HasPrefix(m.Model, "monkeycode-ultra"),
 		"context_limit":    contextLimit,
 		"output_limit":     outputLimit,
 	}); err != nil {

--- a/backend/biz/task/usecase/task_model_config_test.go
+++ b/backend/biz/task/usecase/task_model_config_test.go
@@ -121,6 +121,9 @@ func TestGetCodingConfigsOpenCodeRendersRuntimeConfigEnabled(t *testing.T) {
 
 	renderedModel := opencodeModel(t, provider, "gpt-4.1")
 	assertLimit(t, renderedModel, 128000, 16000)
+	if compat, ok := renderedModel["compat"]; ok {
+		t.Fatalf("compat = %v, want absent", compat)
+	}
 	if options, ok := renderedModel["options"].(map[string]any); ok {
 		if thinking, ok := options["thinking"]; ok {
 			t.Fatalf("model thinking options = %v, want absent", thinking)
@@ -161,6 +164,36 @@ func TestGetCodingConfigsOpenCodeRendersThinkingDisabled(t *testing.T) {
 	}
 	if got := thinking["type"]; got != "disabled" {
 		t.Fatalf("thinking type = %v, want disabled", got)
+	}
+}
+
+func TestGetCodingConfigsOpenCodeRendersUltraForceReasoning(t *testing.T) {
+	uc := &TaskUsecase{}
+	model := &db.Model{
+		BaseURL:         "https://example.com/v1",
+		Model:           "monkeycode-ultra-preview",
+		APIKey:          "sk-test",
+		InterfaceType:   string(consts.InterfaceTypeOpenAIResponse),
+		ThinkingEnabled: true,
+	}
+
+	_, cfs, err := uc.getCodingConfigs(consts.CliNameOpencode, model, nil)
+	if err != nil {
+		t.Fatalf("getCodingConfigs() error = %v", err)
+	}
+
+	config := opencodeConfig(t, cfs)
+	provider := opencodeProvider(t, config)
+	renderedModel := opencodeModel(t, provider, "monkeycode-ultra-preview")
+	if compat, ok := renderedModel["compat"]; ok {
+		t.Fatalf("compat = %v, want absent", compat)
+	}
+	options, ok := renderedModel["options"].(map[string]any)
+	if !ok {
+		t.Fatal("model options is absent")
+	}
+	if got := options["forceReasoning"]; got != true {
+		t.Fatalf("forceReasoning = %v, want true", got)
 	}
 }
 

--- a/backend/templates/opencode.tmpl
+++ b/backend/templates/opencode.tmpl
@@ -14,8 +14,15 @@
       },
       "models": {
         "{{.model}}": {
+{{- if or (not .thinking_enabled) .force_reasoning }}
+          "options": {
 {{- if not .thinking_enabled }}
-          "options": {"thinking": {"type":"disabled"}},
+            "thinking": {"type":"disabled"}{{if .force_reasoning}},{{end}}
+{{- end }}
+{{- if .force_reasoning }}
+            "forceReasoning": true
+{{- end }}
+          },
 {{- end }}
           "name": "{{.model}}",
           "limit": {"context": {{.context_limit}}, "output": {{.output_limit}}}


### PR DESCRIPTION
## Summary
- 为 opencode 模板增加 monkeycode-ultra 前缀模型的 forceReasoning 配置
- 移除 monkeycode-ultra 相关 compat 输出
- 增加 opencode 配置渲染测试覆盖普通模型和 monkeycode-ultra 前缀模型

## Test Plan
- go test -count=1 ./biz/task/usecase