### PR TITLE
fix: 过滤已关闭的平台 MCP 工具

### DIFF
--- a/backend/biz/setting/repo/mcp.go
+++ b/backend/biz/setting/repo/mcp.go
@@ -34,12 +34,22 @@ func NewMCPRepo(i *do.Injector) (domain.UserMCPRepo, error) {
 
 func (r *mcpRepo) ListUserUpstreams(ctx context.Context, uid uuid.UUID, _ domain.CursorReq) ([]*domain.MCPUpstream, error) {
 	rows, err := r.db.MCPUpstream.Query().
-		WithTools().
+		WithTools(func(tq *db.MCPToolQuery) {
+			tq.Where(
+				mcptool.Or(
+					mcptool.ScopeEQ(mcptool.ScopeUser),
+					mcptool.Enabled(true),
+				),
+			)
+		}).
 		WithUser().
 		Where(
 			mcpupstream.Or(
 				mcpupstream.UserID(uid),
-				mcpupstream.ScopeEQ(mcpupstream.ScopePlatform),
+				mcpupstream.And(
+					mcpupstream.ScopeEQ(mcpupstream.ScopePlatform),
+					mcpupstream.Enabled(true),
+				),
 			),
 		).
 		Order(mcpupstream.ByCreatedAt(sql.OrderDesc())).

--- a/backend/biz/setting/repo/mcp_test.go
+++ b/backend/biz/setting/repo/mcp_test.go
@@ -7,10 +7,113 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
+	"github.com/chaitin/MonkeyCode/backend/config"
 	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/db/enttest"
+	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/google/uuid"
 )
+
+func TestListUserUpstreamsSkipsDisabledPlatformResources(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:user-mcp-upstreams-disabled-tools?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	uid := uuid.New()
+	if _, err := client.User.Create().
+		SetID(uid).
+		SetName("tester").
+		SetRole(consts.UserRoleIndividual).
+		SetStatus(consts.UserStatusActive).
+		Save(ctx); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	upstreamID := uuid.New()
+	if _, err := client.MCPUpstream.Create().
+		SetID(upstreamID).
+		SetName("Platform Docs").
+		SetSlug("platform-docs").
+		SetScope("platform").
+		SetType("server").
+		SetURL("https://example.com/mcp").
+		SetHeaders(map[string]string{}).
+		Save(ctx); err != nil {
+		t.Fatalf("create upstream: %v", err)
+	}
+
+	enabledToolID := uuid.New()
+	if _, err := client.MCPTool.Create().
+		SetID(enabledToolID).
+		SetUpstreamID(upstreamID).
+		SetName("search_docs").
+		SetNamespacedName("platform-docs__search_docs").
+		SetScope("platform").
+		SetInputSchema(map[string]any{}).
+		SetEnabled(true).
+		Save(ctx); err != nil {
+		t.Fatalf("create enabled tool: %v", err)
+	}
+	disabledToolID := uuid.New()
+	if _, err := client.MCPTool.Create().
+		SetID(disabledToolID).
+		SetUpstreamID(upstreamID).
+		SetName("closed_docs").
+		SetNamespacedName("platform-docs__closed_docs").
+		SetScope("platform").
+		SetInputSchema(map[string]any{}).
+		SetEnabled(false).
+		Save(ctx); err != nil {
+		t.Fatalf("create disabled tool: %v", err)
+	}
+
+	disabledUpstreamID := uuid.New()
+	if _, err := client.MCPUpstream.Create().
+		SetID(disabledUpstreamID).
+		SetName("Closed Platform Docs").
+		SetSlug("closed-platform-docs").
+		SetScope("platform").
+		SetType("server").
+		SetURL("https://closed.example.com/mcp").
+		SetHeaders(map[string]string{}).
+		SetEnabled(false).
+		Save(ctx); err != nil {
+		t.Fatalf("create disabled upstream: %v", err)
+	}
+	disabledUpstreamToolID := uuid.New()
+	if _, err := client.MCPTool.Create().
+		SetID(disabledUpstreamToolID).
+		SetUpstreamID(disabledUpstreamID).
+		SetName("closed_upstream_search").
+		SetNamespacedName("closed-platform-docs__search_docs").
+		SetScope("platform").
+		SetInputSchema(map[string]any{}).
+		SetEnabled(true).
+		Save(ctx); err != nil {
+		t.Fatalf("create disabled upstream tool: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Server.BaseURL = "https://monkeycode.example"
+	repo := &mcpRepo{db: client, cfg: cfg}
+	upstreams, err := repo.ListUserUpstreams(ctx, uid, domain.CursorReq{})
+	if err != nil {
+		t.Fatalf("ListUserUpstreams() error = %v", err)
+	}
+	if len(upstreams) == 0 {
+		t.Fatal("upstreams is empty, want platform aggregate upstream")
+	}
+
+	gotTools := upstreams[0].Tools
+	if len(gotTools) != 1 {
+		t.Fatalf("platform tools count = %d, want 1", len(gotTools))
+	}
+	if gotTools[0].ID != enabledToolID {
+		t.Fatalf("platform tool id = %s, want enabled tool %s and not disabled tool %s or disabled upstream tool %s", gotTools[0].ID, enabledToolID, disabledToolID, disabledUpstreamToolID)
+	}
+}
 
 func TestDeleteUserUpstreamMarksDeletedAt(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- 在用户 MCP upstream 列表加载 tools 时过滤平台侧已关闭工具
- 保留用户侧 MCP 工具的展示能力，避免影响用户管理自己的工具开关
- 增加 repo 层回归测试覆盖平台关闭工具不出现在用户列表中

## Test Plan
- [x] go test ./biz/setting/... -count=1