### PR TITLE
ci: 调整离线包产物上传方式

### DIFF
--- a/.github/workflows/offline-package.yml
+++ b/.github/workflows/offline-package.yml
@@ -8,6 +8,9 @@ on:
         required: false
         default: "29.0.4"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   package:
     strategy:
@@ -54,11 +57,13 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
           DOCKER_VERSION: ${{ inputs.docker_version || '29.0.4' }}
+          PACKAGE_TGZ: "true"
         run: ./scripts/build-offline-package.sh
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: backend/dist/offline/${{ matrix.artifact }}.tgz
+          archive: false
           if-no-files-found: error


### PR DESCRIPTION
## 变更
- 离线包工作流设置 FORCE_JAVASCRIPT_ACTIONS_TO_NODE24，提前适配 GitHub Actions Node 24
- 构建脚本启用 PACKAGE_TGZ，直接产出 tgz
- upload-artifact 使用 archive: false，避免再包一层 zip

## 验证
- git diff --check

说明：本 PR 只更新 .github/workflows/offline-package.yml，方便先把手动工作流能力合入 main。