### PR TITLE
feat: 增加团队管理项目任务对话统计

### DIFF
--- a/backend/biz/team/handler/http/v1/dashboard.go
+++ b/backend/biz/team/handler/http/v1/dashboard.go
@@ -23,6 +23,11 @@ func NewTeamDashboardHandler(i *do.Injector) (*TeamDashboardHandler, error) {
 	g := w.Group("/api/v1/teams/dashboard")
 	g.Use(auth.TeamAuth())
 	g.GET("", web.BindHandler(h.Overview))
+	teams := w.Group("/api/v1/teams")
+	teams.Use(auth.TeamAuth())
+	teams.GET("/projects", web.BindHandler(h.ListProjects))
+	teams.GET("/tasks", web.BindHandler(h.ListTasks))
+	teams.GET("/conversations", web.BindHandler(h.ListConversations))
 
 	return h, nil
 }
@@ -43,6 +48,69 @@ func NewTeamDashboardHandler(i *do.Injector) (*TeamDashboardHandler, error) {
 func (h *TeamDashboardHandler) Overview(c *web.Context, req domain.TeamDashboardReq) error {
 	teamUser := middleware.GetTeamUser(c)
 	resp, err := h.usecase.Overview(c.Request().Context(), teamUser, req)
+	if err != nil {
+		return err
+	}
+	return c.Success(resp)
+}
+
+// ListProjects 获取团队项目列表
+//
+//	@Summary		获取团队项目列表
+//	@Description	获取当前团队成员创建的项目列表
+//	@Tags			【Team 管理员】团队项目
+//	@Accept			json
+//	@Produce		json
+//	@Security		MonkeyCodeAITeamAuth
+//	@Param			cursor	query		string										false	"分页游标"
+//	@Param			limit	query		int											false	"每页数量"
+//	@Success		200		{object}	web.Resp{data=domain.TeamProjectListResp}	"成功"
+//	@Router			/api/v1/teams/projects [get]
+func (h *TeamDashboardHandler) ListProjects(c *web.Context, req domain.TeamDashboardListReq) error {
+	teamUser := middleware.GetTeamUser(c)
+	resp, err := h.usecase.ListProjects(c.Request().Context(), teamUser, req)
+	if err != nil {
+		return err
+	}
+	return c.Success(resp)
+}
+
+// ListTasks 获取团队任务列表
+//
+//	@Summary		获取团队任务列表
+//	@Description	获取当前团队成员创建的任务列表
+//	@Tags			【Team 管理员】团队任务
+//	@Accept			json
+//	@Produce		json
+//	@Security		MonkeyCodeAITeamAuth
+//	@Param			cursor	query		string									false	"分页游标"
+//	@Param			limit	query		int										false	"每页数量"
+//	@Success		200		{object}	web.Resp{data=domain.TeamTaskListResp}	"成功"
+//	@Router			/api/v1/teams/tasks [get]
+func (h *TeamDashboardHandler) ListTasks(c *web.Context, req domain.TeamDashboardListReq) error {
+	teamUser := middleware.GetTeamUser(c)
+	resp, err := h.usecase.ListTasks(c.Request().Context(), teamUser, req)
+	if err != nil {
+		return err
+	}
+	return c.Success(resp)
+}
+
+// ListConversations 获取团队对话列表
+//
+//	@Summary		获取团队对话列表
+//	@Description	获取当前团队任务日志中的 user-input 对话列表
+//	@Tags			【Team 管理员】团队对话
+//	@Accept			json
+//	@Produce		json
+//	@Security		MonkeyCodeAITeamAuth
+//	@Param			cursor	query		string											false	"分页游标"
+//	@Param			limit	query		int												false	"每页数量"
+//	@Success		200		{object}	web.Resp{data=domain.TeamConversationListResp}	"成功"
+//	@Router			/api/v1/teams/conversations [get]
+func (h *TeamDashboardHandler) ListConversations(c *web.Context, req domain.TeamDashboardListReq) error {
+	teamUser := middleware.GetTeamUser(c)
+	resp, err := h.usecase.ListConversations(c.Request().Context(), teamUser, req)
 	if err != nil {
 		return err
 	}

--- a/backend/biz/team/repo/dashboard.go
+++ b/backend/biz/team/repo/dashboard.go
@@ -2,9 +2,11 @@ package repo
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"math"
 	"sort"
+	"strconv"
 	"time"
 
 	"entgo.io/ent/dialect/sql"
@@ -13,6 +15,9 @@ import (
 
 	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/db/project"
+	"github.com/chaitin/MonkeyCode/backend/db/projectissue"
+	"github.com/chaitin/MonkeyCode/backend/db/projecttask"
 	"github.com/chaitin/MonkeyCode/backend/db/task"
 	"github.com/chaitin/MonkeyCode/backend/db/teamgroupmember"
 	"github.com/chaitin/MonkeyCode/backend/db/teammember"
@@ -26,17 +31,24 @@ type dashboardUsageReader interface {
 	QueryModelUsageTopUsers(ctx context.Context, q clickhouse.ModelUsageQuery, limit int) ([]clickhouse.ModelUsageTopUser, error)
 }
 
+type dashboardConversationReader interface {
+	QueryTeamConversationStats(ctx context.Context, q clickhouse.TeamConversationQuery) (clickhouse.TeamConversationStats, error)
+	QueryTeamConversations(ctx context.Context, q clickhouse.TeamConversationListQuery) (*clickhouse.TeamConversationListResult, error)
+}
+
 type TeamDashboardRepo struct {
-	db          *db.Client
-	usageReader dashboardUsageReader
-	logger      *slog.Logger
+	db                 *db.Client
+	usageReader        dashboardUsageReader
+	conversationReader dashboardConversationReader
+	logger             *slog.Logger
 }
 
 func NewTeamDashboardRepo(i *do.Injector) (domain.TeamDashboardRepo, error) {
 	return &TeamDashboardRepo{
-		db:          do.MustInvoke[*db.Client](i),
-		usageReader: do.MustInvoke[*clickhouse.Client](i),
-		logger:      do.MustInvoke[*slog.Logger](i).With("module", "repo.team_dashboard"),
+		db:                 do.MustInvoke[*db.Client](i),
+		usageReader:        do.MustInvoke[*clickhouse.Client](i),
+		conversationReader: do.MustInvoke[*clickhouse.Client](i),
+		logger:             do.MustInvoke[*slog.Logger](i).With("module", "repo.team_dashboard"),
 	}, nil
 }
 
@@ -48,6 +60,14 @@ func (r *TeamDashboardRepo) Overview(ctx context.Context, teamID uuid.UUID, req 
 	resp := &domain.TeamDashboardResp{}
 	resp.Metrics.TotalMembers = len(memberIDs)
 	if len(memberIDs) == 0 {
+		trendStart := req.TrendStart
+		if trendStart.IsZero() {
+			trendStart = startOfDay(req.End).AddDate(0, 0, -179)
+		}
+		points := fillDailyPoints(trendStart, req.End, nil)
+		resp.ProjectStats.DailyCreated = points
+		resp.TaskStats.DailyCreated = points
+		resp.ConversationStats.DailyCreated = points
 		return resp, nil
 	}
 	if err := r.fillMetrics(ctx, resp, teamID, memberIDs, req); err != nil {
@@ -57,6 +77,9 @@ func (r *TeamDashboardRepo) Overview(ctx context.Context, teamID uuid.UUID, req 
 		return nil, err
 	}
 	if err := r.fillInsights(ctx, resp, teamID, memberIDs, req); err != nil {
+		return nil, err
+	}
+	if err := r.fillRequiredStats(ctx, resp, memberIDs, req); err != nil {
 		return nil, err
 	}
 	return resp, nil
@@ -138,6 +161,153 @@ func (r *TeamDashboardRepo) fillMetrics(ctx context.Context, resp *domain.TeamDa
 		resp.Metrics.CacheHitRate = math.Round(float64(usage.CachedTokens)/float64(usage.InputTokens)*1000) / 10
 	}
 	return nil
+}
+
+func (r *TeamDashboardRepo) fillRequiredStats(ctx context.Context, resp *domain.TeamDashboardResp, memberIDs []uuid.UUID, req domain.TeamDashboardQuery) error {
+	todayStart := startOfDay(req.End)
+	start7d := todayStart.AddDate(0, 0, -6)
+	trendStart := req.TrendStart
+	if trendStart.IsZero() {
+		trendStart = todayStart.AddDate(0, 0, -179)
+	}
+	projectStats, err := r.projectStats(ctx, memberIDs, start7d, todayStart, trendStart, req.End)
+	if err != nil {
+		return err
+	}
+	taskStats, err := r.taskStats(ctx, memberIDs, start7d, todayStart, trendStart, req.End)
+	if err != nil {
+		return err
+	}
+	taskIDs, err := r.teamTaskIDStrings(ctx, memberIDs)
+	if err != nil {
+		return err
+	}
+	conversationStats, err := r.conversationStats(ctx, taskIDs, start7d, todayStart, trendStart, req.End)
+	if err != nil {
+		return err
+	}
+	resp.ProjectStats = projectStats
+	resp.TaskStats = taskStats
+	resp.ConversationStats = conversationStats
+	return nil
+}
+
+func (r *TeamDashboardRepo) projectStats(ctx context.Context, memberIDs []uuid.UUID, start7d, todayStart, trendStart, end time.Time) (domain.TeamProjectStats, error) {
+	var stats domain.TeamProjectStats
+	total, err := r.db.Project.Query().Where(project.UserIDIn(memberIDs...)).Count(ctx)
+	if err != nil {
+		return stats, err
+	}
+	active7d, err := r.activeProjectCount(ctx, memberIDs, start7d, end)
+	if err != nil {
+		return stats, err
+	}
+	activeToday, err := r.activeProjectCount(ctx, memberIDs, todayStart, end)
+	if err != nil {
+		return stats, err
+	}
+	daily, err := r.projectDailyCreated(ctx, memberIDs, trendStart, end)
+	if err != nil {
+		return stats, err
+	}
+	stats.Total = total
+	stats.Active7d = active7d
+	stats.ActiveToday = activeToday
+	stats.DailyCreated = daily
+	return stats, nil
+}
+
+func (r *TeamDashboardRepo) activeProjectCount(ctx context.Context, memberIDs []uuid.UUID, start, end time.Time) (int, error) {
+	return r.db.Project.Query().
+		Where(
+			project.UserIDIn(memberIDs...),
+			project.Or(
+				project.And(project.UpdatedAtGTE(start), project.UpdatedAtLT(end)),
+				project.HasProjectTasksWith(projecttask.HasTaskWith(task.LastActiveAtGTE(start), task.LastActiveAtLT(end))),
+				project.HasIssuesWith(projectissue.UpdatedAtGTE(start), projectissue.UpdatedAtLT(end)),
+			),
+		).
+		Count(ctx)
+}
+
+func (r *TeamDashboardRepo) projectDailyCreated(ctx context.Context, memberIDs []uuid.UUID, start, end time.Time) ([]domain.TeamDashboardTrendPoint, error) {
+	rows, err := r.db.Project.Query().
+		Where(project.UserIDIn(memberIDs...), project.CreatedAtGTE(start), project.CreatedAtLT(end)).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+	counts := make(map[string]int64)
+	for _, p := range rows {
+		counts[p.CreatedAt.Format("2006-01-02")]++
+	}
+	return fillDailyPoints(start, end, counts), nil
+}
+
+func (r *TeamDashboardRepo) taskStats(ctx context.Context, memberIDs []uuid.UUID, start7d, todayStart, trendStart, end time.Time) (domain.TeamTaskStats, error) {
+	var stats domain.TeamTaskStats
+	total, err := r.db.Task.Query().Where(task.UserIDIn(memberIDs...)).Count(ctx)
+	if err != nil {
+		return stats, err
+	}
+	active7d, err := r.db.Task.Query().Where(task.UserIDIn(memberIDs...), task.LastActiveAtGTE(start7d), task.LastActiveAtLT(end)).Count(ctx)
+	if err != nil {
+		return stats, err
+	}
+	activeToday, err := r.db.Task.Query().Where(task.UserIDIn(memberIDs...), task.LastActiveAtGTE(todayStart), task.LastActiveAtLT(end)).Count(ctx)
+	if err != nil {
+		return stats, err
+	}
+	daily, err := r.taskDailyCreated(ctx, memberIDs, trendStart, end)
+	if err != nil {
+		return stats, err
+	}
+	stats.Total = total
+	stats.Active7d = active7d
+	stats.ActiveToday = activeToday
+	stats.DailyCreated = daily
+	return stats, nil
+}
+
+func (r *TeamDashboardRepo) taskDailyCreated(ctx context.Context, memberIDs []uuid.UUID, start, end time.Time) ([]domain.TeamDashboardTrendPoint, error) {
+	rows, err := r.db.Task.Query().
+		Where(task.UserIDIn(memberIDs...), task.CreatedAtGTE(start), task.CreatedAtLT(end)).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+	counts := make(map[string]int64)
+	for _, t := range rows {
+		counts[t.CreatedAt.Format("2006-01-02")]++
+	}
+	return fillDailyPoints(start, end, counts), nil
+}
+
+func (r *TeamDashboardRepo) conversationStats(ctx context.Context, taskIDs []string, start7d, todayStart, trendStart, end time.Time) (domain.TeamConversationStats, error) {
+	var stats domain.TeamConversationStats
+	if r.conversationReader == nil || len(taskIDs) == 0 {
+		stats.DailyCreated = fillDailyPoints(trendStart, end, nil)
+		return stats, nil
+	}
+	raw, err := r.conversationReader.QueryTeamConversationStats(ctx, clickhouse.TeamConversationQuery{
+		TaskIDs:    taskIDs,
+		Start7d:    start7d,
+		TodayStart: todayStart,
+		TrendStart: trendStart,
+		End:        end,
+	})
+	if err != nil {
+		return stats, err
+	}
+	counts := make(map[string]int64)
+	for _, item := range raw.DailyCreated {
+		counts[item.Date] = item.Count
+	}
+	stats.Total = raw.Total
+	stats.Count7d = raw.Count7d
+	stats.CountToday = raw.CountToday
+	stats.DailyCreated = fillDailyPoints(trendStart, end, counts)
+	return stats, nil
 }
 
 func (r *TeamDashboardRepo) fillTrends(ctx context.Context, resp *domain.TeamDashboardResp, teamID uuid.UUID, memberIDs []uuid.UUID, req domain.TeamDashboardQuery) error {
@@ -329,6 +499,140 @@ func (r *TeamDashboardRepo) topUsers(ctx context.Context, teamID uuid.UUID, star
 	}, limit)
 }
 
+func (r *TeamDashboardRepo) ListProjects(ctx context.Context, teamID uuid.UUID, req domain.TeamDashboardListReq) (*domain.TeamProjectListResp, error) {
+	memberIDs, err := r.teamMemberIDs(ctx, teamID)
+	if err != nil {
+		return nil, err
+	}
+	resp := &domain.TeamProjectListResp{}
+	if len(memberIDs) == 0 {
+		return resp, nil
+	}
+	limit := normalizeDashboardLimit(req.Limit)
+	rows, page, err := r.db.Project.Query().
+		Where(project.UserIDIn(memberIDs...)).
+		WithUser().
+		WithIssues().
+		WithProjectTasks().
+		After(ctx, req.Cursor, limit)
+	if err != nil {
+		return nil, err
+	}
+	resp.Page = page
+	for _, p := range rows {
+		resp.Projects = append(resp.Projects, &domain.TeamProjectItem{
+			ID:         p.ID,
+			Name:       p.Name,
+			RepoURL:    p.RepoURL,
+			Branch:     p.Branch,
+			Creator:    userFromDB(p.Edges.User),
+			TaskCount:  len(p.Edges.ProjectTasks),
+			IssueCount: len(p.Edges.Issues),
+			CreatedAt:  p.CreatedAt.Unix(),
+			UpdatedAt:  p.UpdatedAt.Unix(),
+		})
+	}
+	return resp, nil
+}
+
+func (r *TeamDashboardRepo) ListTasks(ctx context.Context, teamID uuid.UUID, req domain.TeamDashboardListReq) (*domain.TeamTaskListResp, error) {
+	memberIDs, err := r.teamMemberIDs(ctx, teamID)
+	if err != nil {
+		return nil, err
+	}
+	resp := &domain.TeamTaskListResp{}
+	if len(memberIDs) == 0 {
+		return resp, nil
+	}
+	rows, page, err := r.db.Task.Query().
+		Where(task.UserIDIn(memberIDs...)).
+		WithUser().
+		WithProjectTasks(func(q *db.ProjectTaskQuery) {
+			q.WithProject()
+		}).
+		After(ctx, req.Cursor, normalizeDashboardLimit(req.Limit))
+	if err != nil {
+		return nil, err
+	}
+	resp.Page = page
+	for _, tk := range rows {
+		item := &domain.TeamTaskItem{
+			ID:           tk.ID,
+			Title:        tk.Title,
+			Content:      tk.Content,
+			Status:       string(tk.Status),
+			Kind:         string(tk.Kind),
+			Creator:      userFromDB(tk.Edges.User),
+			CreatedAt:    tk.CreatedAt.Unix(),
+			LastActiveAt: tk.LastActiveAt.Unix(),
+		}
+		if len(tk.Edges.ProjectTasks) > 0 && tk.Edges.ProjectTasks[0].Edges.Project != nil {
+			p := tk.Edges.ProjectTasks[0].Edges.Project
+			item.ProjectID = p.ID
+			item.ProjectName = p.Name
+		}
+		resp.Tasks = append(resp.Tasks, item)
+	}
+	return resp, nil
+}
+
+func (r *TeamDashboardRepo) ListConversations(ctx context.Context, teamID uuid.UUID, req domain.TeamDashboardListReq) (*domain.TeamConversationListResp, error) {
+	memberIDs, err := r.teamMemberIDs(ctx, teamID)
+	if err != nil {
+		return nil, err
+	}
+	resp := &domain.TeamConversationListResp{}
+	if len(memberIDs) == 0 || r.conversationReader == nil {
+		return resp, nil
+	}
+	taskIDs, err := r.teamTaskIDStrings(ctx, memberIDs)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := r.conversationReader.QueryTeamConversations(ctx, clickhouse.TeamConversationListQuery{
+		TaskIDs: taskIDs,
+		Cursor:  req.Cursor,
+		Limit:   normalizeDashboardLimit(req.Limit),
+	})
+	if err != nil {
+		return nil, err
+	}
+	taskUUIDs := make([]uuid.UUID, 0, len(raw.Rows))
+	for _, row := range raw.Rows {
+		id, err := uuid.Parse(row.TaskID)
+		if err == nil {
+			taskUUIDs = append(taskUUIDs, id)
+		}
+	}
+	taskMap, err := r.taskContextMap(ctx, taskUUIDs)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range raw.Rows {
+		taskID, err := uuid.Parse(row.TaskID)
+		if err != nil {
+			continue
+		}
+		payload := decodeConversationPayload(row.Data)
+		item := &domain.TeamConversationItem{
+			ID:              conversationID(row),
+			TaskID:          taskID,
+			Content:         payload.content,
+			AttachmentCount: len(payload.attachments),
+			CreatedAt:       row.TS.Unix(),
+		}
+		if ctxItem := taskMap[taskID]; ctxItem != nil {
+			item.TaskTitle = ctxItem.taskTitle
+			item.ProjectID = ctxItem.projectID
+			item.ProjectName = ctxItem.projectName
+			item.Creator = ctxItem.creator
+		}
+		resp.Conversations = append(resp.Conversations, item)
+	}
+	resp.Page = &db.Cursor{Cursor: raw.NextCursor, HasNextPage: raw.HasNextPage}
+	return resp, nil
+}
+
 func (r *TeamDashboardRepo) firstGroupName(ctx context.Context, userID uuid.UUID) string {
 	member, err := r.db.TeamGroupMember.Query().
 		Where(teamgroupmember.UserIDEQ(userID)).
@@ -340,6 +644,58 @@ func (r *TeamDashboardRepo) firstGroupName(ctx context.Context, userID uuid.UUID
 	return member.Edges.Group.Name
 }
 
+func (r *TeamDashboardRepo) teamTaskIDStrings(ctx context.Context, memberIDs []uuid.UUID) ([]string, error) {
+	ids, err := r.db.Task.Query().Where(task.UserIDIn(memberIDs...)).IDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]string, 0, len(ids))
+	for _, id := range ids {
+		result = append(result, id.String())
+	}
+	return result, nil
+}
+
+type taskContextItem struct {
+	taskTitle   string
+	projectID   uuid.UUID
+	projectName string
+	creator     *domain.User
+}
+
+func (r *TeamDashboardRepo) taskContextMap(ctx context.Context, taskIDs []uuid.UUID) (map[uuid.UUID]*taskContextItem, error) {
+	result := make(map[uuid.UUID]*taskContextItem)
+	if len(taskIDs) == 0 {
+		return result, nil
+	}
+	rows, err := r.db.Task.Query().
+		Where(task.IDIn(taskIDs...)).
+		WithUser().
+		WithProjectTasks(func(q *db.ProjectTaskQuery) {
+			q.WithProject()
+		}).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, tk := range rows {
+		item := &taskContextItem{
+			taskTitle: tk.Title,
+			creator:   userFromDB(tk.Edges.User),
+		}
+		if item.taskTitle == "" {
+			item.taskTitle = tk.Content
+		}
+		if len(tk.Edges.ProjectTasks) > 0 && tk.Edges.ProjectTasks[0].Edges.Project != nil {
+			p := tk.Edges.ProjectTasks[0].Edges.Project
+			item.projectID = p.ID
+			item.projectName = p.Name
+		}
+		result[tk.ID] = item
+	}
+	return result, nil
+}
+
 func dayKeys(start, end time.Time) []time.Time {
 	start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, start.Location())
 	var days []time.Time
@@ -347,4 +703,66 @@ func dayKeys(start, end time.Time) []time.Time {
 		days = append(days, d)
 	}
 	return days
+}
+
+func fillDailyPoints(start, end time.Time, counts map[string]int64) []domain.TeamDashboardTrendPoint {
+	days := dayKeys(start, end)
+	points := make([]domain.TeamDashboardTrendPoint, 0, len(days))
+	for _, day := range days {
+		date := day.Format("2006-01-02")
+		points = append(points, domain.TeamDashboardTrendPoint{
+			Date:  date,
+			Value: counts[date],
+		})
+	}
+	return points
+}
+
+func startOfDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+}
+
+func normalizeDashboardLimit(limit int) int {
+	if limit <= 0 {
+		return 20
+	}
+	if limit > 100 {
+		return 100
+	}
+	return limit
+}
+
+func userFromDB(src *db.User) *domain.User {
+	if src == nil {
+		return nil
+	}
+	return (&domain.User{}).From(src)
+}
+
+type conversationPayload struct {
+	content     string
+	attachments []domain.TaskAttachment
+}
+
+func decodeConversationPayload(raw string) conversationPayload {
+	var payload struct {
+		Encoding    string                  `json:"encoding"`
+		Content     string                  `json:"content"`
+		Attachments []domain.TaskAttachment `json:"attachments"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return conversationPayload{content: raw}
+	}
+	if payload.Encoding == "plaintext" {
+		return conversationPayload{content: payload.Content, attachments: payload.Attachments}
+	}
+	var legacy domain.TaskUserInputPayload
+	if err := json.Unmarshal([]byte(raw), &legacy); err == nil && len(legacy.Content) > 0 {
+		return conversationPayload{content: string(legacy.Content), attachments: legacy.Attachments}
+	}
+	return conversationPayload{content: payload.Content, attachments: payload.Attachments}
+}
+
+func conversationID(row clickhouse.TeamConversationRow) string {
+	return row.TaskID + ":" + row.TS.UTC().Format(time.RFC3339Nano) + ":" + strconv.FormatUint(uint64(row.TurnSeq), 10) + ":" + strconv.FormatUint(row.MsgSeqStart, 10)
 }

--- a/backend/biz/team/repo/dashboard_test.go
+++ b/backend/biz/team/repo/dashboard_test.go
@@ -176,6 +176,82 @@ func TestTeamDashboardOverviewUsesClickHouseUsageSummary(t *testing.T) {
 	}
 }
 
+func TestTeamDashboardOverviewIncludesProjectTaskConversationMetrics(t *testing.T) {
+	ctx := context.Background()
+	client := newDashboardRepoTestDB(t)
+	now := time.Date(2026, 6, 5, 15, 0, 0, 0, time.UTC)
+	teamID := uuid.New()
+	userID := uuid.New()
+	projectID := uuid.New()
+	taskID := uuid.New()
+	repo := &TeamDashboardRepo{
+		db:          client,
+		usageReader: &dashboardUsageReaderStub{},
+		conversationReader: &dashboardConversationReaderStub{
+			summary: clickhouse.TeamConversationStats{
+				Total:      3,
+				Count7d:    2,
+				CountToday: 1,
+				DailyCreated: []clickhouse.TeamConversationDailyCount{
+					{Date: "2026-06-05", Count: 1},
+				},
+			},
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	createDashboardTeamUser(t, client, teamID, userID, "林航", "前端组")
+	createDashboardProject(t, client, projectID, userID, "控制台", now.AddDate(0, 0, -2), now.Add(-2*time.Hour))
+	createDashboardTask(t, client, taskID, userID, "继续处理", consts.TaskStatusProcessing, now.Add(-3*time.Hour), now.Add(-30*time.Minute), time.Time{})
+	createDashboardProjectTask(t, client, taskID, projectID, now.Add(-3*time.Hour))
+
+	resp, err := repo.Overview(ctx, teamID, domain.TeamDashboardQuery{
+		Start:      now.AddDate(0, 0, -7),
+		End:        now,
+		TrendStart: now.AddDate(0, 0, -179),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ProjectStats.Total != 1 || resp.ProjectStats.Active7d != 1 || resp.ProjectStats.ActiveToday != 1 {
+		t.Fatalf("project stats = %#v", resp.ProjectStats)
+	}
+	if resp.TaskStats.Total != 1 || resp.TaskStats.Active7d != 1 || resp.TaskStats.ActiveToday != 1 {
+		t.Fatalf("task stats = %#v", resp.TaskStats)
+	}
+	if resp.ConversationStats.Total != 3 || resp.ConversationStats.Count7d != 2 || resp.ConversationStats.CountToday != 1 {
+		t.Fatalf("conversation stats = %#v", resp.ConversationStats)
+	}
+}
+
+func TestTeamDashboardListsOnlyCurrentTeamData(t *testing.T) {
+	ctx := context.Background()
+	client := newDashboardRepoTestDB(t)
+	now := time.Date(2026, 6, 5, 15, 0, 0, 0, time.UTC)
+	teamID := uuid.New()
+	otherTeamID := uuid.New()
+	userID := uuid.New()
+	otherUserID := uuid.New()
+	repo := &TeamDashboardRepo{
+		db:          client,
+		usageReader: &dashboardUsageReaderStub{},
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	createDashboardTeamUser(t, client, teamID, userID, "林航", "前端组")
+	createDashboardTeamUser(t, client, otherTeamID, otherUserID, "周宁", "平台组")
+	createDashboardProject(t, client, uuid.New(), userID, "团队项目", now, now)
+	createDashboardProject(t, client, uuid.New(), otherUserID, "其他项目", now, now)
+
+	projects, err := repo.ListProjects(ctx, teamID, domain.TeamDashboardListReq{Limit: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projects.Projects) != 1 || projects.Projects[0].Name != "团队项目" {
+		t.Fatalf("projects = %#v", projects.Projects)
+	}
+}
+
 type dashboardUsageReaderStub struct {
 	summary  clickhouse.ModelUsageSummary
 	topUsers []clickhouse.ModelUsageTopUser
@@ -187,6 +263,18 @@ func (s *dashboardUsageReaderStub) QueryModelUsageSummary(ctx context.Context, q
 
 func (s *dashboardUsageReaderStub) QueryModelUsageTopUsers(ctx context.Context, q clickhouse.ModelUsageQuery, limit int) ([]clickhouse.ModelUsageTopUser, error) {
 	return s.topUsers, nil
+}
+
+type dashboardConversationReaderStub struct {
+	summary clickhouse.TeamConversationStats
+}
+
+func (s *dashboardConversationReaderStub) QueryTeamConversationStats(ctx context.Context, q clickhouse.TeamConversationQuery) (clickhouse.TeamConversationStats, error) {
+	return s.summary, nil
+}
+
+func (s *dashboardConversationReaderStub) QueryTeamConversations(ctx context.Context, q clickhouse.TeamConversationListQuery) (*clickhouse.TeamConversationListResult, error) {
+	return &clickhouse.TeamConversationListResult{}, nil
 }
 
 func TestTeamDashboardRepoAvoidsSQLiteOnlyTimeFunction(t *testing.T) {
@@ -241,6 +329,64 @@ func createDashboardTask(t *testing.T, client *db.Client, taskID, userID uuid.UU
 		create.SetCompletedAt(completedAt)
 	}
 	if _, err := create.Save(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createDashboardProject(t *testing.T, client *db.Client, projectID, userID uuid.UUID, name string, createdAt, updatedAt time.Time) {
+	t.Helper()
+	if _, err := client.Project.Create().
+		SetID(projectID).
+		SetUserID(userID).
+		SetName(name).
+		SetRepoURL("https://example.com/" + name + ".git").
+		SetCreatedAt(createdAt).
+		SetUpdatedAt(updatedAt).
+		Save(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createDashboardProjectTask(t *testing.T, client *db.Client, taskID, projectID uuid.UUID, createdAt time.Time) {
+	t.Helper()
+	userID := uuid.New()
+	modelID := uuid.New()
+	imageID := uuid.New()
+	if _, err := client.User.Create().
+		SetID(userID).
+		SetName("资源用户").
+		SetEmail(userID.String() + "@example.com").
+		SetRole(consts.UserRoleEnterprise).
+		SetStatus(consts.UserStatusActive).
+		Save(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Model.Create().
+		SetID(modelID).
+		SetUserID(userID).
+		SetProvider("openai").
+		SetAPIKey("sk-test").
+		SetBaseURL("https://example.com").
+		SetModel("gpt-test").
+		Save(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Image.Create().
+		SetID(imageID).
+		SetUserID(userID).
+		SetName("ubuntu").
+		Save(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ProjectTask.Create().
+		SetID(uuid.New()).
+		SetTaskID(taskID).
+		SetProjectID(projectID).
+		SetModelID(modelID).
+		SetImageID(imageID).
+		SetCliName(consts.CliNameOpencode).
+		SetCreatedAt(createdAt).
+		Save(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/backend/biz/team/usecase/dashboard.go
+++ b/backend/biz/team/usecase/dashboard.go
@@ -24,9 +24,11 @@ func NewTeamDashboardUsecase(i *do.Injector) (domain.TeamDashboardUsecase, error
 func (u *TeamDashboardUsecase) Overview(ctx context.Context, teamUser *domain.TeamUser, req domain.TeamDashboardReq) (*domain.TeamDashboardResp, error) {
 	now := u.now()
 	start, label := dashboardRange(now, req.Range)
+	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	resp, err := u.repo.Overview(ctx, teamUser.GetTeamID(), domain.TeamDashboardQuery{
-		Start: start,
-		End:   now,
+		Start:      start,
+		End:        now,
+		TrendStart: todayStart.AddDate(0, 0, -179),
 	})
 	if err != nil {
 		return nil, err
@@ -35,6 +37,18 @@ func (u *TeamDashboardUsecase) Overview(ctx context.Context, teamUser *domain.Te
 	resp.StartAt = start.Unix()
 	resp.EndAt = now.Unix()
 	return resp, nil
+}
+
+func (u *TeamDashboardUsecase) ListProjects(ctx context.Context, teamUser *domain.TeamUser, req domain.TeamDashboardListReq) (*domain.TeamProjectListResp, error) {
+	return u.repo.ListProjects(ctx, teamUser.GetTeamID(), req)
+}
+
+func (u *TeamDashboardUsecase) ListTasks(ctx context.Context, teamUser *domain.TeamUser, req domain.TeamDashboardListReq) (*domain.TeamTaskListResp, error) {
+	return u.repo.ListTasks(ctx, teamUser.GetTeamID(), req)
+}
+
+func (u *TeamDashboardUsecase) ListConversations(ctx context.Context, teamUser *domain.TeamUser, req domain.TeamDashboardListReq) (*domain.TeamConversationListResp, error) {
+	return u.repo.ListConversations(ctx, teamUser.GetTeamID(), req)
 }
 
 func dashboardRange(now time.Time, value string) (time.Time, string) {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -216,6 +216,60 @@
                 }
             }
         },
+        "/api/v1/teams/conversations": {
+            "get": {
+                "security": [
+                    {
+                        "MonkeyCodeAITeamAuth": []
+                    }
+                ],
+                "description": "获取当前团队任务日志中的 user-input 对话列表",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "【Team 管理员】团队对话"
+                ],
+                "summary": "获取团队对话列表",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "分页游标",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "每页数量",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "成功",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/web.Resp"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/domain.TeamConversationListResp"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/teams/dashboard": {
             "get": {
                 "security": [
@@ -1798,6 +1852,114 @@
                         "description": "服务器内部错误",
                         "schema": {
                             "$ref": "#/definitions/web.Resp"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/teams/projects": {
+            "get": {
+                "security": [
+                    {
+                        "MonkeyCodeAITeamAuth": []
+                    }
+                ],
+                "description": "获取当前团队成员创建的项目列表",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "【Team 管理员】团队项目"
+                ],
+                "summary": "获取团队项目列表",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "分页游标",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "每页数量",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "成功",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/web.Resp"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/domain.TeamProjectListResp"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/teams/tasks": {
+            "get": {
+                "security": [
+                    {
+                        "MonkeyCodeAITeamAuth": []
+                    }
+                ],
+                "description": "获取当前团队成员创建的任务列表",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "【Team 管理员】团队任务"
+                ],
+                "summary": "获取团队任务列表",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "分页游标",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "每页数量",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "成功",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/web.Resp"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/domain.TeamTaskListResp"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     }
                 }
@@ -7850,6 +8012,50 @@
                 }
             }
         },
+        "/api/v1/users/tasks/speech-to-text-stream": {
+            "get": {
+                "security": [
+                    {
+                        "MonkeyCodeAIAuth": []
+                    }
+                ],
+                "description": "通过 WebSocket 上传实时音频流并实时返回识别结果。\n后端使用豆包流式语音识别 2.0 (bigmodel_async)。完整协议见 docs/speech-to-text-stream.md。\n\n## 帧类型约定\n| 方向 | 帧类型 | 用途 |\n|---|---|---|\n| C → S | Text(JSON) | 控制消息:start / stop |\n| C → S | Binary | 音频字节流,服务端封装为豆包帧透传 |\n| S → C | Text(JSON) | 所有事件(ready / partial / final / done / error) |\n\n## 客户端 → 服务端\n\n### 1) start (第一帧必须是它)\n```json\n{\n\"type\": \"start\",\n\"format\": \"pcm\",\n\"disfluency\": false\n}\n```\n- `format` 可选,默认 `pcm`。支持 `pcm` / `wav` / `ogg` / `mp3`,单声道、16-bit、采样率固定 16000Hz\n- `pcm` / `wav` 内部音频流必须是 `pcm_s16le`;`ogg` 必须为 `opus` 编码;`mp3` 由远端解码\n- `disfluency` 可选,默认 `false`。`true` 时启用语义顺滑(过滤\"嗯/啊\"等口头禅、语义重复词)\n- 服务端校验通过 → 与豆包建立 WSS → 收到首个响应后向客户端下发 `ready` 事件(带 `logid`)\n- **客户端必须在收到 `ready` 之后才能发 Binary 音频帧**\n- 以下能力默认开启:中间结果(双向流式天然有)、标点预测、ITN(中文数字转阿拉伯数字)\n\n### 2) Binary 音频帧\n`ready` 之后,客户端持续发 Binary 帧。**建议每帧 200ms**(豆包推荐值,过碎会影响性能)。\n\n### 3) stop (主动结束)\n```json\n{ \"type\": \"stop\" }\n```\n服务端收到后向豆包发送\"最后一包\"标志,等待豆包最终响应后下发 `done` 事件并关闭 WS。客户端直接 close WS 亦可。\n\n## 服务端 → 客户端\n\n所有事件统一外层结构:\n```json\n{ \"type\": \"\u003cevent_type\u003e\", \"timestamp\": 1733299200000, ... }\n```\n\n### ready — 远端已就绪\n```json\n{ \"type\": \"ready\", \"logid\": \"202407261553070FACFE6D19421815D605\", \"timestamp\": 1733299200000 }\n```\n仅推送一次。客户端收到后开始发 Binary 音频帧。`logid` 是豆包返回的 `X-Tt-Logid`,排障必备,\n建议前端在 session 期间一直打印它,跟后续 error 事件可以关联。\n\n### partial — 中间结果(实时滚动,会反复推送)\n```json\n{ \"type\": \"partial\", \"index\": 1, \"text\": \"今天天气真\", \"timestamp\": 1733299201500 }\n```\n- 同一 `index` 的 `partial` 会反复推送,`text` 通常逐渐变长\n- **客户端必须用 `text` 覆盖该句显示内容,不要追加**\n\n### final — 一句话定稿\n```json\n{ \"type\": \"final\", \"index\": 1, \"text\": \"今天天气真不错。\", \"timestamp\": 1733299202800 }\n```\n- 该句识别完成、内容固化,后续不会再变;客户端用 `text` 覆盖 `index` 对应位置\n- `final` 之后可能立刻有下一句的 `partial`(`index+1`)\n\n### done — 整个 session 结束\n```json\n{ \"type\": \"done\", \"logid\": \"...\", \"timestamp\": 1733299210000 }\n```\n- 服务端已收到豆包最后一包响应、释放资源,即将关闭 WS;`done` 之后不会再有任何事件\n\n### error — 错误\n豆包远端错误:\n```json\n{\n\"type\": \"error\",\n\"logid\": \"202407261553070FACFE6D19421815D605\",\n\"error\": {\n\"code\": 45000001,\n\"message\": \"请求参数无效\",\n\"request_id\": \"67ee89ba-7050-4c04-a3d7-ac61a63499b3\",\n\"logid\": \"202407261553070FACFE6D19421815D605\"\n},\n\"timestamp\": 1733299205000\n}\n```\n本服务前置校验错误(远端连接前):`code=0`,在 `message` 描述原因:\n```json\n{\n\"type\": \"error\",\n\"error\": { \"code\": 0, \"message\": \"first message must be a 'start' control message\" },\n\"timestamp\": 1733299205000\n}\n```\n\n## 豆包常见错误码速查\n| code | 含义 | 典型原因 |\n|---|---|---|\n| `45000001` | 请求参数无效 | 缺字段 / 字段值无效 / 重复请求 |\n| `45000002` | 空音频 | 录音未采集到声音 |\n| `45000081` | 等包超时 | 前端没在期限内连续发送音频帧 |\n| `45000151` | 音频格式不正确 | `format` 与实际音频不匹配 |\n| `55000031` | 服务器繁忙 | 退避重试 |\n| `550xxxxx` | 服务内部错误 | 直接重试,持续失败时带 `logid` 联系运维 |\n\n## 时序示例\n```\nC → S: WS upgrade (带鉴权)\nC → S: {\"type\":\"start\",\"format\":\"pcm\"}\nS → C: {\"type\":\"ready\",\"logid\":\"...\"}\nC → S: \u003cbinary 200ms\u003e \u003cbinary 200ms\u003e ...\nS → C: {\"type\":\"partial\",\"index\":1,\"text\":\"今天\"}\nS → C: {\"type\":\"partial\",\"index\":1,\"text\":\"今天天气真\"}\nS → C: {\"type\":\"final\",\"index\":1,\"text\":\"今天天气真不错。\"}\nC → S: {\"type\":\"stop\"}\nS → C: {\"type\":\"done\",\"logid\":\"...\"}\nWS close\n```\n\n## 与 POST /speech-to-text 的差异\n- POST /speech-to-text:整段录音 → SSE 单段结果,适合短语音 ≤60s\n- 本接口:WS 双向实时流,支持长语音、句级 final、可被打断,适合 Web/移动端边说边显示\n",
+                "tags": [
+                    "【用户】任务管理"
+                ],
+                "summary": "实时语音转写(WebSocket 流式)",
+                "parameters": [
+                    {
+                        "description": "[WS 协议] 客户端连接后首帧 JSON Text 控制消息 schema;不是 HTTP body,仅供前端代码生成 TS 类型,实际通过 WS Text 帧发送",
+                        "name": "start",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/domain.SpeechStreamStartReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "101": {
+                        "description": "WebSocket 升级成功;此后通过 WS 帧通信,事件结构见上方说明",
+                        "schema": {
+                            "$ref": "#/definitions/domain.SpeechStreamEvent"
+                        }
+                    },
+                    "401": {
+                        "description": "未授权",
+                        "schema": {
+                            "$ref": "#/definitions/web.Resp"
+                        }
+                    },
+                    "500": {
+                        "description": "服务器内部错误(ASR 服务未配置等)",
+                        "schema": {
+                            "$ref": "#/definitions/web.Resp"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/users/tasks/stop": {
             "put": {
                 "security": [
@@ -10619,6 +10825,105 @@
                 }
             }
         },
+        "domain.SpeechStreamError": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "description": "错误码;远端 ASR 错误码 (如豆包 45000001),本地校验错误为 0",
+                    "type": "integer",
+                    "example": 45000001
+                },
+                "logid": {
+                    "description": "远端 ASR 服务返回的 trace id (如豆包 X-Tt-Logid),报障必备",
+                    "type": "string",
+                    "example": "202407261553070FACFE6D19421815D605"
+                },
+                "message": {
+                    "description": "错误描述,远端错误为远端 message,本地校验错误为可读原因",
+                    "type": "string",
+                    "example": "请求参数无效"
+                },
+                "request_id": {
+                    "description": "后端发给远端 ASR 的 X-Api-Request-Id (UUID),便于跟单次请求关联日志",
+                    "type": "string",
+                    "example": "67ee89ba-7050-4c04-a3d7-ac61a63499b3"
+                }
+            }
+        },
+        "domain.SpeechStreamEvent": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "description": "错误详情;仅 error 事件携带",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/domain.SpeechStreamError"
+                        }
+                    ]
+                },
+                "index": {
+                    "description": "句子序号,从 1 开始;partial / final 携带,其余事件省略",
+                    "type": "integer",
+                    "example": 1
+                },
+                "logid": {
+                    "description": "远端 ASR 服务的 trace id;ready / error 事件携带,便于全程关联日志",
+                    "type": "string",
+                    "example": "202407261553070FACFE6D19421815D605"
+                },
+                "text": {
+                    "description": "识别文本;partial(中间结果,会反复变化)/ final(本句定稿)携带",
+                    "type": "string",
+                    "example": "今天天气真不错。"
+                },
+                "timestamp": {
+                    "description": "服务端时间(毫秒),所有事件都有",
+                    "type": "integer",
+                    "example": 1733299200000
+                },
+                "type": {
+                    "description": "事件类型:ready / partial / final / done / error",
+                    "type": "string",
+                    "enum": [
+                        "ready",
+                        "partial",
+                        "final",
+                        "done",
+                        "error"
+                    ],
+                    "example": "partial"
+                }
+            }
+        },
+        "domain.SpeechStreamStartReq": {
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "disfluency": {
+                    "description": "是否启用语义顺滑(过滤\"嗯/啊\"等口头禅、语义重复词),默认 false",
+                    "type": "boolean",
+                    "example": false
+                },
+                "format": {
+                    "description": "音频容器格式,单声道、16-bit、采样率固定 16000Hz。\npcm / wav 内部音频流必须是 pcm_s16le;ogg 必须为 opus 编码;mp3 由服务端解码。",
+                    "type": "string",
+                    "enum": [
+                        "pcm",
+                        "wav",
+                        "ogg",
+                        "mp3"
+                    ],
+                    "example": "pcm"
+                },
+                "type": {
+                    "description": "消息类型,固定为 \"start\"",
+                    "type": "string",
+                    "example": "start"
+                }
+            }
+        },
         "domain.SubscriptionResp": {
             "type": "object",
             "properties": {
@@ -10824,6 +11129,72 @@
                 }
             }
         },
