### PR TITLE
修复终端前端断开后的日志风暴

### DIFF
--- a/backend/biz/host/handler/v1/host.go
+++ b/backend/biz/host/handler/v1/host.go
@@ -27,6 +27,19 @@ type HostHandler struct {
 	logger      *slog.Logger
 }
 
+type terminalWriter interface {
+	WriteJSON(any) error
+}
+
+func writeTerminalMessage(ctx context.Context, cancel context.CancelFunc, w terminalWriter, msg domain.VMTerminalMessage, logger *slog.Logger) bool {
+	if err := w.WriteJSON(msg); err != nil {
+		logger.With("error", err).ErrorContext(ctx, "failed to write message to frontend")
+		cancel()
+		return false
+	}
+	return true
+}
+
 func NewHostHandler(i *do.Injector) (*HostHandler, error) {
 	w := do.MustInvoke[*web.Web](i)
 	auth := do.MustInvoke[*middleware.AuthMiddleware](i)
@@ -217,7 +230,10 @@ func (h *HostHandler) JoinTerminal(c *web.Context, req domain.JoinTerminalReq) e
 
 	h.logger.InfoContext(c.Request().Context(), "websocket connection established", "col", col, "row", row)
 
-	shell, shared, err := h.usecase.JoinTerminal(c.Request().Context(), &req)
+	ctx, cancel := context.WithCancel(c.Request().Context())
+	defer cancel()
+
+	shell, shared, err := h.usecase.JoinTerminal(ctx, &req)
 	if err != nil {
 		h.logger.With("req", req).ErrorContext(c.Request().Context(), "failed to connect to vm terminal 验证密码失败", "error", err)
 		wsConn.WriteJSON(domain.VMTerminalMessage{
@@ -228,8 +244,6 @@ func (h *HostHandler) JoinTerminal(c *web.Context, req domain.JoinTerminalReq) e
 	}
 	defer shell.Stop()
 
-	ctx, cancel := context.WithCancel(c.Request().Context())
-	defer cancel()
 	go h.terminalPing(ctx, cancel, wsConn, req.TerminalID)
 
 	go func() {
@@ -294,10 +308,12 @@ func (h *HostHandler) JoinTerminal(c *web.Context, req domain.JoinTerminalReq) e
 				b = fmt.Appendf(nil, `{"username": "%s"}`, shared.User.Name)
 			}
 
-			wsConn.WriteJSON(domain.VMTerminalMessage{
+			if !writeTerminalMessage(ctx, cancel, wsConn, domain.VMTerminalMessage{
 				Type: domain.VMTerminalMessageTypeConnected,
 				Data: string(b),
-			})
+			}, h.logger) {
+				return
+			}
 		}
 
 		if len(td.Data) > 0 {
@@ -306,8 +322,8 @@ func (h *HostHandler) JoinTerminal(c *web.Context, req domain.JoinTerminalReq) e
 				Type: domain.VMTerminalMessageTypeData,
 				Data: data,
 			}
-			if err := wsConn.WriteJSON(msg); err != nil {
-				h.logger.With("error", err).ErrorContext(ctx, "failed to write message to frontend")
+			if !writeTerminalMessage(ctx, cancel, wsConn, *msg, h.logger) {
+				return
 			}
 		}
 
@@ -320,8 +336,8 @@ func (h *HostHandler) JoinTerminal(c *web.Context, req domain.JoinTerminalReq) e
 					Type: domain.VMTerminalMessageTypeResize,
 					Data: string(b),
 				}
-				if err := wsConn.WriteJSON(msg); err != nil {
-					h.logger.With("error", err).ErrorContext(ctx, "failed to write message to frontend")
+				if !writeTerminalMessage(ctx, cancel, wsConn, *msg, h.logger) {
+					return
 				}
 			}
 		}
