### PR TITLE
fix: 限制团队成员新增数量

### DIFF
--- a/backend/biz/team/repo/user.go
+++ b/backend/biz/team/repo/user.go
@@ -73,6 +73,10 @@ func (r *TeamGroupUserRepo) Create(ctx context.Context, teamID uuid.UUID, req *d
 
 // CreateUsers 创建团队成员
 func (r *TeamGroupUserRepo) CreateUsers(ctx context.Context, teamID uuid.UUID, req *domain.AddTeamUserReq) ([]*db.User, error) {
+	if err := r.checkTeamMemberLimit(ctx, teamID, req.Emails); err != nil {
+		return nil, err
+	}
+
 	var users []*db.User
 
 	for _, emailAddr := range req.Emails {
@@ -130,6 +134,10 @@ func (r *TeamGroupUserRepo) CreateUsers(ctx context.Context, teamID uuid.UUID, r
 }
 
 func (r *TeamGroupUserRepo) CreateUsersWithPassword(ctx context.Context, teamID uuid.UUID, req *domain.AddTeamUserWithPasswordReq) ([]*db.User, error) {
+	if err := r.checkTeamMemberLimit(ctx, teamID, req.Emails); err != nil {
+		return nil, err
+	}
+
 	var users []*db.User
 
 	for _, emailAddr := range req.Emails {
@@ -213,6 +221,10 @@ func (r *TeamGroupUserRepo) ResetPassword(ctx context.Context, userID uuid.UUID,
 
 // CreateAdmin 创建团队管理员
 func (r *TeamGroupUserRepo) CreateAdmin(ctx context.Context, teamID uuid.UUID, req *domain.AddTeamAdminReq) (*db.User, error) {
+	if err := r.checkTeamMemberLimit(ctx, teamID, []string{req.Email}); err != nil {
+		return nil, err
+	}
+
 	// 检查邮箱是否已注册
 	existingUser, err := r.db.User.Query().Where(user.EmailEQ(req.Email)).First(ctx)
 	if err == nil && existingUser != nil {
@@ -257,6 +269,66 @@ func (r *TeamGroupUserRepo) CreateAdmin(ctx context.Context, teamID uuid.UUID, r
 		return nil, err
 	}
 	return newUser, nil
+}
+
+func (r *TeamGroupUserRepo) checkTeamMemberLimit(ctx context.Context, teamID uuid.UUID, emails []string) error {
+	team, err := r.db.Team.Get(ctx, teamID)
+	if err != nil {
+		return err
+	}
+	if team.MemberLimit <= 0 {
+		return nil
+	}
+
+	existingCount, err := r.db.TeamMember.Query().
+		Where(teammember.TeamIDEQ(teamID)).
+		Count(ctx)
+	if err != nil {
+		return err
+	}
+
+	addCount, err := r.countNewTeamMembers(ctx, teamID, emails)
+	if err != nil {
+		return err
+	}
+	if existingCount+addCount > team.MemberLimit {
+		return errcode.ErrTeamMemberLimitExceeded
+	}
+	return nil
+}
+
+func (r *TeamGroupUserRepo) countNewTeamMembers(ctx context.Context, teamID uuid.UUID, emails []string) (int, error) {
+	seen := make(map[string]struct{}, len(emails))
+	count := 0
+
+	for _, emailAddr := range emails {
+		if _, ok := seen[emailAddr]; ok {
+			continue
+		}
+		seen[emailAddr] = struct{}{}
+
+		existingUser, err := r.db.User.Query().Where(user.EmailEQ(emailAddr)).First(ctx)
+		if err != nil {
+			if db.IsNotFound(err) {
+				count++
+				continue
+			}
+			return 0, err
+		}
+		exists, err := r.db.TeamMember.Query().
+			Where(
+				teammember.TeamIDEQ(teamID),
+				teammember.UserIDEQ(existingUser.ID),
+			).
+			Exist(ctx)
+		if err != nil {
+			return 0, err
+		}
+		if !exists {
+			count++
+		}
+	}
+	return count, nil
 }
 
 // Update 更新团队分组

--- a/backend/biz/team/repo/user_test.go
+++ b/backend/biz/team/repo/user_test.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/db/teamimage"
 	"github.com/chaitin/MonkeyCode/backend/db/teammember"
 	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/errcode"
 	"github.com/chaitin/MonkeyCode/backend/pkg/crypto"
 )
 
@@ -197,6 +199,108 @@ func TestCreateUsersWithPasswordStoresHashedPassword(t *testing.T) {
 	}
 }
 
+func TestCreateUsersRejectsWhenTeamMemberLimitExceeded(t *testing.T) {
+	ctx := context.Background()
+	client := newTeamRepoTestDB(t)
+	repo := &TeamGroupUserRepo{
+		db:     client,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	teamID := createTeamAtLimit(t, client)
+
+	users, err := repo.CreateUsers(ctx, teamID, &domain.AddTeamUserReq{
+		Emails: []string{"new-member@example.com"},
+	})
+
+	if !errors.Is(err, errcode.ErrTeamMemberLimitExceeded) {
+		t.Fatalf("err = %v, want %v", err, errcode.ErrTeamMemberLimitExceeded)
+	}
+	if len(users) != 0 {
+		t.Fatalf("users len = %d, want 0", len(users))
+	}
+	assertTeamMemberCount(t, client, teamID, 1)
+}
+
+func TestCreateUsersWithPasswordRejectsWhenTeamMemberLimitExceeded(t *testing.T) {
+	ctx := context.Background()
+	client := newTeamRepoTestDB(t)
+	repo := &TeamGroupUserRepo{
+		db:     client,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	teamID := createTeamAtLimit(t, client)
+
+	users, err := repo.CreateUsersWithPassword(ctx, teamID, &domain.AddTeamUserWithPasswordReq{
+		Emails: []string{"new-member@example.com"},
+		Passwords: map[string]string{
+			"new-member@example.com": "Abcdef123456",
+		},
+	})
+
+	if !errors.Is(err, errcode.ErrTeamMemberLimitExceeded) {
+		t.Fatalf("err = %v, want %v", err, errcode.ErrTeamMemberLimitExceeded)
+	}
+	if len(users) != 0 {
+		t.Fatalf("users len = %d, want 0", len(users))
+	}
+	assertTeamMemberCount(t, client, teamID, 1)
+}
+
+func TestCreateAdminRejectsWhenTeamMemberLimitExceeded(t *testing.T) {
+	ctx := context.Background()
+	client := newTeamRepoTestDB(t)
+	repo := &TeamGroupUserRepo{
+		db:     client,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	teamID := createTeamAtLimit(t, client)
+	if _, err := client.User.Create().
+		SetID(uuid.New()).
+		SetName("new-admin").
+		SetEmail("new-admin@example.com").
+		SetPassword("hashed").
+		SetRole(consts.UserRoleIndividual).
+		SetStatus(consts.UserStatusActive).
+		Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	admin, err := repo.CreateAdmin(ctx, teamID, &domain.AddTeamAdminReq{
+		Email: "new-admin@example.com",
+		Name:  "new-admin",
+	})
+
+	if !errors.Is(err, errcode.ErrTeamMemberLimitExceeded) {
+		t.Fatalf("err = %v, want %v", err, errcode.ErrTeamMemberLimitExceeded)
+	}
+	if admin != nil {
+		t.Fatalf("admin = %v, want nil", admin)
+	}
+	assertTeamMemberCount(t, client, teamID, 1)
+}
+
+func TestCreateUsersSkipsExistingTeamMembersWithoutConsumingLimit(t *testing.T) {
+	ctx := context.Background()
+	client := newTeamRepoTestDB(t)
+	repo := &TeamGroupUserRepo{
+		db:     client,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	teamID := createTeamAtLimit(t, client)
+
+	users, err := repo.CreateUsers(ctx, teamID, &domain.AddTeamUserReq{
+		Emails: []string{"existing@example.com"},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(users) != 0 {
+		t.Fatalf("users len = %d, want 0", len(users))
+	}
+	assertTeamMemberCount(t, client, teamID, 1)
+}
+
 func TestResetPasswordStoresHashedPassword(t *testing.T) {
 	ctx := context.Background()
 	client := newTeamRepoTestDB(t)
@@ -236,5 +340,51 @@ func TestResetPasswordStoresHashedPassword(t *testing.T) {
 	}
 	if err := crypto.VerifyPassword(updated.Password, "old-password"); err == nil {
 		t.Fatal("old password should not remain valid")
+	}
+}
+
+func createTeamAtLimit(t *testing.T, client *db.Client) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	teamID := uuid.New()
+	userID := uuid.New()
+	if _, err := client.Team.Create().
+		SetID(teamID).
+		SetName("MonkeyCode").
+		SetMemberLimit(1).
+		Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.User.Create().
+		SetID(userID).
+		SetName("existing").
+		SetEmail("existing@example.com").
+		SetPassword("hashed").
+		SetRole(consts.UserRoleSubAccount).
+		SetStatus(consts.UserStatusActive).
+		Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.TeamMember.Create().
+		SetID(uuid.New()).
+		SetTeamID(teamID).
+		SetUserID(userID).
+		SetRole(consts.TeamMemberRoleUser).
+		Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return teamID
+}
+
+func assertTeamMemberCount(t *testing.T, client *db.Client, teamID uuid.UUID, want int) {
+	t.Helper()
+	count, err := client.TeamMember.Query().
+		Where(teammember.TeamIDEQ(teamID)).
+		Count(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != want {
+		t.Fatalf("team member count = %d, want %d", count, want)
 	}
 }

--- a/backend/errcode/errcode_test.go
+++ b/backend/errcode/errcode_test.go
@@ -1,0 +1,19 @@
+package errcode_test
+
+import (
+	"testing"
+
+	"github.com/GoYoko/web/locale"
+	"github.com/chaitin/MonkeyCode/backend/errcode"
+	"golang.org/x/text/language"
+)
+
+func TestTeamMemberLimitExceededHasChineseMessage(t *testing.T) {
+	localizer := locale.NewLocalizerWithFile(language.Chinese, errcode.LocalFS, []string{"locale.zh.toml", "locale.en.toml"})
+
+	got := localizer.Message("zh", "err-team-member-limit-exceeded", nil)
+
+	if got != "团队成员数量已达上限" {
+		t.Fatalf("message = %q, want %q", got, "团队成员数量已达上限")
+	}
+}

--- a/backend/errcode/locale.zh.toml
+++ b/backend/errcode/locale.zh.toml
@@ -89,7 +89,7 @@ other = "重复绑定仓库"
 other = "该 Git 身份已被项目使用，无法删除"
 
 [err-team-member-limit-exceeded]
-other = "团队成员数量超出限制"
+other = "团队成员数量已达上限"
 
 [err-invalid-password]
 other = "密码无效"


### PR DESCRIPTION
## 变更内容
- 在团队普通成员、带密码成员、管理员新增路径前统一校验成员上限
- 已在团队内的成员不会重复消耗名额
- 补充成员上限超出与重复成员跳过的仓储层测试

## 测试
- go test ./biz/team/...