### PR TITLE
feat: 补充 VM 活跃回调接口

### DIFF
--- a/backend/biz/host/handler/v1/internal.go
+++ b/backend/biz/host/handler/v1/internal.go
@@ -17,6 +17,7 @@ import (
 	"github.com/samber/do"
 
 	gituc "github.com/chaitin/MonkeyCode/backend/biz/git/usecase"
+	vmidle "github.com/chaitin/MonkeyCode/backend/biz/vmidle/usecase"
 	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/domain"
@@ -45,6 +46,7 @@ type InternalHostHandler struct {
 	taskConns      *ws.TaskConn
 	projectUsecase domain.ProjectUsecase
 	tokenProvider  *gituc.TokenProvider
+	idleRefresher  vmidle.VMIdleRefresher
 }
 
 type taskLogStoreRepo interface {
@@ -72,6 +74,7 @@ func NewInternalHostHandler(i *do.Injector) (*InternalHostHandler, error) {
 		taskConns:      do.MustInvoke[*ws.TaskConn](i),
 		projectUsecase: do.MustInvoke[domain.ProjectUsecase](i),
 		tokenProvider:  do.MustInvoke[*gituc.TokenProvider](i),
+		idleRefresher:  do.MustInvoke[vmidle.VMIdleRefresher](i),
 	}
 
 	g := w.Group("/internal")
@@ -85,10 +88,16 @@ func NewInternalHostHandler(i *do.Injector) (*InternalHostHandler, error) {
 	g.POST("/git-credential", web.BindHandler(h.GitCredential))
 	g.GET("/vm/list", web.BaseHandler(h.VMList))
 	g.POST("/vm/batch-env-vm", web.BindHandler(h.BatchGetVmIDsByEnvIDs))
+	g.POST("/vm/activity", web.BindHandler(h.VMActivity))
 	g.POST("/task-log-store", web.BindHandler(h.GetTaskLogStore))
 	g.POST("/task-stream-ips", web.BindHandler(h.GetTaskStreamIPs))
 
 	return h, nil
+}
+
+type VMActivityReq struct {
+	VMID         string `json:"vm_id"`
+	LastActiveAt int64  `json:"last_active_at"`
 }
 
 // ReportHostInfo 上报宿主机信息
@@ -104,6 +113,17 @@ func (h *InternalHostHandler) ReportHostInfo(c *web.Context, host taskflow.Host)
 func (h *InternalHostHandler) ReportVirtualMachine(c *web.Context, vm taskflow.VirtualMachine) error {
 	if err := h.repo.UpsertVirtualMachine(context.Background(), &vm); err != nil {
 		h.logger.ErrorContext(context.Background(), "upsert virtual machine failed", "error", err)
+		return err
+	}
+	return c.Success(nil)
+}
+
+func (h *InternalHostHandler) VMActivity(c *web.Context, req VMActivityReq) error {
+	if strings.TrimSpace(req.VMID) == "" {
+		return errors.New("vm_id is required")
+	}
+	if err := h.idleRefresher.Refresh(c.Request().Context(), req.VMID); err != nil {
+		h.logger.WarnContext(c.Request().Context(), "failed to refresh vm idle timers on activity", "vm_id", req.VMID, "error", err)
 		return err
 	}
 	return c.Success(nil)

--- a/backend/biz/host/handler/v1/internal_vm_activity_test.go
+++ b/backend/biz/host/handler/v1/internal_vm_activity_test.go
@@ -1,0 +1,78 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/GoYoko/web"
+)
+
+func TestInternalHostHandler_VMActivityRefreshesIdleTimer(t *testing.T) {
+	refresher := &internalVMIdleRefresherStub{ch: make(chan string, 1)}
+	h := &InternalHostHandler{
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		idleRefresher: refresher,
+	}
+
+	body := `{"vm_id":"vm-activity-1","last_active_at":1710000000}`
+	w := web.New()
+	w.POST("/internal/vm/activity", web.BindHandler(h.VMActivity))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/internal/vm/activity", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	select {
+	case got := <-refresher.ch:
+		if got != "vm-activity-1" {
+			t.Fatalf("refreshed vm id = %q, want %q", got, "vm-activity-1")
+		}
+	default:
+		t.Fatal("expected idle refresher to be called")
+	}
+}
+
+func TestInternalHostHandler_VMActivityRejectsEmptyVMID(t *testing.T) {
+	h := &InternalHostHandler{
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		idleRefresher: &internalVMIdleRefresherStub{ch: make(chan string, 1)},
+	}
+
+	w := web.New()
+	w.POST("/internal/vm/activity", web.BindHandler(h.VMActivity))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/internal/vm/activity", strings.NewReader(`{"last_active_at":1710000000}`))
+	req.Header.Set("Content-Type", "application/json")
+	w.Echo().ServeHTTP(rec, req)
+
+	var resp web.Resp
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal resp: %v, body = %s", err, rec.Body.String())
+	}
+	if resp.Code == 0 {
+		t.Fatalf("response = %+v, want error", resp)
+	}
+}
+
+type internalVMIdleRefresherStub struct {
+	ch chan string
+}
+
+func (s *internalVMIdleRefresherStub) Refresh(_ context.Context, vmID string) error {
+	select {
+	case s.ch <- vmID:
+	default:
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- 注册 `/internal/vm/activity` taskflow 回调接口
- 接收 agent 侧 VM 活跃上报后刷新 VM 空闲计时器
- 增加 handler 测试覆盖正常刷新和空 VMID 错误

## Test Plan
- `cd backend && go test ./biz/host/handler/v1`
- `cd backend && go test ./...`