@@ -331,8 +347,8 @@ func (h *HostHandler) JoinTerminal(c *web.Context, req domain.JoinTerminalReq) e
 				Type: domain.VMTerminalMessageTypeError,
 				Data: *td.Error,
 			}
-			if err := wsConn.WriteJSON(msg); err != nil {
-				h.logger.With("error", err).ErrorContext(ctx, "failed to write message to frontend")
+			if !writeTerminalMessage(ctx, cancel, wsConn, *msg, h.logger) {
+				return
 			}
 			cancel()
 		}
@@ -472,10 +488,12 @@ func (h *HostHandler) ConnectVMTerminal(c *web.Context, req domain.TerminalReq) 
 				logger.ErrorContext(ctx, "failed to marshal success message", "error", err)
 				b = fmt.Appendf(nil, `{"username": "%s"}`, user.Name)
 			}
-			wsConn.WriteJSON(domain.VMTerminalMessage{
+			if !writeTerminalMessage(ctx, cancel, wsConn, domain.VMTerminalMessage{
 				Type: domain.VMTerminalMessageTypeConnected,
 				Data: string(b),
-			})
+			}, logger) {
+				return
+			}
 		}
 
 		if len(td.Data) > 0 {
@@ -484,8 +502,8 @@ func (h *HostHandler) ConnectVMTerminal(c *web.Context, req domain.TerminalReq) 
 				Type: domain.VMTerminalMessageTypeData,
 				Data: data,
 			}
-			if err := wsConn.WriteJSON(msg); err != nil {
-				logger.With("error", err).ErrorContext(ctx, "failed to write message to frontend")
+			if !writeTerminalMessage(ctx, cancel, wsConn, *msg, logger) {
+				return
 			}
 		}
 
@@ -498,8 +516,8 @@ func (h *HostHandler) ConnectVMTerminal(c *web.Context, req domain.TerminalReq) 
 					Type: domain.VMTerminalMessageTypeResize,
 					Data: string(b),
 				}
-				if err := wsConn.WriteJSON(msg); err != nil {
-					logger.With("error", err).ErrorContext(ctx, "failed to write message to frontend")
+				if !writeTerminalMessage(ctx, cancel, wsConn, *msg, logger) {
+					return
 				}
 			}
 		}
@@ -508,8 +526,8 @@ func (h *HostHandler) ConnectVMTerminal(c *web.Context, req domain.TerminalReq) 
 				Type: domain.VMTerminalMessageTypeError,
 				Data: *td.Error,
 			}
-			if err := wsConn.WriteJSON(msg); err != nil {
-				logger.With("error", err).ErrorContext(ctx, "failed to write message to frontend")
+			if !writeTerminalMessage(ctx, cancel, wsConn, *msg, logger) {
+				return
 			}
 
 			cancel()

--- a/backend/biz/host/handler/v1/terminal_write_test.go
+++ b/backend/biz/host/handler/v1/terminal_write_test.go
@@ -1,0 +1,36 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+type failingTerminalWriter struct{}
+
+func (failingTerminalWriter) WriteJSON(any) error {
+	return errors.New("broken pipe")
+}
+
+func TestWriteTerminalMessageCancelsOnFrontendWriteError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ok := writeTerminalMessage(
+		ctx,
+		cancel,
+		failingTerminalWriter{},
+		domain.VMTerminalMessage{Type: domain.VMTerminalMessageTypeData},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	if ok {
+		t.Fatal("writeTerminalMessage returned true, want false")
+	}
+	if ctx.Err() == nil {
+		t.Fatal("context was not canceled after frontend write failure")
+	}
+}


### PR DESCRIPTION
## 变更
- 前端 websocket 写失败时立即取消终端转发上下文，停止继续向断开的连接写数据
- JoinTerminal 使用可取消上下文创建 taskflow shell，确保取消能传递到 taskflow client
- 增加写失败后取消上下文的单元测试

## 验证
- go test ./biz/host/handler/v1 -count=1