+        "domain.TeamConversationItem": {
+            "type": "object",
+            "properties": {
+                "attachment_count": {
+                    "type": "integer"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "integer"
+                },
+                "creator": {
+                    "$ref": "#/definitions/domain.User"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "project_name": {
+                    "type": "string"
+                },
+                "task_id": {
+                    "type": "string"
+                },
+                "task_title": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.TeamConversationListResp": {
+            "type": "object",
+            "properties": {
+                "conversations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.TeamConversationItem"
+                    }
+                },
+                "page": {
+                    "$ref": "#/definitions/db.Cursor"
+                }
+            }
+        },
+        "domain.TeamConversationStats": {
+            "type": "object",
+            "properties": {
+                "count_7d": {
+                    "type": "integer"
+                },
+                "count_today": {
+                    "type": "integer"
+                },
+                "daily_created": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.TeamDashboardTrendPoint"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
         "domain.TeamDashboardConsumptionInsight": {
             "type": "object",
             "properties": {
@@ -10905,10 +11276,22 @@
                 "average_duration": {
                     "type": "integer"
                 },
+                "cache_hit_rate": {
+                    "type": "number"
+                },
+                "cached_tokens": {
+                    "type": "integer"
+                },
                 "finished_task_count": {
                     "type": "integer"
                 },
+                "input_tokens": {
+                    "type": "integer"
+                },
                 "llm_requests": {
+                    "type": "integer"
+                },
+                "output_tokens": {
                     "type": "integer"
                 },
                 "running_task_count": {
@@ -10928,6 +11311,9 @@
         "domain.TeamDashboardResp": {
             "type": "object",
             "properties": {
+                "conversation_stats": {
+                    "$ref": "#/definitions/domain.TeamConversationStats"
+                },
                 "end_at": {
                     "type": "integer"
                 },
@@ -10937,11 +11323,17 @@
                 "metrics": {
                     "$ref": "#/definitions/domain.TeamDashboardMetrics"
                 },
+                "project_stats": {
+                    "$ref": "#/definitions/domain.TeamProjectStats"
+                },
                 "range": {
                     "type": "string"
                 },
                 "start_at": {
                     "type": "integer"
+                },
+                "task_stats": {
+                    "$ref": "#/definitions/domain.TeamTaskStats"
                 },
                 "trends": {
                     "$ref": "#/definitions/domain.TeamDashboardTrends"
@@ -11164,6 +11556,141 @@
                     "type": "number"
                 },
                 "updated_at": {
+                    "type": "integer"
+                }
+            }
+        },
+        "domain.TeamProjectItem": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "integer"
+                },
+                "creator": {
+                    "$ref": "#/definitions/domain.User"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "issue_count": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "repo_url": {
+                    "type": "string"
+                },
+                "task_count": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "integer"
+                }
+            }
+        },
+        "domain.TeamProjectListResp": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "$ref": "#/definitions/db.Cursor"
+                },
+                "projects": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.TeamProjectItem"
+                    }
+                }
+            }
+        },
+        "domain.TeamProjectStats": {
+            "type": "object",
+            "properties": {
+                "active_7d": {
+                    "type": "integer"
+                },
+                "active_today": {
+                    "type": "integer"
+                },
+                "daily_created": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.TeamDashboardTrendPoint"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "domain.TeamTaskItem": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "integer"
+                },
+                "creator": {
+                    "$ref": "#/definitions/domain.User"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "last_active_at": {
+                    "type": "integer"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "project_name": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.TeamTaskListResp": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "$ref": "#/definitions/db.Cursor"
+                },
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.TeamTaskItem"
+                    }
+                }
+            }
+        },
+        "domain.TeamTaskStats": {
+            "type": "object",
+            "properties": {
+                "active_7d": {
+                    "type": "integer"
+                },
+                "active_today": {
+                    "type": "integer"
+                },
+                "daily_created": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.TeamDashboardTrendPoint"
+                    }
+                },
+                "total": {
                     "type": "integer"
                 }
             }

