### PR TITLE
feat: 支持配置任务创建请求缓存时间

### DIFF
--- a/backend/biz/task/usecase/create_req_ttl_test.go
+++ b/backend/biz/task/usecase/create_req_ttl_test.go
@@ -1,0 +1,25 @@
+package usecase
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+)
+
+func TestCreateReqTTLUsesConfiguredSeconds(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Task.CreateReqTTLSeconds = 3600
+
+	if got := createReqTTL(cfg); got != time.Hour {
+		t.Fatalf("createReqTTL() = %s, want 1h", got)
+	}
+}
+
+func TestCreateReqTTLFallsBackToDefault(t *testing.T) {
+	cfg := &config.Config{}
+
+	if got := createReqTTL(cfg); got != 10*time.Minute {
+		t.Fatalf("createReqTTL() = %s, want 10m", got)
+	}
+}

--- a/backend/biz/task/usecase/gittask.go
+++ b/backend/biz/task/usecase/gittask.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
@@ -123,7 +122,7 @@ func (g *GitTaskUsecase) Create(ctx context.Context, req domain.CreateGitTaskReq
 			return vm, err
 		}
 		reqKey := fmt.Sprintf("task:create_req:%s", t.ID.String())
-		if err := g.redis.Set(ctx, reqKey, string(b), 10*time.Minute).Err(); err != nil {
+		if err := g.redis.Set(ctx, reqKey, string(b), createReqTTL(g.cfg)).Err(); err != nil {
 			g.logger.WarnContext(ctx, "failed to store CreateTaskReq in Redis", "error", err)
 		}
 

--- a/backend/biz/task/usecase/task.go
+++ b/backend/biz/task/usecase/task.go
@@ -36,6 +36,8 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/templates"
 )
 
