### PR TITLE
优化团队管理列表页样式

### DIFF
--- a/frontend/src/components/manager/manager-list-page.tsx
+++ b/frontend/src/components/manager/manager-list-page.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from "react"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty"
+import { Spinner } from "@/components/ui/spinner"
+
+export function ManagerListCard({
+  title,
+  description,
+  icon,
+  count,
+  children,
+  pagination,
+}: {
+  title: string
+  description: string
+  icon: ReactNode
+  count?: number
+  children: ReactNode
+  pagination: ReactNode
+}) {
+  return (
+    <Card className="min-h-0 flex-1 shadow-none">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 [&_svg]:size-5">
+          {icon}
+          {title}
+        </CardTitle>
+        <CardDescription>
+          {description}
+          {typeof count === "number" && ` · 当前 ${count} 条`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex min-h-0 flex-1 flex-col px-0 pb-0">
+        <div className="min-h-0 flex-1 overflow-auto">{children}</div>
+        {pagination}
+      </CardContent>
+    </Card>
+  )
+}
+
+export function ManagerListLoading({ title }: { title: string }) {
+  return (
+    <Card className="min-h-0 flex-1 shadow-none">
+      <CardContent className="flex min-h-0 flex-1">
+        <Empty className="border-0">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <Spinner className="size-6" />
+            </EmptyMedia>
+            <EmptyTitle>{title}</EmptyTitle>
+          </EmptyHeader>
+        </Empty>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function ManagerListEmpty({
+  title,
+  description,
+  colSpan,
+}: {
+  title: string
+  description: string
+  colSpan: number
+}) {
+  return (
+    <tr>
+      <td colSpan={colSpan}>
+        <Empty className="border-0 py-16">
+          <EmptyHeader>
+            <EmptyTitle>{title}</EmptyTitle>
+            <EmptyDescription>{description}</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      </td>
+    </tr>
+  )
+}

--- a/frontend/src/components/manager/team-data-table-pagination.tsx
+++ b/frontend/src/components/manager/team-data-table-pagination.tsx
@@ -31,9 +31,9 @@ export function TeamDataTablePagination({
   onPageSizeChange: (size: number) => void
 }) {
   return (
-    <div className="flex shrink-0 flex-col items-start justify-between gap-4 border-t bg-background px-4 py-4 sm:flex-row sm:items-center">
+    <div className="flex shrink-0 flex-col items-start justify-between gap-4 border-t bg-background px-6 py-4 sm:flex-row sm:items-center">
       <div className="flex items-center gap-2">
-        <span className="text-muted-foreground text-sm whitespace-nowrap">每页显示：</span>
+        <span className="whitespace-nowrap text-sm text-muted-foreground">每页显示：</span>
         <Select value={pageSize.toString()} onValueChange={(value) => onPageSizeChange(Number(value))}>
           <SelectTrigger className="h-8 w-[80px]">
             <SelectValue />
@@ -48,7 +48,7 @@ export function TeamDataTablePagination({
       </div>
 
       <div className="flex items-center gap-2">
-        <div className="text-muted-foreground mr-2 text-sm">
+        <div className="mr-2 text-sm text-muted-foreground">
           第 <span className="font-medium text-foreground">{page}</span> 页
         </div>
         <Button variant="outline" size="sm" onClick={onFirstPage} disabled={!canPrevPage || loading} title="首页">

--- a/frontend/src/pages/console/manager/conversations.tsx
+++ b/frontend/src/pages/console/manager/conversations.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from "react"
-import { MessagesSquare } from "lucide-react"
+import { IconMessages } from "@tabler/icons-react"
 import { toast } from "sonner"
 
 import type { Dbv2Cursor, DomainTeamConversationItem } from "@/api/Api"
+import {
+  ManagerListEmpty,
+  ManagerListLoading,
+  ManagerListCard,
+} from "@/components/manager/manager-list-page"
 import { TeamDataTablePagination } from "@/components/manager/team-data-table-pagination"
 import { Badge } from "@/components/ui/badge"
-import { Empty, EmptyHeader, EmptyMedia } from "@/components/ui/empty"
-import { Spinner } from "@/components/ui/spinner"
 import {
   Table,
   TableBody,
@@ -20,6 +23,10 @@ import { apiRequest } from "@/utils/requestUtils"
 function formatTime(value?: number) {
   if (!value) return "-"
   return new Date(value * 1000).toLocaleString("zh-CN", { hour12: false }).replace(/\//g, "-")
+}
+
+function creatorName(item: DomainTeamConversationItem) {
+  return item.creator?.name || item.creator?.email || "-"
 }
 
 export default function TeamManagerConversations() {
@@ -78,69 +85,74 @@ export default function TeamManagerConversations() {
   }
 
   if (loading && conversations.length === 0) {
-    return (
-      <Empty className="bg-muted">
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <Spinner className="size-6" />
-          </EmptyMedia>
-        </EmptyHeader>
-      </Empty>
-    )
+    return <ManagerListLoading title="正在加载对话" />
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="mb-4 flex items-center gap-2">
-        <MessagesSquare className="size-5" />
-        <h1 className="text-xl font-semibold">对话</h1>
-      </div>
-      <div className="min-h-0 flex-1 overflow-auto">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>用户输入</TableHead>
-              <TableHead>任务</TableHead>
-              <TableHead>项目</TableHead>
-              <TableHead>创建人</TableHead>
-              <TableHead>附件</TableHead>
-              <TableHead>时间</TableHead>
+    <ManagerListCard
+      title="对话"
+      description="查看团队对话输入、关联任务、创建人和附件数量。"
+      icon={<IconMessages />}
+      count={conversations.length}
+      pagination={
+        <TeamDataTablePagination
+          page={cursorHistory.length}
+          pageSize={pageSize}
+          loading={loading}
+          hasNextPage={hasNextPage}
+          canPrevPage={cursorHistory.length > 1}
+          onFirstPage={goFirst}
+          onPrevPage={goPrev}
+          onNextPage={goNext}
+          onPageSizeChange={changePageSize}
+        />
+      }
+    >
+      <Table>
+        <TableHeader>
+          <TableRow className="bg-muted/30 hover:bg-muted/30">
+            <TableHead className="px-6">用户输入</TableHead>
+            <TableHead>创建人</TableHead>
+            <TableHead>附件</TableHead>
+            <TableHead>时间</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {!loading && conversations.length === 0 && (
+            <ManagerListEmpty
+              colSpan={4}
+              title="暂无对话"
+              description="团队成员发起对话后，这里会显示输入内容和关联任务。"
+            />
+          )}
+          {conversations.map((item) => (
+            <TableRow key={item.id}>
+              <TableCell className="px-6">
+                <div className="max-w-[560px] space-y-1">
+                  <div className="truncate font-medium">
+                    {item.content || "-"}
+                  </div>
+                  <div className="truncate text-xs leading-4 text-muted-foreground">
+                    {item.task_title || item.task_id || "未关联任务"}
+                    {item.project_name ? ` · ${item.project_name}` : ""}
+                  </div>
+                </div>
+              </TableCell>
+              <TableCell>
+                <div className="max-w-[180px] truncate text-sm">
+                  {creatorName(item)}
+                </div>
+              </TableCell>
+              <TableCell>
+                <Badge variant={item.attachment_count ? "secondary" : "outline"}>
+                  {item.attachment_count || 0}
+                </Badge>
+              </TableCell>
+              <TableCell>{formatTime(item.created_at)}</TableCell>
             </TableRow>
-          </TableHeader>
-          <TableBody>
-            {!loading && conversations.length === 0 && (
-              <TableRow>
-                <TableCell colSpan={6} className="py-3.5 text-center">
-                  无数据
-                </TableCell>
-              </TableRow>
-            )}
-            {conversations.map((item) => (
-              <TableRow key={item.id}>
-                <TableCell className="max-w-[420px] truncate font-medium">{item.content || "-"}</TableCell>
-                <TableCell className="max-w-[240px] truncate">{item.task_title || item.task_id || "-"}</TableCell>
-                <TableCell>{item.project_name || "-"}</TableCell>
-                <TableCell>{item.creator?.name || item.creator?.email || "-"}</TableCell>
-                <TableCell>
-                  <Badge variant={item.attachment_count ? "secondary" : "outline"}>{item.attachment_count || 0}</Badge>
-                </TableCell>
-                <TableCell>{formatTime(item.created_at)}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
-      <TeamDataTablePagination
-        page={cursorHistory.length}
-        pageSize={pageSize}
-        loading={loading}
-        hasNextPage={hasNextPage}
-        canPrevPage={cursorHistory.length > 1}
-        onFirstPage={goFirst}
-        onPrevPage={goPrev}
-        onNextPage={goNext}
-        onPageSizeChange={changePageSize}
-      />
-    </div>
+          ))}
+        </TableBody>
+      </Table>
+    </ManagerListCard>
   )
 }

--- a/frontend/src/pages/console/manager/projects.tsx
+++ b/frontend/src/pages/console/manager/projects.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from "react"
-import { FolderGit2 } from "lucide-react"
+import { IconFolder } from "@tabler/icons-react"
 import { toast } from "sonner"
 
 import type { Dbv2Cursor, DomainTeamProjectItem } from "@/api/Api"
+import {
+  ManagerListEmpty,
+  ManagerListLoading,
+  ManagerListCard,
+} from "@/components/manager/manager-list-page"
 import { TeamDataTablePagination } from "@/components/manager/team-data-table-pagination"
-import { Empty, EmptyHeader, EmptyMedia } from "@/components/ui/empty"
-import { Spinner } from "@/components/ui/spinner"
 import {
   Table,
   TableBody,
@@ -19,6 +22,10 @@ import { apiRequest } from "@/utils/requestUtils"
 function formatTime(value?: number) {
   if (!value) return "-"
   return new Date(value * 1000).toLocaleString("zh-CN", { hour12: false }).replace(/\//g, "-")
+}
+
+function creatorName(project: DomainTeamProjectItem) {
+  return project.creator?.name || project.creator?.email || "-"
 }
 
 export default function TeamManagerProjects() {
@@ -77,69 +84,82 @@ export default function TeamManagerProjects() {
   }
 
   if (loading && projects.length === 0) {
-    return (
-      <Empty className="bg-muted">
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <Spinner className="size-6" />
-          </EmptyMedia>
-        </EmptyHeader>
-      </Empty>
-    )
+    return <ManagerListLoading title="正在加载项目" />
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="mb-4 flex items-center gap-2">
-        <FolderGit2 className="size-5" />
-        <h1 className="text-xl font-semibold">项目</h1>
-      </div>
-      <div className="min-h-0 flex-1 overflow-auto">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>项目</TableHead>
-              <TableHead>仓库</TableHead>
-              <TableHead>创建人</TableHead>
-              <TableHead>任务</TableHead>
-              <TableHead>需求</TableHead>
-              <TableHead>创建时间</TableHead>
-              <TableHead>更新时间</TableHead>
+    <ManagerListCard
+      title="项目"
+      description="查看团队内项目、仓库来源、创建人和任务规模。"
+      icon={<IconFolder />}
+      count={projects.length}
+      pagination={
+        <TeamDataTablePagination
+          page={cursorHistory.length}
+          pageSize={pageSize}
+          loading={loading}
+          hasNextPage={hasNextPage}
+          canPrevPage={cursorHistory.length > 1}
+          onFirstPage={goFirst}
+          onPrevPage={goPrev}
+          onNextPage={goNext}
+          onPageSizeChange={changePageSize}
+        />
+      }
+    >
+      <Table>
+        <TableHeader>
+          <TableRow className="bg-muted/30 hover:bg-muted/30">
+            <TableHead className="px-6">项目</TableHead>
+            <TableHead>创建人</TableHead>
+            <TableHead className="text-right">任务</TableHead>
+            <TableHead className="text-right">需求</TableHead>
+            <TableHead>更新时间</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {!loading && projects.length === 0 && (
+            <ManagerListEmpty
+              colSpan={5}
+              title="暂无项目"
+              description="团队创建项目后，这里会显示项目、仓库和任务规模。"
+            />
+          )}
+          {projects.map((project) => (
+            <TableRow key={project.id}>
+              <TableCell className="px-6">
+                <div className="max-w-[480px] space-y-1">
+                  <div className="truncate font-medium">
+                    {project.name || "-"}
+                  </div>
+                  <div className="truncate text-xs leading-4 text-muted-foreground">
+                    {project.repo_url || "暂无仓库地址"}
+                  </div>
+                </div>
+              </TableCell>
+              <TableCell>
+                <div className="max-w-[180px] truncate text-sm">
+                  {creatorName(project)}
+                </div>
+              </TableCell>
+              <TableCell className="text-right font-medium">
+                {project.task_count || 0}
+              </TableCell>
+              <TableCell className="text-right text-muted-foreground">
+                {project.issue_count || 0}
+              </TableCell>
+              <TableCell>
+                <div className="space-y-1">
+                  <div className="text-sm">{formatTime(project.updated_at)}</div>
+                  <div className="text-xs leading-4 text-muted-foreground">
+                    创建于 {formatTime(project.created_at)}
+                  </div>
+                </div>
+              </TableCell>
             </TableRow>
-          </TableHeader>
-          <TableBody>
-            {!loading && projects.length === 0 && (
-              <TableRow>
-                <TableCell colSpan={7} className="py-3.5 text-center">
-                  无数据
-                </TableCell>
-              </TableRow>
-            )}
-            {projects.map((project) => (
-              <TableRow key={project.id}>
-                <TableCell className="font-medium">{project.name || "-"}</TableCell>
-                <TableCell className="max-w-[360px] truncate">{project.repo_url || "-"}</TableCell>
-                <TableCell>{project.creator?.name || project.creator?.email || "-"}</TableCell>
-                <TableCell>{project.task_count || 0}</TableCell>
-                <TableCell>{project.issue_count || 0}</TableCell>
-                <TableCell>{formatTime(project.created_at)}</TableCell>
-                <TableCell>{formatTime(project.updated_at)}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
-      <TeamDataTablePagination
-        page={cursorHistory.length}
-        pageSize={pageSize}
-        loading={loading}
-        hasNextPage={hasNextPage}
-        canPrevPage={cursorHistory.length > 1}
-        onFirstPage={goFirst}
-        onPrevPage={goPrev}
-        onNextPage={goNext}
-        onPageSizeChange={changePageSize}
-      />
-    </div>
+          ))}
+        </TableBody>
+      </Table>
+    </ManagerListCard>
   )
 }

--- a/frontend/src/pages/console/manager/tasks.tsx
+++ b/frontend/src/pages/console/manager/tasks.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from "react"
-import { ListTodo } from "lucide-react"
+import { IconListCheck } from "@tabler/icons-react"
 import { toast } from "sonner"
 
 import type { Dbv2Cursor, DomainTeamTaskItem } from "@/api/Api"
+import {
+  ManagerListEmpty,
+  ManagerListLoading,
+  ManagerListCard,
+} from "@/components/manager/manager-list-page"
 import { TeamDataTablePagination } from "@/components/manager/team-data-table-pagination"
 import { Badge } from "@/components/ui/badge"
-import { Empty, EmptyHeader, EmptyMedia } from "@/components/ui/empty"
-import { Spinner } from "@/components/ui/spinner"
 import {
   Table,
   TableBody,
@@ -15,6 +18,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { cn } from "@/lib/utils"
 import { apiRequest } from "@/utils/requestUtils"
 
 function formatTime(value?: number) {
@@ -24,6 +28,75 @@ function formatTime(value?: number) {
 
 function taskTitle(task: DomainTeamTaskItem) {
   return task.title || task.content || "未命名任务"
+}
+
+function creatorName(task: DomainTeamTaskItem) {
+  return task.creator?.name || task.creator?.email || "-"
+}
+
+function taskStatusMeta(status?: string) {
+  switch (status) {
+    case "pending":
+      return {
+        label: "准备中",
+        className: "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300",
+      }
+    case "processing":
+      return {
+        label: "运行中",
+        className: "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-500/30 dark:bg-blue-500/10 dark:text-blue-300",
+      }
+    case "finished":
+      return {
+        label: "已完成",
+        className: "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300",
+      }
+    case "error":
+      return {
+        label: "失败",
+        className: "border-destructive/20 bg-destructive/10 text-destructive",
+      }
+    default:
+      return {
+        label: status || "-",
+        className: "text-muted-foreground",
+      }
+  }
+}
+
+function taskKindText(kind?: string) {
+  switch (kind) {
+    case "develop":
+      return "开发"
+    case "design":
+      return "设计"
+    case "review":
+      return "评审"
+    case "generate_docs":
+      return "生成文档"
+    case "generate_requirement":
+      return "生成需求"
+    case "generate_design":
+      return "生成设计"
+    case "generate_tasklist":
+      return "生成任务"
+    case "execute_task":
+      return "执行任务"
+    case "pr_review":
+      return "PR 评审"
+    default:
+      return kind || "-"
+  }
+}
+
+function TaskStatusBadge({ status }: { status?: string }) {
+  const meta = taskStatusMeta(status)
+
+  return (
+    <Badge variant="outline" className={cn(meta.className)}>
+      {meta.label}
+    </Badge>
+  )
 }
 
 export default function TeamManagerTasks() {
@@ -82,71 +155,80 @@ export default function TeamManagerTasks() {
   }
 
   if (loading && tasks.length === 0) {
-    return (
-      <Empty className="bg-muted">
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <Spinner className="size-6" />
-          </EmptyMedia>
-        </EmptyHeader>
-      </Empty>
-    )
+    return <ManagerListLoading title="正在加载任务" />
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="mb-4 flex items-center gap-2">
-        <ListTodo className="size-5" />
-        <h1 className="text-xl font-semibold">任务</h1>
-      </div>
-      <div className="min-h-0 flex-1 overflow-auto">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>任务</TableHead>
-              <TableHead>项目</TableHead>
-              <TableHead>创建人</TableHead>
-              <TableHead>状态</TableHead>
-              <TableHead>类型</TableHead>
-              <TableHead>创建时间</TableHead>
-              <TableHead>最后活动</TableHead>
+    <ManagerListCard
+      title="任务"
+      description="查看团队任务的状态、归属项目、创建人和最后活动时间。"
+      icon={<IconListCheck />}
+      count={tasks.length}
+      pagination={
+        <TeamDataTablePagination
+          page={cursorHistory.length}
+          pageSize={pageSize}
+          loading={loading}
+          hasNextPage={hasNextPage}
+          canPrevPage={cursorHistory.length > 1}
+          onFirstPage={goFirst}
+          onPrevPage={goPrev}
+          onNextPage={goNext}
+          onPageSizeChange={changePageSize}
+        />
+      }
+    >
+      <Table>
+        <TableHeader>
+          <TableRow className="bg-muted/30 hover:bg-muted/30">
+            <TableHead className="px-6">任务</TableHead>
+            <TableHead>状态</TableHead>
+            <TableHead>类型</TableHead>
+            <TableHead>创建人</TableHead>
+            <TableHead>最后活动</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {!loading && tasks.length === 0 && (
+            <ManagerListEmpty
+              colSpan={5}
+              title="暂无任务"
+              description="团队成员创建任务后，这里会显示任务状态和活动时间。"
+            />
+          )}
+          {tasks.map((task) => (
+            <TableRow key={task.id}>
+              <TableCell className="px-6">
+                <div className="max-w-[520px] space-y-1">
+                  <div className="truncate font-medium">{taskTitle(task)}</div>
+                  <div className="truncate text-xs leading-4 text-muted-foreground">
+                    {task.project_name || "未关联项目"}
+                  </div>
+                </div>
+              </TableCell>
+              <TableCell>
+                <TaskStatusBadge status={task.status} />
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {taskKindText(task.kind)}
+              </TableCell>
+              <TableCell>
+                <div className="max-w-[180px] truncate text-sm">
+                  {creatorName(task)}
+                </div>
+              </TableCell>
+              <TableCell>
+                <div className="space-y-1">
+                  <div className="text-sm">{formatTime(task.last_active_at)}</div>
+                  <div className="text-xs leading-4 text-muted-foreground">
+                    创建于 {formatTime(task.created_at)}
+                  </div>
+                </div>
+              </TableCell>
             </TableRow>
-          </TableHeader>
-          <TableBody>
-            {!loading && tasks.length === 0 && (
-              <TableRow>
-                <TableCell colSpan={7} className="py-3.5 text-center">
-                  无数据
-                </TableCell>
-              </TableRow>
-            )}
-            {tasks.map((task) => (
-              <TableRow key={task.id}>
-                <TableCell className="max-w-[360px] truncate font-medium">{taskTitle(task)}</TableCell>
-                <TableCell>{task.project_name || "-"}</TableCell>
-                <TableCell>{task.creator?.name || task.creator?.email || "-"}</TableCell>
-                <TableCell>
-                  <Badge variant="outline">{task.status || "-"}</Badge>
-                </TableCell>
-                <TableCell>{task.kind || "-"}</TableCell>
-                <TableCell>{formatTime(task.created_at)}</TableCell>
-                <TableCell>{formatTime(task.last_active_at)}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
-      <TeamDataTablePagination
-        page={cursorHistory.length}
-        pageSize={pageSize}
-        loading={loading}
-        hasNextPage={hasNextPage}
-        canPrevPage={cursorHistory.length > 1}
-        onFirstPage={goFirst}
-        onPrevPage={goPrev}
-        onNextPage={goNext}
-        onPageSizeChange={changePageSize}
-      />
-    </div>
+          ))}
+        </TableBody>
+      </Table>
+    </ManagerListCard>
   )
 }


### PR DESCRIPTION
## 变更内容
- 统一项目、任务、对话页面为成员管理一致的卡片式列表结构
- 调整三类列表的信息层级和 8px 间距对齐
- 任务状态和类型增加中文映射，任务状态增加语义化颜色

## 验证
- pnpm build:online
- git diff --check