### PR TITLE
feat: 迁移成员与审计日志接口

### DIFF
--- a/backend/biz/team/handler/http/v1/audit.go
+++ b/backend/biz/team/handler/http/v1/audit.go
@@ -1,0 +1,63 @@
+package v1
+
+import (
+	"log/slog"
+
+	"github.com/GoYoko/web"
+	"github.com/samber/do"
+
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/errcode"
+	"github.com/chaitin/MonkeyCode/backend/middleware"
+)
+
+// AuditHandler 审计日志处理器
+type AuditHandler struct {
+	logger  *slog.Logger
+	usecase domain.AuditUsecase
+}
+
+// NewAuditHandler 创建审计日志处理器
+func NewAuditHandler(i *do.Injector) (*AuditHandler, error) {
+	w := do.MustInvoke[*web.Web](i)
+	logger := do.MustInvoke[*slog.Logger](i)
+	usecase := do.MustInvoke[domain.AuditUsecase](i)
+	auth := do.MustInvoke[*middleware.AuthMiddleware](i)
+	targetActive := do.MustInvoke[*middleware.TargetActiveMiddleware](i)
+
+	h := &AuditHandler{
+		logger:  logger.With("component", "handler.audit"),
+		usecase: usecase,
+	}
+
+	v1 := w.Group("/api/v1/teams/audits")
+	v1.GET("", web.BindHandler(h.ListAudits), auth.TeamAuth(), targetActive.TargetActive())
+
+	return h, nil
+}
+
+// ListAudits 查询审计日志列表
+//
+//	@Summary		查询审计日志
+//	@Description	查询审计日志列表，支持条件过滤和分页
+//	@Tags			【Team管理员】审计日志
+//	@Accept			json
+//	@Produce		json
+//	@Security		MonkeyCodeAITeamAuth
+//	@Param			req	query		domain.ListAuditsRequest	false	"查询参数"
+//	@Success		200	{object}	domain.ListAuditsResponse
+//	@Failure		401	{object}	web.Resp	"未授权"
+//	@Failure		500	{object}	web.Resp	"服务器内部错误"
+//	@Router			/api/v1/teams/audits [get]
+func (h *AuditHandler) ListAudits(c *web.Context, req domain.ListAuditsRequest) error {
+	if req.Limit <= 0 {
+		req.Limit = 10000
+	}
+	teamUser := middleware.GetTeamUser(c)
+	resp, err := h.usecase.ListAudits(c.Request().Context(), teamUser, &req)
+	if err != nil {
+		h.logger.ErrorContext(c.Request().Context(), "failed to list audits", "error", err)
+		return errcode.ErrInternalServer
+	}
+	return c.Success(resp)
+}

