### PR TITLE
ci: 上传离线包到私有 OSS

### DIFF
--- a/.github/workflows/offline-package.yml
+++ b/.github/workflows/offline-package.yml
@@ -6,7 +6,11 @@ on:
       docker_version:
         description: Docker static binary version
         required: false
-        default: "29.0.4"
+        default: "29.5.0"
+      package_version:
+        description: Optional package version directory in OSS
+        required: false
+        default: ""
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -60,10 +64,43 @@ jobs:
           PACKAGE_TGZ: "true"
         run: ./scripts/build-offline-package.sh
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.artifact }}
-          path: backend/dist/offline/${{ matrix.artifact }}.tgz
-          archive: false
-          if-no-files-found: error
+      - name: Upload package to private OSS
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.OSS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+          AWS_DEFAULT_REGION: ${{ secrets.OSS_REGION || 'us-east-1' }}
+          AWS_EC2_METADATA_DISABLED: "true"
+          OSS_ENDPOINT: ${{ secrets.OSS_ENDPOINT }}
+          OSS_BUCKET: ${{ secrets.OSS_BUCKET }}
+          OSS_PREFIX: ${{ secrets.OSS_PREFIX }}
+          PACKAGE_VERSION: ${{ inputs.package_version }}
+          ARTIFACT_NAME: ${{ matrix.artifact }}
+        run: |
+          set -eu
+
+          for required in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY OSS_ENDPOINT OSS_BUCKET; do
+            eval "value=\${$required:-}"
+            if [ -z "$value" ]; then
+              echo "::error::$required is required"
+              exit 1
+            fi
+          done
+
+          package_file="backend/dist/offline/${ARTIFACT_NAME}.tgz"
+          if [ ! -f "$package_file" ]; then
+            echo "::error::package file not found: $package_file"
+            exit 1
+          fi
+
+          version="${PACKAGE_VERSION:-}"
+          if [ -z "$version" ]; then
+            version="${GITHUB_REF_NAME}-${GITHUB_SHA}"
+          fi
+
+          object_prefix="${OSS_PREFIX:-monkeycode/offline-package}"
+          object_prefix="${object_prefix%/}/$version"
+          object_uri="s3://${OSS_BUCKET}/${object_prefix}/${ARTIFACT_NAME}.tgz"
+
+          aws configure set default.s3.addressing_style path
+          aws s3 cp "$package_file" "$object_uri" --endpoint-url "$OSS_ENDPOINT" --only-show-errors
+          echo "package uploaded: $object_uri"


### PR DESCRIPTION
## 变更说明
- 将离线包 workflow 的产物发布从 GitHub artifact 改为 S3 兼容私有 OSS 上传
- 新增手动输入 package_version，用于控制 OSS 目录
- 上传时使用 path-style，兼容 RustFS / 私有 S3 / OSS 网关

## 需要配置的 Secrets
- OSS_ENDPOINT
- OSS_BUCKET
- OSS_ACCESS_KEY_ID
- OSS_ACCESS_KEY_SECRET
- OSS_REGION，可选
- OSS_PREFIX，可选，默认 monkeycode/offline-package

## 验证
- git diff --check