+const defaultCreateReqTTL = 10 * time.Minute
+
 // TaskUsecase 任务业务逻辑实现
 type TaskUsecase struct {
 	cfg                   *config.Config
@@ -547,7 +549,7 @@ func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.
 
 		mcps := a.buildMCPConfigs(t.ID, token)
 
-		// 存储 CreateTaskReq 到 Redis（10 分钟过期），供 Lifecycle Manager 消费
+		// 存储 CreateTaskReq 到 Redis，供 Lifecycle Manager 消费
 		createTaskReq := &taskflow.CreateTaskReq{
 			ID:           t.ID,
 			VMID:         vm.ID,
@@ -570,7 +572,7 @@ func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.
 			return vm, err
 		}
 		reqKey := fmt.Sprintf("task:create_req:%s", t.ID.String())
-		if err := a.redis.Set(ctx, reqKey, string(b), 10*time.Minute).Err(); err != nil {
+		if err := a.redis.Set(ctx, reqKey, string(b), createReqTTL(a.cfg)).Err(); err != nil {
 			a.logger.WarnContext(ctx, "failed to store CreateTaskReq in Redis", "error", err)
 		}
 
@@ -619,6 +621,13 @@ func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.
 	}
 
 	return result, nil
+}
+
+func createReqTTL(cfg *config.Config) time.Duration {
+	if cfg == nil || cfg.Task.CreateReqTTLSeconds <= 0 {
+		return defaultCreateReqTTL
+	}
+	return time.Duration(cfg.Task.CreateReqTTLSeconds) * time.Second
 }
 
 func (a *TaskUsecase) refreshCreatedTaskState(ctx context.Context, taskID uuid.UUID, vmID string) {

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -153,11 +153,12 @@ type HostInstaller struct {
 
 // Task 任务相关配置
 type Task struct {
-	LogLimit         int    `mapstructure:"log_limit"`          // Loki tail 日志 limit
-	TaskerTTLSeconds int    `mapstructure:"tasker_ttl_seconds"` // Tasker 状态机 TTL（秒）
-	ImageID          string `mapstructure:"image_id"`           // 默认镜像 ID
-	Core             int    `mapstructure:"core"`               // VM CPU 核数
-	Memory           uint64 `mapstructure:"memory"`             // VM 内存（字节）
+	LogLimit            int    `mapstructure:"log_limit"`              // Loki tail 日志 limit
+	TaskerTTLSeconds    int    `mapstructure:"tasker_ttl_seconds"`     // Tasker 状态机 TTL（秒）
+	CreateReqTTLSeconds int    `mapstructure:"create_req_ttl_seconds"` // 创建任务请求 Redis TTL（秒）
+	ImageID             string `mapstructure:"image_id"`               // 默认镜像 ID
+	Core                int    `mapstructure:"core"`                   // VM CPU 核数
+	Memory              uint64 `mapstructure:"memory"`                 // VM 内存（字节）
 }
 
 // TaskSummary 任务摘要生成配置
@@ -281,6 +282,7 @@ func Init(dir string) (*Config, error) {
 	v.SetDefault("taskflow.grpc_url", "")
 	v.SetDefault("task.at_keyword", "")
 	v.SetDefault("task.host_ids", []string{})
+	v.SetDefault("task.create_req_ttl_seconds", 600)
 	v.SetDefault("mcp_hub.enabled", false)
 	v.SetDefault("mcp_hub.url", "")
 	v.SetDefault("mcp_hub.token", "")

--- a/backend/config/oss_config_test.go
+++ b/backend/config/oss_config_test.go
@@ -10,6 +10,7 @@ func TestObjectStorageDefaults(t *testing.T) {
 	t.Setenv("MCAI_OBJECT_STORAGE_MAX_SIZE", "")
 	t.Setenv("MCAI_OBJECT_STORAGE_TEMP_PREFIX", "")
 	t.Setenv("MCAI_TASKFLOW_GRPC_URL", "")
+	t.Setenv("MCAI_TASK_CREATE_REQ_TTL_SECONDS", "")
 
 	cfg, err := Init(t.TempDir())
 	if err != nil {
@@ -42,6 +43,9 @@ func TestObjectStorageDefaults(t *testing.T) {
 	if cfg.TaskFlow.GrpcURL != "" {
 		t.Fatalf("taskflow.grpc_url = %q, want empty", cfg.TaskFlow.GrpcURL)
 	}
+	if cfg.Task.CreateReqTTLSeconds != 600 {
+		t.Fatalf("task.create_req_ttl_seconds = %d, want 600", cfg.Task.CreateReqTTLSeconds)
+	}
 	if !cfg.StaticFiles.Enabled {
 		t.Fatal("static_files.enabled default = false, want true")
 	}
@@ -56,5 +60,17 @@ func TestObjectStorageDefaults(t *testing.T) {
 	}
 	if cfg.HostInstaller.BundlePath != "installer/{{.arch}}/host.tgz" {
 		t.Fatalf("host_installer.bundle_path = %q", cfg.HostInstaller.BundlePath)
+	}
+}
+
+func TestTaskCreateReqTTLCanBeConfiguredByEnv(t *testing.T) {
+	t.Setenv("MCAI_TASK_CREATE_REQ_TTL_SECONDS", "3600")
+
+	cfg, err := Init(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Task.CreateReqTTLSeconds != 3600 {
+		t.Fatalf("task.create_req_ttl_seconds = %d, want 3600", cfg.Task.CreateReqTTLSeconds)
 	}
 }

--- a/backend/config/server/config.yaml.example
+++ b/backend/config/server/config.yaml.example
@@ -54,6 +54,9 @@ vm_idle:
   # VM 回收前，非微信公众号渠道（钉钉/飞书等）的提前预警时长（秒），<=0 视为禁用；省略则使用 3600（1h）
   recycle_warn_default_lead_seconds: 3600
 
+task:
+  create_req_ttl_seconds: 600
+
 clickhouse:
   addr: ""
   database: ""

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -144,6 +144,7 @@ services:
       MCAI_SERVER_BASE_URL: http://${REMOTE_IP}:${NGINX_PORT:-80}
       MCAI_LLM_PROXY_BASE_URL: http://${REMOTE_IP}:${NGINX_PORT:-80}
       MCAI_HOST_INSTALLER_MODE: offline
+      MCAI_TASK_CREATE_REQ_TTL_SECONDS: 3600
       MCAI_DATABASE_MASTER: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@monkeycode-ai-db:5432/${POSTGRES_DB}?sslmode=disable&timezone=Asia/Shanghai
       MCAI_REDIS_HOST: monkeycode-ai-redis
       MCAI_REDIS_PASS: ${REDIS_PASSWORD}

--- a/backend/pkg/lifecycle/README.md
+++ b/backend/pkg/lifecycle/README.md
@@ -284,7 +284,7 @@ mgr := lifecycle.NewManager[string, OrderState, OrderMetadata](
 1. TaskUsecase.Create()
    ├─ 创建任务记录（数据库）
    ├─ 创建 VM（taskflow）
-   ├─ 存储 CreateTaskReq 到 Redis（10 分钟过期）
+   ├─ 存储 CreateTaskReq 到 Redis（按 task.create_req_ttl_seconds 配置过期，默认 10 分钟）
    │   key: task:create_req:{taskID}
    ├─ taskMgr.Transition(taskID, TaskStatePending, meta)
    └─ vmMgr.Transition(vmID, VMStatePending, meta)
@@ -310,9 +310,9 @@ func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.
         // 2. 创建 VM
         vm := a.taskflow.VirtualMachiner().Create(...)
 
-        // 3. 临时存储 CreateTaskReq（10 分钟过期）
+        // 3. 临时存储 CreateTaskReq（按 task.create_req_ttl_seconds 配置过期）
         reqKey := fmt.Sprintf("task:create_req:%s", task.ID)
-        a.redis.Set(ctx, reqKey, createReq, 10*time.Minute)
+        a.redis.Set(ctx, reqKey, createReq, createReqTTL(a.cfg))
 
         // 4. 初始化状态（Transition 会自动触发 Hook）
         taskMeta := lifecycle.TaskMetadata{TaskID: t.ID, UserID: user.ID.String()}


### PR DESCRIPTION
## 概要
- 新增 `task.create_req_ttl_seconds` 配置，默认 600 秒。
- 普通任务和 Git Review 任务写入 `task:create_req:{taskID}` 时统一使用配置 TTL。
- 私有化部署 compose 覆盖为 3600 秒，并同步示例配置和 lifecycle 文档。

## 验证
- `go test ./config ./biz/task/usecase ./pkg/lifecycle -count=1`