--- a/backend/biz/team/handler/http/v1/audit_route_test.go
+++ b/backend/biz/team/handler/http/v1/audit_route_test.go
@@ -1,0 +1,43 @@
+package v1
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/GoYoko/web"
+	"github.com/samber/do"
+
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/middleware"
+)
+
+func TestNewAuditHandlerRegistersListRoute(t *testing.T) {
+	injector := do.New()
+	w := web.New()
+	do.ProvideValue(injector, w)
+	do.ProvideValue(injector, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	do.ProvideValue[domain.AuditUsecase](injector, &auditUsecaseStub{})
+	do.ProvideValue(injector, &middleware.AuthMiddleware{})
+	do.ProvideValue(injector, middleware.NewTargetActiveMiddleware(slog.New(slog.NewTextHandler(io.Discard, nil)), nil))
+
+	if _, err := NewAuditHandler(injector); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, route := range w.Routes() {
+		if route.Method == "GET" && route.Path == "/api/v1/teams/audits" {
+			return
+		}
+	}
+	t.Fatal("GET /api/v1/teams/audits route is not registered")
+}
+
+type auditUsecaseStub struct {
+	domain.AuditUsecase
+}
+
+func (s *auditUsecaseStub) ListAudits(ctx context.Context, teamUser *domain.TeamUser, req *domain.ListAuditsRequest) (*domain.ListAuditsResponse, error) {
+	return &domain.ListAuditsResponse{}, nil
+}

--- a/backend/biz/team/register.go
+++ b/backend/biz/team/register.go
@@ -14,6 +14,7 @@ func ProvideTeam(i *do.Injector) {
 	do.Provide(i, repo.NewAuditRepo)
 	do.Provide(i, usecase.NewTeamGroupUserUsecase)
 	do.Provide(i, usecase.NewAuditUsecase)
+	do.Provide(i, v1.NewAuditHandler)
 	do.Provide(i, repo.NewTeamModelRepo)
 	do.Provide(i, usecase.NewTeamModelUsecase)
 	do.Provide(i, v1.NewTeamModelHandler)
@@ -32,6 +33,7 @@ func InvokeTeam(i *do.Injector) {
 	if err != nil {
 		panic(err)
 	}
+	do.MustInvoke[*v1.AuditHandler](i)
 	do.MustInvoke[*v1.TeamModelHandler](i)
 	do.MustInvoke[*v1.TeamImageHandler](i)
 	do.MustInvoke[*v1.TeamHostHandler](i)

--- a/backend/biz/user/handler/v1/auth.go
+++ b/backend/biz/user/handler/v1/auth.go
@@ -23,6 +23,7 @@ type AuthHandler struct {
 	config         *config.Config
 	logger         *slog.Logger
 	usecase        domain.UserUsecase
+	teamUsecase    domain.TeamGroupUserUsecase
 	redis          *redis.Client
 	authMiddleware *middleware.AuthMiddleware
 	captcha        *captcha.Captcha
@@ -34,6 +35,7 @@ func NewAuthHandler(i *do.Injector) (*AuthHandler, error) {
 	cfg := do.MustInvoke[*config.Config](i)
 	logger := do.MustInvoke[*slog.Logger](i)
 	usecase := do.MustInvoke[domain.UserUsecase](i)
+	teamUsecase := do.MustInvoke[domain.TeamGroupUserUsecase](i)
 	redisClient := do.MustInvoke[*redis.Client](i)
 	auth := do.MustInvoke[*middleware.AuthMiddleware](i)
 	targetActive := do.MustInvoke[*middleware.TargetActiveMiddleware](i)
@@ -43,6 +45,7 @@ func NewAuthHandler(i *do.Injector) (*AuthHandler, error) {
 		config:         cfg,
 		logger:         logger.With("module", "auth.handler"),
 		usecase:        usecase,
+		teamUsecase:    teamUsecase,
 		redis:          redisClient,
 		authMiddleware: auth,
 		captcha:        captchaSvc,
@@ -61,6 +64,7 @@ func NewAuthHandler(i *do.Injector) (*AuthHandler, error) {
 	v1.PUT("/passwords/change", web.BindHandler(h.ChangePassword), auth.Check(), targetActive.TargetActive())
 	v1.GET("/status", web.BaseHandler(h.Status), auth.Check(), targetActive.TargetActive())
 	v1.POST("/logout", web.BaseHandler(h.Logout), auth.Auth(), targetActive.TargetActive())
+	v1.GET("/members", web.BindHandler(h.MemberList), auth.Auth(), targetActive.TargetActive())
 
 	// 邮箱绑定接口
 	v1.PUT("/email/bind-request", web.BindHandler(h.SendBindEmailVerification), auth.Auth(), targetActive.TargetActive())
@@ -132,6 +136,60 @@ func (h *AuthHandler) Update(c *web.Context, req domain.UpdateUserReq) error {
 		Message: "success",
 		Success: true,
 	})
+}
+
+// MemberList 获取当前用户所在团队的普通成员列表
+//
+//	@Summary		获取团队成员列表
+//	@Description	获取当前用户所在团队的普通成员列表
+//	@Tags			【用户】用户
+//	@Accept			json
+//	@Produce		json
+//	@Security		MonkeyCodeAIAuth
+//	@Success		200	{object}	web.Resp{data=domain.TeamMembersResp}	"成功"
+//	@Failure		401	{object}	web.Resp								"未授权"
+//	@Failure		500	{object}	web.Resp								"服务器内部错误"
+//	@Router			/api/v1/users/members [get]
+func (h *AuthHandler) MemberList(c *web.Context, _ domain.UserMemberListReq) error {
+	user := middleware.GetUser(c)
+	if user == nil {
+		return errcode.ErrUnauthorized
+	}
+
+	teamInfo, err := h.usecase.GetUserWithTeams(c.Request().Context(), user.ID)
+	if err != nil {
+		return err
+	}
+
+	users := make(domain.TeamMembersResp, 0)
+	seen := make(map[uuid.UUID]struct{})
+	for _, team := range teamInfo.Teams {
+		teamUser := &domain.TeamUser{
+			User: user,
+			Team: &domain.Team{
+				ID:   team.TeamID,
+				Name: team.TeamName,
+			},
+		}
+		resp, err := h.teamUsecase.MemberList(c.Request().Context(), teamUser, &domain.MemberListReq{
+			Role: consts.TeamMemberRoleUser,
+		})
+		if err != nil {
+			return err
+		}
+		for _, member := range resp.Members {
+			if member.User == nil {
+				continue
+			}
+			if _, ok := seen[member.User.ID]; ok {
+				continue
+			}
+			seen[member.User.ID] = struct{}{}
+			users = append(users, member.User)
+		}
+	}
+
+	return c.Success(users)
 }
 
 // ChangePassword 修改密码接口

--- a/backend/biz/user/handler/v1/members_route_test.go
+++ b/backend/biz/user/handler/v1/members_route_test.go
@@ -1,0 +1,59 @@
+package v1
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/GoYoko/web"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/samber/do"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/middleware"
+	"github.com/chaitin/MonkeyCode/backend/pkg/captcha"
+)
+
+func TestNewAuthHandlerRegistersMembersRoute(t *testing.T) {
+	injector := do.New()
+	w := web.New()
+	do.ProvideValue(injector, w)
+	do.ProvideValue(injector, &config.Config{})
+	do.ProvideValue(injector, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	do.ProvideValue(injector, (*redis.Client)(nil))
+	do.ProvideValue[domain.UserUsecase](injector, &membersUserUsecaseStub{})
+	do.ProvideValue[domain.TeamGroupUserUsecase](injector, &membersTeamUsecaseStub{})
+	do.ProvideValue(injector, &middleware.AuthMiddleware{})
+	do.ProvideValue(injector, middleware.NewTargetActiveMiddleware(slog.New(slog.NewTextHandler(io.Discard, nil)), nil))
+	do.ProvideValue(injector, captcha.NewCaptcha())
+
+	if _, err := NewAuthHandler(injector); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, route := range w.Routes() {
+		if route.Method == "GET" && route.Path == "/api/v1/users/members" {
+			return
+		}
+	}
+	t.Fatal("GET /api/v1/users/members route is not registered")
+}
+
+type membersUserUsecaseStub struct {
+	domain.UserUsecase
+}
+
+func (s *membersUserUsecaseStub) GetUserWithTeams(ctx context.Context, userID uuid.UUID) (*domain.TeamUserInfo, error) {
+	return &domain.TeamUserInfo{}, nil
+}
+
+type membersTeamUsecaseStub struct {
+	domain.TeamGroupUserUsecase
+}
+
+func (s *membersTeamUsecaseStub) MemberList(ctx context.Context, teamUser *domain.TeamUser, req *domain.MemberListReq) (*domain.MemberListResp, error) {
+	return &domain.MemberListResp{}, nil
+}

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -124,6 +124,98 @@
                 }
             }
         },
+        "/api/v1/teams/audits": {
+            "get": {
+                "security": [
+                    {
+                        "MonkeyCodeAITeamAuth": []
+                    }
+                ],
+                "description": "查询审计日志列表，支持条件过滤和分页",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "【Team管理员】审计日志"
+                ],
+                "summary": "查询审计日志",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "name": "created_at_end",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "created_at_start",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "operation",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "request",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "response",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "source_ip",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "user_agent",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "name": "user_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ListAuditsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未授权",
+                        "schema": {
+                            "$ref": "#/definitions/web.Resp"
+                        }
+                    },
+                    "500": {
+                        "description": "服务器内部错误",
+                        "schema": {
+                            "$ref": "#/definitions/web.Resp"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/teams/groups": {
             "get": {
                 "security": [
@@ -1961,6 +2053,69 @@
                 }
             }
         },
+        "/api/v1/teams/users/with-password": {
+            "post": {
+                "security": [
+                    {
+                        "MonkeyCodeAITeamAuth": []
+                    }
+                ],
+                "description": "创建团队成员，后端生成初始密码并只在响应中返回一次",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "【Team 管理员】分组成员管理"
+                ],
+                "summary": "创建团队成员并返回初始密码",
+                "parameters": [
+                    {
+                        "description": "请求参数",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/domain.AddTeamUserReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "成功",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/web.Resp"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/domain.AddTeamUserWithPasswordResp"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "未授权",
+                        "schema": {
+                            "$ref": "#/definitions/web.Resp"
+                        }
+                    },
+                    "500": {
+                        "description": "服务器内部错误",
+                        "schema": {
+                            "$ref": "#/definitions/web.Resp"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/teams/users/{user_id}": {
             "put": {
                 "security": [
@@ -2026,6 +2181,60 @@
                         "description": "服务器内部错误",
                         "schema": {
                             "$ref": "#/definitions/web.Resp"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/users": {
+            "put": {
+                "security": [
+                    {
+                        "MonkeyCodeAIAuth": []
+                    }
+                ],
+                "description": "更新用户昵称和头像",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "【用户】用户"
+                ],
+                "summary": "更新用户信息",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "昵称",
+                        "name": "name",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "OSS 头像地址",
+                        "name": "avatar_url",
+                        "in": "formData"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/web.Resp"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/domain.UpdateUserResp"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     }
                 }
@@ -4920,6 +5129,61 @@
                 }
             }
         },
+        "/api/v1/users/members": {
+            "get": {
+                "security": [
+                    {
+                        "MonkeyCodeAIAuth": []
+                    }
+                ],
+                "description": "获取当前用户所在团队的普通成员列表",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "【用户】用户"
+                ],
+                "summary": "获取团队成员列表",
+                "responses": {
+                    "200": {
+                        "description": "成功",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/web.Resp"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/domain.User"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "未授权",
+                        "schema": {
+                            "$ref": "#/definitions/web.Resp"
+                        }
+                    },
+                    "500": {
+                        "description": "服务器内部错误",
+                        "schema": {
+                            "$ref": "#/definitions/web.Resp"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/users/models": {
             "get": {
                 "security": [
@@ -7083,6 +7347,52 @@
                 }
             }
         },
+        "/api/v1/users/subscription": {
+            "get": {
+                "security": [
+                    {
+                        "MonkeyCodeAIAuth": []
+                    }
+                ],
+                "description": "开源版固定返回基础订阅状态",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "【用户】会员"
+                ],
+                "summary": "查询当前会员状态",
+                "responses": {
+                    "200": {
+                        "description": "成功",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/web.Resp"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/domain.SubscriptionResp"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "未授权，用户未登录",
+                        "schema": {
+                            "$ref": "#/definitions/web.Resp"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/users/tasks": {
             "get": {
                 "security": [
@@ -8196,6 +8506,23 @@
                 }
             }
         },
+        "domain.AddTeamUserWithPasswordResp": {
+            "type": "object",
+            "properties": {
+                "passwords": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.TeamUserPassword"
+                    }
+                },
+                "users": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.TeamUser"
+                    }
+                }
+            }
+        },
         "domain.ApplyPortReq": {
             "type": "object",
             "required": [
@@ -8216,6 +8543,35 @@
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "domain.Audit": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "operation": {
+                    "type": "string"
+                },
+                "request": {
+                    "type": "string"
+                },
+                "response": {
+                    "type": "string"
+                },
+                "source_ip": {
+                    "type": "string"
+                },
+                "user": {
+                    "$ref": "#/definitions/domain.User"
+                },
+                "user_agent": {
+                    "type": "string"
                 }
             }
         },
@@ -8984,6 +9340,20 @@
                 }
             }
         },
+        "domain.ListAuditsResponse": {
+            "type": "object",
+            "properties": {
+                "audits": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Audit"
+                    }
+                },
+                "page": {
+                    "$ref": "#/definitions/db.Cursor"
+                }
+            }
+        },
         "domain.ListCollaboratorsResp": {
             "type": "object",
             "properties": {
@@ -9359,6 +9729,62 @@
                 }
             }
         },
+        "domain.ModelBrief": {
+            "type": "object",
+            "properties": {
+                "access_level": {
+                    "type": "string"
+                },
+                "context_limit": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "interface_type": {
+                    "$ref": "#/definitions/consts.InterfaceType"
+                },
+                "is_free": {
+                    "type": "boolean"
+                },
+                "last_check_at": {
+                    "type": "integer"
+                },
+                "last_check_error": {
+                    "type": "string"
+                },
+                "last_check_success": {
+                    "type": "boolean"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "output_limit": {
+                    "type": "integer"
+                },
+                "owner": {
+                    "$ref": "#/definitions/domain.Owner"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "temperature": {
+                    "type": "number"
+                },
+                "thinking_enabled": {
+                    "type": "boolean"
+                },
+                "updated_at": {
+                    "type": "integer"
+                },
+                "weight": {
+                    "type": "integer"
+                }
+            }
+        },
         "domain.NotifyChannel": {
             "type": "object",
             "properties": {
@@ -9669,7 +10095,7 @@
                     "$ref": "#/definitions/consts.LogStore"
                 },
                 "model": {
-                    "$ref": "#/definitions/domain.Model"
+                    "$ref": "#/definitions/domain.ModelBrief"
                 },
                 "repo_filename": {
                     "type": "string"
@@ -9916,6 +10342,23 @@
                 }
             }
         },
+        "domain.SubscriptionResp": {
+            "type": "object",
+            "properties": {
+                "auto_renew": {
+                    "type": "boolean"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "plan": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.Task": {
             "type": "object",
             "properties": {
@@ -9953,7 +10396,7 @@
                     "$ref": "#/definitions/consts.LogStore"
                 },
                 "model": {
-                    "$ref": "#/definitions/domain.Model"
+                    "$ref": "#/definitions/domain.ModelBrief"
                 },
                 "repo_filename": {
                     "type": "string"
@@ -10277,6 +10720,17 @@
                 },
                 "user": {
                     "$ref": "#/definitions/domain.User"
+                }
+            }
+        },
+        "domain.TeamUserPassword": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
                 }
             }
         },
