### PR TITLE
ci: 增加离线包手动构建工作流

### DIFF
--- a/.github/workflows/offline-package.yml
+++ b/.github/workflows/offline-package.yml
@@ -1,0 +1,64 @@
+name: Offline Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker_version:
+        description: Docker static binary version
+        required: false
+        default: "29.0.4"
+
+jobs:
+  package:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            artifact: monkeycode-offline-linux-amd64
+          - arch: arm64
+            artifact: monkeycode-offline-linux-arm64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.8"
+          cache-dependency-path: backend/go.sum
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Build frontend dist
+        working-directory: frontend
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run build
+          rm -rf docker/dist
+          mkdir -p docker/dist
+          cp -R dist/. docker/dist/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build offline package
+        working-directory: backend
+        env:
+          ARCH: ${{ matrix.arch }}
+          DOCKER_VERSION: ${{ inputs.docker_version || '29.0.4' }}
+        run: ./scripts/build-offline-package.sh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: backend/dist/offline/${{ matrix.artifact }}.tgz
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- 新增 Offline Package 手动触发 GitHub Actions 工作流
- 支持 amd64 和 arm64 离线包矩阵构建
- 上传对应架构的离线包 artifact

## Test Plan
- python3 YAML 解析校验通过

## Note
- 本 PR 只包含 workflow 文件，用于让默认分支显示手动 Action。实际运行需要选择包含 backend/scripts/build-offline-package.sh 的业务分支。