### PR TITLE
fix(installer): 修复升级备份 ClickHouse 符号链接失败

### DIFF
--- a/backend/pkg/installer/deploy/snapshot.go
+++ b/backend/pkg/installer/deploy/snapshot.go
@@ -49,12 +49,15 @@ func centerSnapshotPaths() []string {
 }
 
 func copyPathIfExists(src, dst string) error {
-	info, err := os.Stat(src)
+	info, err := os.Lstat(src)
 	if os.IsNotExist(err) {
 		return nil
 	}
 	if err != nil {
 		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return copySymlink(src, dst)
 	}
 	if info.IsDir() {
 		return copyDir(src, dst)
@@ -77,11 +80,28 @@ func copyDir(src, dst string) error {
 		if err != nil {
 			return err
 		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return copySymlink(path, target)
+		}
 		if entry.IsDir() {
 			return os.MkdirAll(target, info.Mode())
 		}
 		return copyFileMode(path, target, info.Mode())
 	})
+}
+
+func copySymlink(src, dst string) error {
+	link, err := os.Readlink(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dst); err != nil {
+		return err
+	}
+	return os.Symlink(link, dst)
 }
 
 func copyFileMode(src, dst string, mode os.FileMode) error {

--- a/backend/pkg/installer/deploy/snapshot_test.go
+++ b/backend/pkg/installer/deploy/snapshot_test.go
@@ -40,3 +40,50 @@ func TestCreateAndRestoreCenterSnapshot(t *testing.T) {
 		t.Fatalf(".env = %q", got)
 	}
 }
+
+func TestCreateCenterSnapshotPreservesDirectorySymlink(t *testing.T) {
+	installDir := t.TempDir()
+	storeDir := filepath.Join(installDir, "data", "clickhouse", "store", "abc")
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(storeDir, "data.bin"), []byte("rows"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dbDir := filepath.Join(installDir, "data", "clickhouse", "data", "monkeycode%2Dai")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../../store/abc", filepath.Join(dbDir, "task_logs")); err != nil {
+		t.Fatal(err)
+	}
+
+	backupDir := filepath.Join(installDir, ".monkeycode", "backups", "snap")
+	if _, err := CreateCenterSnapshot(installDir, backupDir); err != nil {
+		t.Fatal(err)
+	}
+
+	link := filepath.Join(backupDir, "data", "clickhouse", "data", "monkeycode%2Dai", "task_logs")
+	got, err := os.Readlink(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "../../store/abc" {
+		t.Fatalf("symlink target = %q, want %q", got, "../../store/abc")
+	}
+
+	if err := os.RemoveAll(filepath.Join(installDir, "data")); err != nil {
+		t.Fatal(err)
+	}
+	if err := RestoreCenterSnapshot(installDir, CenterSnapshot{Path: backupDir}); err != nil {
+		t.Fatal(err)
+	}
+	restored := filepath.Join(installDir, "data", "clickhouse", "data", "monkeycode%2Dai", "task_logs")
+	got, err = os.Readlink(restored)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "../../store/abc" {
+		t.Fatalf("restored symlink target = %q, want %q", got, "../../store/abc")
+	}
+}


### PR DESCRIPTION
## Summary
- 使用 `Lstat` 识别快照路径中的符号链接，避免升级备份时解引用 ClickHouse Atomic 表目录链接。
- 新增 `copySymlink`，在备份和恢复时保留 symlink 本身。
- 增加 ClickHouse `data/<db>/<table>` 目录 symlink 的备份与恢复回归测试。

## Test Plan
- [x] `cd backend && go test ./...`
- [x] `git diff --check`