@@ -10630,6 +11084,20 @@
                 }
             }
         },
+        "domain.UpdateUserResp": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                },
+                "user": {
+                    "$ref": "#/definitions/domain.User"
+                }
+            }
+        },
         "domain.UpdateVMReq": {
             "type": "object",
             "required": [
@@ -10764,7 +11232,7 @@
                 "conditions": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/types.Condition"
+                        "$ref": "#/definitions/github_com_chaitin_MonkeyCode_backend_ent_types.Condition"
                     }
                 },
                 "cores": {
@@ -10811,6 +11279,29 @@
                 },
                 "version": {
                     "type": "string"
+                }
+            }
+        },
+        "github_com_chaitin_MonkeyCode_backend_ent_types.Condition": {
+            "type": "object",
+            "properties": {
+                "last_transition_time": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "progress": {
+                    "type": "integer"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.ConditionStatus"
+                },
+                "type": {
+                    "$ref": "#/definitions/types.ConditionType"
                 }
             }
         },
@@ -10954,29 +11445,6 @@
                 "VirtualMachineStatusOffline",
                 "VirtualMachineStatusHibernated"
             ]
-        },
-        "types.Condition": {
-            "type": "object",
-            "properties": {
-                "last_transition_time": {
-                    "type": "integer"
-                },
-                "message": {
-                    "type": "string"
-                },
-                "progress": {
-                    "type": "integer"
-                },
-                "reason": {
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.ConditionStatus"
-                },
-                "type": {
-                    "$ref": "#/definitions/types.ConditionType"
-                }
-            }
         },
         "types.ConditionStatus": {
             "type": "integer",

--- a/backend/domain/user.go
+++ b/backend/domain/user.go
@@ -184,6 +184,9 @@ func (r *ResetUserPasswordEmailReq) Validate() error {
 // TeamMembersResp 团队成员列表响应
 type TeamMembersResp []*User
 
+// UserMemberListReq 用户侧团队成员列表请求
+type UserMemberListReq struct{}
+
 // ActivateReq 激活请求
 type ActivateReq struct {
 	InviteCode string `json:"invite_code" validate:"required"`


### PR DESCRIPTION
## Summary
- 新增用户侧 GET /api/v1/users/members，复用团队成员查询能力并按用户去重
- 新增团队审计日志 GET /api/v1/teams/audits handler，并接入 team 模块 DI
- 补充路由注册测试并更新 swagger.json

## Test Plan
- go test ./... -count=1
- make swag
- git diff --check