--- a/backend/domain/team_dashboard.go
+++ b/backend/domain/team_dashboard.go
@@ -5,14 +5,22 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/db"
 )
 
 type TeamDashboardUsecase interface {
 	Overview(ctx context.Context, teamUser *TeamUser, req TeamDashboardReq) (*TeamDashboardResp, error)
+	ListProjects(ctx context.Context, teamUser *TeamUser, req TeamDashboardListReq) (*TeamProjectListResp, error)
+	ListTasks(ctx context.Context, teamUser *TeamUser, req TeamDashboardListReq) (*TeamTaskListResp, error)
+	ListConversations(ctx context.Context, teamUser *TeamUser, req TeamDashboardListReq) (*TeamConversationListResp, error)
 }
 
 type TeamDashboardRepo interface {
 	Overview(ctx context.Context, teamID uuid.UUID, req TeamDashboardQuery) (*TeamDashboardResp, error)
+	ListProjects(ctx context.Context, teamID uuid.UUID, req TeamDashboardListReq) (*TeamProjectListResp, error)
+	ListTasks(ctx context.Context, teamID uuid.UUID, req TeamDashboardListReq) (*TeamTaskListResp, error)
+	ListConversations(ctx context.Context, teamID uuid.UUID, req TeamDashboardListReq) (*TeamConversationListResp, error)
 }
 
 type TeamDashboardReq struct {
@@ -20,17 +28,42 @@ type TeamDashboardReq struct {
 }
 
 type TeamDashboardQuery struct {
-	Start time.Time
-	End   time.Time
+	Start      time.Time
+	End        time.Time
+	TrendStart time.Time
 }
 
 type TeamDashboardResp struct {
-	Range    string                `json:"range"`
-	StartAt  int64                 `json:"start_at"`
-	EndAt    int64                 `json:"end_at"`
-	Metrics  TeamDashboardMetrics  `json:"metrics"`
-	Trends   TeamDashboardTrends   `json:"trends"`
-	Insights TeamDashboardInsights `json:"insights"`
+	Range             string                `json:"range"`
+	StartAt           int64                 `json:"start_at"`
+	EndAt             int64                 `json:"end_at"`
+	Metrics           TeamDashboardMetrics  `json:"metrics"`
+	Trends            TeamDashboardTrends   `json:"trends"`
+	Insights          TeamDashboardInsights `json:"insights"`
+	ProjectStats      TeamProjectStats      `json:"project_stats"`
+	TaskStats         TeamTaskStats         `json:"task_stats"`
+	ConversationStats TeamConversationStats `json:"conversation_stats"`
+}
+
+type TeamProjectStats struct {
+	Total        int                       `json:"total"`
+	Active7d     int                       `json:"active_7d"`
+	ActiveToday  int                       `json:"active_today"`
+	DailyCreated []TeamDashboardTrendPoint `json:"daily_created"`
+}
+
+type TeamTaskStats struct {
+	Total        int                       `json:"total"`
+	Active7d     int                       `json:"active_7d"`
+	ActiveToday  int                       `json:"active_today"`
+	DailyCreated []TeamDashboardTrendPoint `json:"daily_created"`
+}
+
+type TeamConversationStats struct {
+	Total        int64                     `json:"total"`
+	Count7d      int64                     `json:"count_7d"`
+	CountToday   int64                     `json:"count_today"`
+	DailyCreated []TeamDashboardTrendPoint `json:"daily_created"`
 }
 
 type TeamDashboardMetrics struct {
@@ -92,4 +125,61 @@ type TeamDashboardTaskInsight struct {
 	Duration  int64     `json:"duration"`
 	HostName  string    `json:"host_name"`
 	CreatedAt int64     `json:"created_at"`
+}
+
+type TeamDashboardListReq struct {
+	Cursor string `query:"cursor" json:"cursor" validate:"omitempty"`
+	Limit  int    `query:"limit" json:"limit" validate:"omitempty,min=0,max=100"`
+}
+
+type TeamProjectListResp struct {
+	Projects []*TeamProjectItem `json:"projects"`
+	Page     *db.Cursor          `json:"page"`
+}
+
+type TeamProjectItem struct {
+	ID        uuid.UUID `json:"id"`
+	Name      string    `json:"name"`
+	RepoURL   string    `json:"repo_url"`
+	Branch    string    `json:"branch"`
+	Creator   *User     `json:"creator"`
+	TaskCount int       `json:"task_count"`
+	IssueCount int      `json:"issue_count"`
+	CreatedAt int64     `json:"created_at"`
+	UpdatedAt int64     `json:"updated_at"`
+}
+
+type TeamTaskListResp struct {
+	Tasks []*TeamTaskItem `json:"tasks"`
+	Page  *db.Cursor      `json:"page"`
+}
+
+type TeamTaskItem struct {
+	ID           uuid.UUID `json:"id"`
+	Title        string    `json:"title"`
+	Content      string    `json:"content"`
+	Status       string    `json:"status"`
+	Kind         string    `json:"kind"`
+	Creator      *User     `json:"creator"`
+	ProjectID    uuid.UUID `json:"project_id"`
+	ProjectName  string    `json:"project_name"`
+	CreatedAt    int64     `json:"created_at"`
+	LastActiveAt int64     `json:"last_active_at"`
+}
+
+type TeamConversationListResp struct {
+	Conversations []*TeamConversationItem `json:"conversations"`
+	Page          *db.Cursor               `json:"page"`
+}
+
+type TeamConversationItem struct {
+	ID              string    `json:"id"`
+	TaskID          uuid.UUID `json:"task_id"`
+	TaskTitle       string    `json:"task_title"`
+	ProjectID       uuid.UUID `json:"project_id"`
+	ProjectName     string    `json:"project_name"`
+	Creator          *User     `json:"creator"`
+	Content          string    `json:"content"`
+	AttachmentCount int       `json:"attachment_count"`
+	CreatedAt       int64     `json:"created_at"`
 }

--- a/backend/pkg/clickhouse/client.go
+++ b/backend/pkg/clickhouse/client.go
@@ -194,6 +194,49 @@ type ModelUsageTopUser struct {
 	Requests    int64
 }
 
+type TeamConversationQuery struct {
+	TaskIDs    []string
+	Start7d    time.Time
+	TodayStart time.Time
+	TrendStart time.Time
+	End        time.Time
+}
+
+type TeamConversationStats struct {
+	Total        int64
+	Count7d      int64
+	CountToday   int64
+	DailyCreated []TeamConversationDailyCount
+}
+
+type TeamConversationDailyCount struct {
+	Date  string
+	Count int64
+}
+
+type TeamConversationListQuery struct {
+	TaskIDs []string
+	Cursor  string
+	Limit   int
+}
+
+type TeamConversationRow struct {
+	TaskID    string
+	TS        time.Time
+	Event     string
+	Kind      string
+	TurnSeq   uint32
+	Data      string
+	MsgSeqStart uint64
+	MsgSeqEnd   uint64
+}
+
+type TeamConversationListResult struct {
+	Rows        []TeamConversationRow
+	NextCursor  string
+	HasNextPage bool
+}
+
 func (c *Client) InsertModelUsageEvent(ctx context.Context, event ModelUsageEvent) error {
 	if c == nil || c.db == nil {
 		return fmt.Errorf("clickhouse client is nil")
@@ -290,6 +333,124 @@ LIMIT ?`, tableIdentifier)
 		return nil, err
 	}
 	return users, nil
+}
+
+func (c *Client) QueryTeamConversationStats(ctx context.Context, q TeamConversationQuery) (TeamConversationStats, error) {
+	var stats TeamConversationStats
+	if c == nil || c.db == nil {
+		return stats, fmt.Errorf("clickhouse client is nil")
+	}
+	if len(q.TaskIDs) == 0 {
+		return stats, nil
+	}
+	tableIdentifier, err := quoteIdentifier(c.Table())
+	if err != nil {
+		return stats, err
+	}
+	inClause, args := buildInClause(q.TaskIDs)
+	query := fmt.Sprintf(`SELECT
+	coalesce(count(), 0) AS total,
+	coalesce(countIf(ts >= ? AND ts < ?), 0) AS count_7d,
+	coalesce(countIf(ts >= ? AND ts < ?), 0) AS count_today
+FROM %s
+WHERE task_id IN (%s) AND event = 'user-input'`, tableIdentifier, inClause)
+	countArgs := append([]any{q.Start7d, q.End, q.TodayStart, q.End}, args...)
+	if err := c.db.QueryRowContext(ctx, query, countArgs...).Scan(&stats.Total, &stats.Count7d, &stats.CountToday); err != nil {
+		return stats, err
+	}
+
+	dailyQuery := fmt.Sprintf(`SELECT toString(toDate(ts)) AS date, count() AS count
+FROM %s
+WHERE task_id IN (%s) AND event = 'user-input' AND ts >= ? AND ts < ?
+GROUP BY date
+ORDER BY date ASC`, tableIdentifier, inClause)
+	dailyArgs := append([]any{}, args...)
+	dailyArgs = append(dailyArgs, q.TrendStart, q.End)
+	rows, err := c.db.QueryContext(ctx, dailyQuery, dailyArgs...)
+	if err != nil {
+		return stats, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var item TeamConversationDailyCount
+		if err := rows.Scan(&item.Date, &item.Count); err != nil {
+			return stats, err
+		}
+		stats.DailyCreated = append(stats.DailyCreated, item)
+	}
+	if err := rows.Err(); err != nil {
+		return stats, err
+	}
+	return stats, nil
+}
+
+func (c *Client) QueryTeamConversations(ctx context.Context, q TeamConversationListQuery) (*TeamConversationListResult, error) {
+	if c == nil || c.db == nil {
+		return nil, fmt.Errorf("clickhouse client is nil")
+	}
+	if len(q.TaskIDs) == 0 {
+		return &TeamConversationListResult{}, nil
+	}
+	if q.Limit <= 0 {
+		q.Limit = 20
+	}
+	if q.Limit > 100 {
+		q.Limit = 100
+	}
+	tableIdentifier, err := quoteIdentifier(c.Table())
+	if err != nil {
+		return nil, err
+	}
+	inClause, args := buildInClause(q.TaskIDs)
+	cursorFilter := ""
+	if q.Cursor != "" {
+		cursorAt, err := time.Parse(time.RFC3339Nano, q.Cursor)
+		if err != nil {
+			return nil, err
+		}
+		cursorFilter = "AND ts < ?"
+		args = append(args, cursorAt)
+	}
+	args = append(args, q.Limit+1)
+	query := fmt.Sprintf(`SELECT task_id, ts, event, kind, turn_seq, data, msg_seq_start, msg_seq_end
+FROM %s
+WHERE task_id IN (%s) AND event = 'user-input' %s
+ORDER BY ts DESC, task_id DESC, turn_seq DESC, msg_seq_start DESC
+LIMIT ?`, tableIdentifier, inClause, cursorFilter)
+	rows, err := c.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := &TeamConversationListResult{}
+	for rows.Next() {
+		var row TeamConversationRow
+		if err := rows.Scan(&row.TaskID, &row.TS, &row.Event, &row.Kind, &row.TurnSeq, &row.Data, &row.MsgSeqStart, &row.MsgSeqEnd); err != nil {
+			return nil, err
+		}
+		result.Rows = append(result.Rows, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(result.Rows) > q.Limit {
+		result.HasNextPage = true
+		result.Rows = result.Rows[:q.Limit]
+	}
+	if len(result.Rows) > 0 {
+		result.NextCursor = result.Rows[len(result.Rows)-1].TS.UTC().Format(time.RFC3339Nano)
+	}
+	return result, nil
+}
+
+func buildInClause(values []string) (string, []any) {
+	placeholders := make([]string, 0, len(values))
+	args := make([]any, 0, len(values))
+	for _, value := range values {
+		placeholders = append(placeholders, "?")
+		args = append(args, value)
+	}
+	return strings.Join(placeholders, ","), args
 }
 
 func applyPoolOptions(db *sql.DB, cfg config.ClickHouse) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,9 @@ import TeamManagerImages from "@/pages/console/manager/images"
 import TeamManagerLogs from "@/pages/console/manager/logs"
 import TeamManagerHosts from "./pages/console/manager/hosts"
 import TeamManagerOverview from "./pages/console/manager/overview"
+import TeamManagerProjects from "./pages/console/manager/projects"
+import TeamManagerTasks from "./pages/console/manager/tasks"
+import TeamManagerConversations from "./pages/console/manager/conversations"
 import ResetPasswordPage from "./pages/resetpassword"
 import FindPasswordPage from "./pages/findpassword"
 import TeamManagerManager from "./pages/console/manager/manager"
@@ -67,6 +70,9 @@ function App() {
             <Route path="/manager" element={<ManagerConsolePage />}>
               <Route index element={<Navigate to="/manager/overview" replace />} />
               <Route path="overview" element={<TeamManagerOverview />} />
+              <Route path="projects" element={<TeamManagerProjects />} />
+              <Route path="tasks" element={<TeamManagerTasks />} />
+              <Route path="conversations" element={<TeamManagerConversations />} />
               <Route path="members" element={<TeamManagerMembers />} />
               <Route path="hosts" element={<TeamManagerHosts />} />
               <Route path="images" element={<TeamManagerImages />} />

--- a/frontend/src/api/Api.ts
+++ b/frontend/src/api/Api.ts
@@ -1497,6 +1497,30 @@ export interface DomainTeam {
   name?: string;
 }
 
+export interface DomainTeamConversationItem {
+  attachment_count?: number;
+  content?: string;
+  created_at?: number;
+  creator?: DomainUser;
+  id?: string;
+  project_id?: string;
+  project_name?: string;
+  task_id?: string;
+  task_title?: string;
+}
+
+export interface DomainTeamConversationListResp {
+  conversations?: DomainTeamConversationItem[];
+  page?: Dbv2Cursor;
+}
+
+export interface DomainTeamConversationStats {
+  count_7d?: number;
+  count_today?: number;
+  daily_created?: DomainTeamDashboardTrendPoint[];
+  total?: number;
+}
+
 export interface DomainTeamDashboardConsumptionInsight {
   id?: string;
   llm_requests?: number;
@@ -1534,11 +1558,14 @@ export interface DomainTeamDashboardMetrics {
 }
 
 export interface DomainTeamDashboardResp {
+  conversation_stats?: DomainTeamConversationStats;
   end_at?: number;
   insights?: DomainTeamDashboardInsights;
   metrics?: DomainTeamDashboardMetrics;
+  project_stats?: DomainTeamProjectStats;
   range?: string;
   start_at?: number;
+  task_stats?: DomainTeamTaskStats;
   trends?: DomainTeamDashboardTrends;
 }
 
@@ -1569,6 +1596,55 @@ export interface DomainTeamGroup {
   name?: string;
   updated_at?: number;
   users?: DomainUser[];
+}
+
+export interface DomainTeamProjectItem {
+  branch?: string;
+  created_at?: number;
+  creator?: DomainUser;
+  id?: string;
+  issue_count?: number;
+  name?: string;
+  repo_url?: string;
+  task_count?: number;
+  updated_at?: number;
+}
+
+export interface DomainTeamProjectListResp {
+  page?: Dbv2Cursor;
+  projects?: DomainTeamProjectItem[];
+}
+
+export interface DomainTeamProjectStats {
+  active_7d?: number;
+  active_today?: number;
+  daily_created?: DomainTeamDashboardTrendPoint[];
+  total?: number;
+}
+
+export interface DomainTeamTaskItem {
+  content?: string;
+  created_at?: number;
+  creator?: DomainUser;
+  id?: string;
+  kind?: string;
+  last_active_at?: number;
+  project_id?: string;
+  project_name?: string;
+  status?: string;
+  title?: string;
+}
+
+export interface DomainTeamTaskListResp {
+  page?: Dbv2Cursor;
+  tasks?: DomainTeamTaskItem[];
+}
+
+export interface DomainTeamTaskStats {
+  active_7d?: number;
+  active_today?: number;
+  daily_created?: DomainTeamDashboardTrendPoint[];
+  total?: number;
 }
 
 export interface DomainTeamImage {
@@ -2866,6 +2942,105 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         GithubComGoYokoWebResp
       >({
         path: `/api/v1/teams/dashboard`,
+        method: "GET",
+        query: query,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description 获取当前团队任务日志中的 user-input 对话列表
+     *
+     * @tags 【Team 管理员】团队对话
+     * @name V1TeamsConversationsList
+     * @summary 获取团队对话列表
+     * @request GET:/api/v1/teams/conversations
+     * @secure
+     */
+    v1TeamsConversationsList: (
+      query?: {
+        /** 分页游标 */
+        cursor?: string;
+        /** 每页数量 */
+        limit?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        GithubComGoYokoWebResp & {
+          data?: DomainTeamConversationListResp;
+        },
+        GithubComGoYokoWebResp
+      >({
+        path: `/api/v1/teams/conversations`,
+        method: "GET",
+        query: query,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description 获取当前团队成员创建的项目列表
+     *
+     * @tags 【Team 管理员】团队项目
+     * @name V1TeamsProjectsList
+     * @summary 获取团队项目列表
+     * @request GET:/api/v1/teams/projects
+     * @secure
+     */
+    v1TeamsProjectsList: (
+      query?: {
+        /** 分页游标 */
+        cursor?: string;
+        /** 每页数量 */
+        limit?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        GithubComGoYokoWebResp & {
+          data?: DomainTeamProjectListResp;
+        },
+        GithubComGoYokoWebResp
+      >({
+        path: `/api/v1/teams/projects`,
+        method: "GET",
+        query: query,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description 获取当前团队成员创建的任务列表
+     *
+     * @tags 【Team 管理员】团队任务
+     * @name V1TeamsTasksList
+     * @summary 获取团队任务列表
+     * @request GET:/api/v1/teams/tasks
+     * @secure
+     */
+    v1TeamsTasksList: (
+      query?: {
+        /** 分页游标 */
+        cursor?: string;
+        /** 每页数量 */
+        limit?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        GithubComGoYokoWebResp & {
+          data?: DomainTeamTaskListResp;
+        },
+        GithubComGoYokoWebResp
+      >({
+        path: `/api/v1/teams/tasks`,
         method: "GET",
         query: query,
         secure: true,

--- a/frontend/src/components/manager/nav-teams.tsx
+++ b/frontend/src/components/manager/nav-teams.tsx
@@ -8,7 +8,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
 import { IconReport, IconUsersGroup } from "@tabler/icons-react"
-import { Bot, Box, LayoutDashboard, MonitorCloud, User } from "lucide-react"
+import { Bot, Box, FolderGit2, LayoutDashboard, ListTodo, MessagesSquare, MonitorCloud, User } from "lucide-react"
 
 export default function NavTeams() {
   const location = useLocation()
@@ -25,6 +25,39 @@ export default function NavTeams() {
             <Link to="/manager/overview">
               <LayoutDashboard />
               <span>概览</span>
+            </Link>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            isActive={location.pathname === "/manager/projects"}
+            asChild
+          >
+            <Link to="/manager/projects">
+              <FolderGit2 />
+              <span>项目</span>
+            </Link>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            isActive={location.pathname === "/manager/tasks"}
+            asChild
+          >
+            <Link to="/manager/tasks">
+              <ListTodo />
+              <span>任务</span>
+            </Link>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            isActive={location.pathname === "/manager/conversations"}
+            asChild
+          >
+            <Link to="/manager/conversations">
+              <MessagesSquare />
+              <span>对话</span>
             </Link>
           </SidebarMenuButton>
         </SidebarMenuItem>

--- a/frontend/src/components/manager/team-data-table-pagination.tsx
+++ b/frontend/src/components/manager/team-data-table-pagination.tsx
@@ -1,0 +1,66 @@
+import { IconChevronLeft, IconChevronRight, IconChevronsLeft } from "@tabler/icons-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+export function TeamDataTablePagination({
+  page,
+  pageSize,
+  loading,
+  hasNextPage,
+  canPrevPage,
+  onFirstPage,
+  onPrevPage,
+  onNextPage,
+  onPageSizeChange,
+}: {
+  page: number
+  pageSize: number
+  loading: boolean
+  hasNextPage: boolean
+  canPrevPage: boolean
+  onFirstPage: () => void
+  onPrevPage: () => void
+  onNextPage: () => void
+  onPageSizeChange: (size: number) => void
+}) {
+  return (
+    <div className="flex shrink-0 flex-col items-start justify-between gap-4 border-t bg-background px-4 py-4 sm:flex-row sm:items-center">
+      <div className="flex items-center gap-2">
+        <span className="text-muted-foreground text-sm whitespace-nowrap">每页显示：</span>
+        <Select value={pageSize.toString()} onValueChange={(value) => onPageSizeChange(Number(value))}>
+          <SelectTrigger className="h-8 w-[80px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="10">10</SelectItem>
+            <SelectItem value="20">20</SelectItem>
+            <SelectItem value="50">50</SelectItem>
+            <SelectItem value="100">100</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <div className="text-muted-foreground mr-2 text-sm">
+          第 <span className="font-medium text-foreground">{page}</span> 页
+        </div>
+        <Button variant="outline" size="sm" onClick={onFirstPage} disabled={!canPrevPage || loading} title="首页">
+          <IconChevronsLeft className="h-4 w-4" />
+        </Button>
+        <Button variant="outline" size="sm" onClick={onPrevPage} disabled={!canPrevPage || loading} title="上一页">
+          <IconChevronLeft className="h-4 w-4" />
+        </Button>
+        <Button variant="outline" size="sm" onClick={onNextPage} disabled={!hasNextPage || loading} title="下一页">
+          <IconChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/console/manager/conversations.tsx
+++ b/frontend/src/pages/console/manager/conversations.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from "react"
+import { MessagesSquare } from "lucide-react"
+import { toast } from "sonner"
+
+import type { Dbv2Cursor, DomainTeamConversationItem } from "@/api/Api"
+import { TeamDataTablePagination } from "@/components/manager/team-data-table-pagination"
+import { Badge } from "@/components/ui/badge"
+import { Empty, EmptyHeader, EmptyMedia } from "@/components/ui/empty"
+import { Spinner } from "@/components/ui/spinner"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { apiRequest } from "@/utils/requestUtils"
+
+function formatTime(value?: number) {
+  if (!value) return "-"
+  return new Date(value * 1000).toLocaleString("zh-CN", { hour12: false }).replace(/\//g, "-")
+}
+
+export default function TeamManagerConversations() {
+  const [conversations, setConversations] = useState<DomainTeamConversationItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [pageSize, setPageSize] = useState(20)
+  const [currentCursor, setCurrentCursor] = useState<string | undefined>()
+  const [nextCursor, setNextCursor] = useState<string | undefined>()
+  const [hasNextPage, setHasNextPage] = useState(false)
+  const [cursorHistory, setCursorHistory] = useState<(string | undefined)[]>([undefined])
+
+  const fetchConversations = async (cursor?: string, limit = pageSize) => {
+    setLoading(true)
+    setCurrentCursor(cursor)
+    await apiRequest("v1TeamsConversationsList", { cursor, limit }, [], (resp) => {
+      if (resp.code === 0) {
+        const page = resp.data?.page as Dbv2Cursor | undefined
+        setConversations(resp.data?.conversations || [])
+        setNextCursor(page?.cursor)
+        setHasNextPage(!!page?.has_next_page)
+      } else {
+        toast.error(resp.message || "获取对话列表失败")
+      }
+    })
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    fetchConversations()
+  }, [])
+
+  const goFirst = () => {
+    setCursorHistory([undefined])
+    fetchConversations(undefined)
+  }
+
+  const goPrev = () => {
+    if (cursorHistory.length <= 1) return
+    const nextHistory = [...cursorHistory]
+    nextHistory.pop()
+    const prev = nextHistory[nextHistory.length - 1]
+    setCursorHistory(nextHistory)
+    fetchConversations(prev)
+  }
+
+  const goNext = () => {
+    if (!nextCursor || !hasNextPage) return
+    setCursorHistory((prev) => [...prev, currentCursor])
+    fetchConversations(nextCursor)
+  }
+
+  const changePageSize = (size: number) => {
+    setPageSize(size)
+    setCursorHistory([undefined])
+    fetchConversations(undefined, size)
+  }
+
+  if (loading && conversations.length === 0) {
+    return (
+      <Empty className="bg-muted">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <Spinner className="size-6" />
+          </EmptyMedia>
+        </EmptyHeader>
+      </Empty>
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="mb-4 flex items-center gap-2">
+        <MessagesSquare className="size-5" />
+        <h1 className="text-xl font-semibold">对话</h1>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>用户输入</TableHead>
+              <TableHead>任务</TableHead>
+              <TableHead>项目</TableHead>
+              <TableHead>创建人</TableHead>
+              <TableHead>附件</TableHead>
+              <TableHead>时间</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {!loading && conversations.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={6} className="py-3.5 text-center">
+                  无数据
+                </TableCell>
+              </TableRow>
+            )}
+            {conversations.map((item) => (
+              <TableRow key={item.id}>
+                <TableCell className="max-w-[420px] truncate font-medium">{item.content || "-"}</TableCell>
+                <TableCell className="max-w-[240px] truncate">{item.task_title || item.task_id || "-"}</TableCell>
+                <TableCell>{item.project_name || "-"}</TableCell>
+                <TableCell>{item.creator?.name || item.creator?.email || "-"}</TableCell>
+                <TableCell>
+                  <Badge variant={item.attachment_count ? "secondary" : "outline"}>{item.attachment_count || 0}</Badge>
+                </TableCell>
+                <TableCell>{formatTime(item.created_at)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <TeamDataTablePagination
+        page={cursorHistory.length}
+        pageSize={pageSize}
+        loading={loading}
+        hasNextPage={hasNextPage}
+        canPrevPage={cursorHistory.length > 1}
+        onFirstPage={goFirst}
+        onPrevPage={goPrev}
+        onNextPage={goNext}
+        onPageSizeChange={changePageSize}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/console/manager/overview.tsx
+++ b/frontend/src/pages/console/manager/overview.tsx
@@ -38,6 +38,10 @@ function InsightEmpty() {
   return <div className="text-muted-foreground text-sm">暂无数据</div>
 }
 
+function formatCount(value?: number) {
+  return String(value || 0)
+}
+
 export default function TeamManagerOverview() {
   const [range, setRange] = useState<DashboardRange>("7d")
   const [data, setData] = useState<DomainTeamDashboardResp | null>(null)
@@ -64,9 +68,12 @@ export default function TeamManagerOverview() {
   }, [range])
 
   const metrics = data?.metrics
-  const taskTrend = useMemo(() => data?.trends?.task_counts || [], [data])
-  const activeTrend = useMemo(() => data?.trends?.active_members || [], [data])
-  const tokenTrend = useMemo(() => data?.trends?.token_usage || [], [data])
+  const projectStats = data?.project_stats
+  const taskStats = data?.task_stats
+  const conversationStats = data?.conversation_stats
+  const projectTrend = useMemo(() => projectStats?.daily_created || [], [projectStats])
+  const taskTrend = useMemo(() => taskStats?.daily_created || [], [taskStats])
+  const conversationTrend = useMemo(() => conversationStats?.daily_created || [], [conversationStats])
 
   return (
     <div className="flex flex-col gap-4">
@@ -75,7 +82,7 @@ export default function TeamManagerOverview() {
           <h1 className="text-2xl font-semibold tracking-normal">
             团队管理概览
           </h1>
-          <p className="text-muted-foreground text-sm">团队使用与模型消耗</p>
+          <p className="text-muted-foreground text-sm">项目、任务与对话统计</p>
         </div>
         <TimeRangeTabs value={range} onChange={setRange} />
       </div>
@@ -91,33 +98,28 @@ export default function TeamManagerOverview() {
         </Empty>
       ) : (
         <>
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <div className="grid gap-4 md:grid-cols-3">
             <MetricCard
-              title="活跃成员"
-              value={`${metrics?.active_members || 0} / ${metrics?.total_members || 0}`}
-              description={`活跃率 ${metrics?.active_rate || 0}%`}
+              title="项目总数"
+              value={formatCount(projectStats?.total)}
+              description={`近 7 天活动 ${projectStats?.active_7d || 0} · 今日活动 ${projectStats?.active_today || 0}`}
             />
             <MetricCard
-              title="本周任务"
-              value={String(metrics?.task_count || 0)}
-              description={`运行中 ${metrics?.running_task_count || 0} · 已结束 ${metrics?.finished_task_count || 0}`}
+              title="任务总数"
+              value={formatCount(taskStats?.total)}
+              description={`近 7 天活动 ${taskStats?.active_7d || 0} · 今日活动 ${taskStats?.active_today || 0}`}
             />
             <MetricCard
-              title="平均耗时"
-              value={formatDuration(metrics?.average_duration)}
-              description="仅统计已完成任务"
-            />
-            <MetricCard
-              title="Token 消耗"
-              value={formatTokens(metrics?.total_tokens)}
-              description={`模型调用 ${metrics?.llm_requests || 0} 次`}
+              title="对话总数"
+              value={formatCount(conversationStats?.total)}
+              description={`近 7 天 ${conversationStats?.count_7d || 0} · 今日 ${conversationStats?.count_today || 0}`}
             />
           </div>
 
           <div className="grid gap-4 xl:grid-cols-3">
-            <TrendCard title="任务量趋势">
+            <TrendCard title="每天创建项目数">
               <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={taskTrend}>
+                <LineChart data={projectTrend}>
                   <XAxis dataKey="date" tickLine={false} axisLine={false} />
                   <YAxis tickLine={false} axisLine={false} width={32} />
                   <Tooltip />
@@ -131,9 +133,9 @@ export default function TeamManagerOverview() {
                 </LineChart>
               </ResponsiveContainer>
             </TrendCard>
-            <TrendCard title="活跃成员趋势">
+            <TrendCard title="每天创建任务数">
               <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={activeTrend}>
+                <LineChart data={taskTrend}>
                   <XAxis dataKey="date" tickLine={false} axisLine={false} />
                   <YAxis tickLine={false} axisLine={false} width={32} />
                   <Tooltip />
@@ -147,9 +149,9 @@ export default function TeamManagerOverview() {
                 </LineChart>
               </ResponsiveContainer>
             </TrendCard>
-            <TrendCard title="Token 消耗趋势">
+            <TrendCard title="每天创建对话数">
               <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={tokenTrend}>
+                <LineChart data={conversationTrend}>
                   <XAxis dataKey="date" tickLine={false} axisLine={false} />
                   <YAxis tickLine={false} axisLine={false} width={40} />
                   <Tooltip />
@@ -163,6 +165,29 @@ export default function TeamManagerOverview() {
                 </LineChart>
               </ResponsiveContainer>
             </TrendCard>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <MetricCard
+              title="活跃成员"
+              value={`${metrics?.active_members || 0} / ${metrics?.total_members || 0}`}
+              description={`活跃率 ${metrics?.active_rate || 0}%`}
+            />
+            <MetricCard
+              title="周期任务"
+              value={String(metrics?.task_count || 0)}
+              description={`运行中 ${metrics?.running_task_count || 0} · 已结束 ${metrics?.finished_task_count || 0}`}
+            />
+            <MetricCard
+              title="平均耗时"
+              value={formatDuration(metrics?.average_duration)}
+              description="仅统计已完成任务"
+            />
+            <MetricCard
+              title="Token 消耗"
+              value={formatTokens(metrics?.total_tokens)}
+              description={`模型调用 ${metrics?.llm_requests || 0} 次`}
+            />
           </div>
 
           <div className="grid gap-4 xl:grid-cols-3">

--- a/frontend/src/pages/console/manager/page.tsx
+++ b/frontend/src/pages/console/manager/page.tsx
@@ -29,6 +29,15 @@ export default function ManagerConsolePage() {
     "/manager/overview": [
       { label: "概览", href: "/manager/overview" },
     ],
+    "/manager/projects": [
+      { label: "项目", href: "/manager/projects" },
+    ],
+    "/manager/tasks": [
+      { label: "任务", href: "/manager/tasks" },
+    ],
+    "/manager/conversations": [
+      { label: "对话", href: "/manager/conversations" },
+    ],
     "/manager/members": [
       { label: "成员管理", href: "/manager/members" },
     ],

--- a/frontend/src/pages/console/manager/projects.tsx
+++ b/frontend/src/pages/console/manager/projects.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from "react"
+import { FolderGit2 } from "lucide-react"
+import { toast } from "sonner"
+
+import type { Dbv2Cursor, DomainTeamProjectItem } from "@/api/Api"
+import { TeamDataTablePagination } from "@/components/manager/team-data-table-pagination"
+import { Empty, EmptyHeader, EmptyMedia } from "@/components/ui/empty"
+import { Spinner } from "@/components/ui/spinner"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { apiRequest } from "@/utils/requestUtils"
+
+function formatTime(value?: number) {
+  if (!value) return "-"
+  return new Date(value * 1000).toLocaleString("zh-CN", { hour12: false }).replace(/\//g, "-")
+}
+
+export default function TeamManagerProjects() {
+  const [projects, setProjects] = useState<DomainTeamProjectItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [pageSize, setPageSize] = useState(20)
+  const [currentCursor, setCurrentCursor] = useState<string | undefined>()
+  const [nextCursor, setNextCursor] = useState<string | undefined>()
+  const [hasNextPage, setHasNextPage] = useState(false)
+  const [cursorHistory, setCursorHistory] = useState<(string | undefined)[]>([undefined])
+
+  const fetchProjects = async (cursor?: string, limit = pageSize) => {
+    setLoading(true)
+    setCurrentCursor(cursor)
+    await apiRequest("v1TeamsProjectsList", { cursor, limit }, [], (resp) => {
+      if (resp.code === 0) {
+        const page = resp.data?.page as Dbv2Cursor | undefined
+        setProjects(resp.data?.projects || [])
+        setNextCursor(page?.cursor)
+        setHasNextPage(!!page?.has_next_page)
+      } else {
+        toast.error(resp.message || "获取项目列表失败")
+      }
+    })
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    fetchProjects()
+  }, [])
+
+  const goFirst = () => {
+    setCursorHistory([undefined])
+    fetchProjects(undefined)
+  }
+
+  const goPrev = () => {
+    if (cursorHistory.length <= 1) return
+    const nextHistory = [...cursorHistory]
+    nextHistory.pop()
+    const prev = nextHistory[nextHistory.length - 1]
+    setCursorHistory(nextHistory)
+    fetchProjects(prev)
+  }
+
+  const goNext = () => {
+    if (!nextCursor || !hasNextPage) return
+    setCursorHistory((prev) => [...prev, currentCursor])
+    fetchProjects(nextCursor)
+  }
+
+  const changePageSize = (size: number) => {
+    setPageSize(size)
+    setCursorHistory([undefined])
+    fetchProjects(undefined, size)
+  }
+
+  if (loading && projects.length === 0) {
+    return (
+      <Empty className="bg-muted">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <Spinner className="size-6" />
+          </EmptyMedia>
+        </EmptyHeader>
+      </Empty>
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="mb-4 flex items-center gap-2">
+        <FolderGit2 className="size-5" />
+        <h1 className="text-xl font-semibold">项目</h1>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>项目</TableHead>
+              <TableHead>仓库</TableHead>
+              <TableHead>创建人</TableHead>
+              <TableHead>任务</TableHead>
+              <TableHead>需求</TableHead>
+              <TableHead>创建时间</TableHead>
+              <TableHead>更新时间</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {!loading && projects.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={7} className="py-3.5 text-center">
+                  无数据
+                </TableCell>
+              </TableRow>
+            )}
+            {projects.map((project) => (
+              <TableRow key={project.id}>
+                <TableCell className="font-medium">{project.name || "-"}</TableCell>
+                <TableCell className="max-w-[360px] truncate">{project.repo_url || "-"}</TableCell>
+                <TableCell>{project.creator?.name || project.creator?.email || "-"}</TableCell>
+                <TableCell>{project.task_count || 0}</TableCell>
+                <TableCell>{project.issue_count || 0}</TableCell>
+                <TableCell>{formatTime(project.created_at)}</TableCell>
+                <TableCell>{formatTime(project.updated_at)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <TeamDataTablePagination
+        page={cursorHistory.length}
+        pageSize={pageSize}
+        loading={loading}
+        hasNextPage={hasNextPage}
+        canPrevPage={cursorHistory.length > 1}
+        onFirstPage={goFirst}
+        onPrevPage={goPrev}
+        onNextPage={goNext}
+        onPageSizeChange={changePageSize}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/console/manager/tasks.tsx
+++ b/frontend/src/pages/console/manager/tasks.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from "react"
+import { ListTodo } from "lucide-react"
+import { toast } from "sonner"
+
+import type { Dbv2Cursor, DomainTeamTaskItem } from "@/api/Api"
+import { TeamDataTablePagination } from "@/components/manager/team-data-table-pagination"
+import { Badge } from "@/components/ui/badge"
+import { Empty, EmptyHeader, EmptyMedia } from "@/components/ui/empty"
+import { Spinner } from "@/components/ui/spinner"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { apiRequest } from "@/utils/requestUtils"
+
+function formatTime(value?: number) {
+  if (!value) return "-"
+  return new Date(value * 1000).toLocaleString("zh-CN", { hour12: false }).replace(/\//g, "-")
+}
+
+function taskTitle(task: DomainTeamTaskItem) {
+  return task.title || task.content || "未命名任务"
+}
+
+export default function TeamManagerTasks() {
+  const [tasks, setTasks] = useState<DomainTeamTaskItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [pageSize, setPageSize] = useState(20)
+  const [currentCursor, setCurrentCursor] = useState<string | undefined>()
+  const [nextCursor, setNextCursor] = useState<string | undefined>()
+  const [hasNextPage, setHasNextPage] = useState(false)
+  const [cursorHistory, setCursorHistory] = useState<(string | undefined)[]>([undefined])
+
+  const fetchTasks = async (cursor?: string, limit = pageSize) => {
+    setLoading(true)
+    setCurrentCursor(cursor)
+    await apiRequest("v1TeamsTasksList", { cursor, limit }, [], (resp) => {
+      if (resp.code === 0) {
+        const page = resp.data?.page as Dbv2Cursor | undefined
+        setTasks(resp.data?.tasks || [])
+        setNextCursor(page?.cursor)
+        setHasNextPage(!!page?.has_next_page)
+      } else {
+        toast.error(resp.message || "获取任务列表失败")
+      }
+    })
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    fetchTasks()
+  }, [])
+
+  const goFirst = () => {
+    setCursorHistory([undefined])
+    fetchTasks(undefined)
+  }
+
+  const goPrev = () => {
+    if (cursorHistory.length <= 1) return
+    const nextHistory = [...cursorHistory]
+    nextHistory.pop()
+    const prev = nextHistory[nextHistory.length - 1]
+    setCursorHistory(nextHistory)
+    fetchTasks(prev)
+  }
+
+  const goNext = () => {
+    if (!nextCursor || !hasNextPage) return
+    setCursorHistory((prev) => [...prev, currentCursor])
+    fetchTasks(nextCursor)
+  }
+
+  const changePageSize = (size: number) => {
+    setPageSize(size)
+    setCursorHistory([undefined])
+    fetchTasks(undefined, size)
+  }
+
+  if (loading && tasks.length === 0) {
+    return (
+      <Empty className="bg-muted">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <Spinner className="size-6" />
+          </EmptyMedia>
+        </EmptyHeader>
+      </Empty>
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="mb-4 flex items-center gap-2">
+        <ListTodo className="size-5" />
+        <h1 className="text-xl font-semibold">任务</h1>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>任务</TableHead>
+              <TableHead>项目</TableHead>
+              <TableHead>创建人</TableHead>
+              <TableHead>状态</TableHead>
+              <TableHead>类型</TableHead>
+              <TableHead>创建时间</TableHead>
+              <TableHead>最后活动</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {!loading && tasks.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={7} className="py-3.5 text-center">
+                  无数据
+                </TableCell>
+              </TableRow>
+            )}
+            {tasks.map((task) => (
+              <TableRow key={task.id}>
+                <TableCell className="max-w-[360px] truncate font-medium">{taskTitle(task)}</TableCell>
+                <TableCell>{task.project_name || "-"}</TableCell>
+                <TableCell>{task.creator?.name || task.creator?.email || "-"}</TableCell>
+                <TableCell>
+                  <Badge variant="outline">{task.status || "-"}</Badge>
+                </TableCell>
+                <TableCell>{task.kind || "-"}</TableCell>
+                <TableCell>{formatTime(task.created_at)}</TableCell>
+                <TableCell>{formatTime(task.last_active_at)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <TeamDataTablePagination
+        page={cursorHistory.length}
+        pageSize={pageSize}
+        loading={loading}
+        hasNextPage={hasNextPage}
+        canPrevPage={cursorHistory.length > 1}
+        onFirstPage={goFirst}
+        onPrevPage={goPrev}
+        onNextPage={goNext}
+        onPageSizeChange={changePageSize}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- 新增团队管理项目、任务、对话列表接口和页面
- 扩展团队管理 Dashboard，增加项目/任务/对话统计与 180 天趋势
- 对话按 task_logs 中的 user-input 事件统计和展示

## Test Plan
- go test ./biz/team/... ./pkg/clickhouse/... ./domain -count=1
- pnpm build

## Notes
- pnpm lint 当前因项目 ESLint flat config 配置解析问题失败，未进入代码规则检查。