### PR TITLE
feat: 增加团队任务开发环境空闲策略

### DIFF
--- a/backend/biz/team/handler/http/v1/policy.go
+++ b/backend/biz/team/handler/http/v1/policy.go
@@ -1,0 +1,82 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/GoYoko/web"
+	"github.com/google/uuid"
+	"github.com/samber/do"
+
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/middleware"
+)
+
+type TeamPolicyHandler struct {
+	usecase domain.TeamPolicyUsecase
+	repo    domain.TeamPolicyRepo
+}
+
+func NewTeamPolicyHandler(i *do.Injector) (*TeamPolicyHandler, error) {
+	w := do.MustInvoke[*web.Web](i)
+	auth := do.MustInvoke[*middleware.AuthMiddleware](i)
+	audit := do.MustInvoke[*middleware.AuditMiddleware](i)
+
+	h := &TeamPolicyHandler{
+		usecase: do.MustInvoke[domain.TeamPolicyUsecase](i),
+		repo:    do.MustInvoke[domain.TeamPolicyRepo](i),
+	}
+
+	adminAuth := middleware.TeamAdminAuth(func(ctx context.Context, teamID, userID uuid.UUID) bool {
+		member, err := h.repo.GetMember(ctx, teamID, userID)
+		if err != nil {
+			return false
+		}
+		return member.Role == consts.TeamMemberRoleAdmin
+	})
+
+	g := w.Group("/api/v1/teams/task-vm-idle-policy")
+	g.GET("", web.BaseHandler(h.Get), auth.TeamAuth())
+	g.PUT("", web.BindHandler(h.Update), auth.TeamAuth(), adminAuth, audit.Audit("update_team_task_vm_idle_policy"))
+
+	return h, nil
+}
+
+// Get 获取任务开发环境空闲策略
+//
+//	@Summary		获取任务开发环境空闲策略
+//	@Description	获取当前团队任务创建开发环境的空闲休眠和回收策略
+//	@Tags			【Team 管理员】开发环境管理
+//	@Accept			json
+//	@Produce		json
+//	@Security		MonkeyCodeAITeamAuth
+//	@Success		200	{object}	web.Resp{data=domain.TeamTaskVMIdlePolicy}	"成功"
+//	@Router			/api/v1/teams/task-vm-idle-policy [get]
+func (h *TeamPolicyHandler) Get(c *web.Context) error {
+	teamUser := middleware.GetTeamUser(c)
+	resp, err := h.usecase.GetTaskVMIdlePolicy(c.Request().Context(), teamUser)
+	if err != nil {
+		return err
+	}
+	return c.Success(resp)
+}
+
+// Update 更新任务开发环境空闲策略
+//
+//	@Summary		更新任务开发环境空闲策略
+//	@Description	更新当前团队任务创建开发环境的空闲休眠和回收策略
+//	@Tags			【Team 管理员】开发环境管理
+//	@Accept			json
+//	@Produce		json
+//	@Security		MonkeyCodeAITeamAuth
+//	@Param			req	body		domain.UpdateTeamTaskVMIdlePolicyReq	true	"请求参数"
+//	@Success		200	{object}	web.Resp{data=domain.TeamTaskVMIdlePolicy}	"成功"
+//	@Router			/api/v1/teams/task-vm-idle-policy [put]
+func (h *TeamPolicyHandler) Update(c *web.Context, req domain.UpdateTeamTaskVMIdlePolicyReq) error {
+	teamUser := middleware.GetTeamUser(c)
+	resp, err := h.usecase.UpdateTaskVMIdlePolicy(c.Request().Context(), teamUser, &req)
+	if err != nil {
+		return err
+	}
+	return c.Success(resp)
+}

--- a/backend/biz/team/handler/http/v1/policy.go
+++ b/backend/biz/team/handler/http/v1/policy.go
@@ -69,7 +69,7 @@ func (h *TeamPolicyHandler) Get(c *web.Context) error {
 //	@Accept			json
 //	@Produce		json
 //	@Security		MonkeyCodeAITeamAuth
-//	@Param			req	body		domain.UpdateTeamTaskVMIdlePolicyReq	true	"请求参数"
+//	@Param			req	body		domain.UpdateTeamTaskVMIdlePolicyReq		true	"请求参数"
 //	@Success		200	{object}	web.Resp{data=domain.TeamTaskVMIdlePolicy}	"成功"
 //	@Router			/api/v1/teams/task-vm-idle-policy [put]
 func (h *TeamPolicyHandler) Update(c *web.Context, req domain.UpdateTeamTaskVMIdlePolicyReq) error {

--- a/backend/biz/team/handler/http/v1/policy_route_test.go
+++ b/backend/biz/team/handler/http/v1/policy_route_test.go
@@ -1,0 +1,70 @@
+package v1
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/GoYoko/web"
+	"github.com/google/uuid"
+	"github.com/samber/do"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/middleware"
+)
+
+func TestNewTeamPolicyHandlerRegistersRoutes(t *testing.T) {
+	injector := do.New()
+	w := web.New()
+	do.ProvideValue(injector, w)
+	do.ProvideValue(injector, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	do.ProvideValue(injector, &config.Config{})
+	do.ProvideValue(injector, &middleware.AuthMiddleware{})
+	do.ProvideValue(injector, &middleware.AuditMiddleware{})
+	do.ProvideValue[domain.TeamPolicyUsecase](injector, &teamPolicyUsecaseStub{})
+	do.ProvideValue[domain.TeamPolicyRepo](injector, &teamPolicyRepoStub{})
+
+	if _, err := NewTeamPolicyHandler(injector); err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]bool{
+		"GET /api/v1/teams/task-vm-idle-policy": false,
+		"PUT /api/v1/teams/task-vm-idle-policy": false,
+	}
+	for _, route := range w.Routes() {
+		key := route.Method + " " + route.Path
+		if _, ok := want[key]; ok {
+			want[key] = true
+		}
+	}
+	for route, ok := range want {
+		if !ok {
+			t.Fatalf("%s route is not registered", route)
+		}
+	}
+}
+
+type teamPolicyUsecaseStub struct {
+	domain.TeamPolicyUsecase
+}
+
+func (s *teamPolicyUsecaseStub) GetTaskVMIdlePolicy(ctx context.Context, teamUser *domain.TeamUser) (*domain.TeamTaskVMIdlePolicy, error) {
+	return &domain.TeamTaskVMIdlePolicy{}, nil
+}
+
+func (s *teamPolicyUsecaseStub) UpdateTaskVMIdlePolicy(ctx context.Context, teamUser *domain.TeamUser, req *domain.UpdateTeamTaskVMIdlePolicyReq) (*domain.TeamTaskVMIdlePolicy, error) {
+	return &domain.TeamTaskVMIdlePolicy{}, nil
+}
+
+type teamPolicyRepoStub struct {
+	domain.TeamPolicyRepo
+}
+
+func (s *teamPolicyRepoStub) GetMember(ctx context.Context, teamID, userID uuid.UUID) (*db.TeamMember, error) {
+	return &db.TeamMember{Role: consts.TeamMemberRoleAdmin}, nil
+}

--- a/backend/biz/team/register.go
+++ b/backend/biz/team/register.go
@@ -27,6 +27,9 @@ func ProvideTeam(i *do.Injector) {
 	do.Provide(i, repo.NewTeamHostRepo)
 	do.Provide(i, usecase.NewTeamHostUsecase)
 	do.Provide(i, v1.NewTeamHostHandler)
+	do.Provide(i, repo.NewTeamPolicyRepo)
+	do.Provide(i, usecase.NewTeamPolicyUsecase)
+	do.Provide(i, v1.NewTeamPolicyHandler)
 	do.Provide(i, v1.NewTeamGroupUserHandler)
 }
 
@@ -41,4 +44,5 @@ func InvokeTeam(i *do.Injector) {
 	do.MustInvoke[*v1.TeamModelHandler](i)
 	do.MustInvoke[*v1.TeamImageHandler](i)
 	do.MustInvoke[*v1.TeamHostHandler](i)
+	do.MustInvoke[*v1.TeamPolicyHandler](i)
 }

--- a/backend/biz/team/repo/policy.go
+++ b/backend/biz/team/repo/policy.go
@@ -1,0 +1,49 @@
+package repo
+
+import (
+	"context"
+
+	"entgo.io/ent/dialect/sql"
+	"github.com/google/uuid"
+	"github.com/samber/do"
+
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/db/team"
+	"github.com/chaitin/MonkeyCode/backend/db/teammember"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+type TeamPolicyRepo struct {
+	db *db.Client
+}
+
+func NewTeamPolicyRepo(i *do.Injector) (domain.TeamPolicyRepo, error) {
+	return &TeamPolicyRepo{db: do.MustInvoke[*db.Client](i)}, nil
+}
+
+func (r *TeamPolicyRepo) GetTeam(ctx context.Context, teamID uuid.UUID) (*db.Team, error) {
+	return r.db.Team.Get(ctx, teamID)
+}
+
+func (r *TeamPolicyRepo) GetTeamByUserID(ctx context.Context, userID uuid.UUID) (*db.Team, error) {
+	return r.db.Team.Query().
+		Where(team.HasTeamMembersWith(teammember.UserIDEQ(userID))).
+		Order(team.ByCreatedAt(sql.OrderAsc())).
+		First(ctx)
+}
+
+func (r *TeamPolicyRepo) UpdateTaskVMIdlePolicy(ctx context.Context, teamID uuid.UUID, req *domain.UpdateTeamTaskVMIdlePolicyReq) (*db.Team, error) {
+	return r.db.Team.UpdateOneID(teamID).
+		SetTaskVMSleepEnabled(req.SleepEnabled).
+		SetTaskVMSleepSeconds(req.SleepSeconds).
+		SetTaskVMRecycleEnabled(req.RecycleEnabled).
+		SetTaskVMRecycleSeconds(req.RecycleSeconds).
+		Save(ctx)
+}
+
+func (r *TeamPolicyRepo) GetMember(ctx context.Context, teamID, userID uuid.UUID) (*db.TeamMember, error) {
+	return r.db.TeamMember.Query().
+		Where(teammember.TeamIDEQ(teamID), teammember.UserIDEQ(userID)).
+		WithUser().
+		First(ctx)
+}

--- a/backend/biz/team/usecase/policy.go
+++ b/backend/biz/team/usecase/policy.go
@@ -1,0 +1,43 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/do"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/errcode"
+)
+
+type TeamPolicyUsecase struct {
+	repo domain.TeamPolicyRepo
+	cfg  *config.Config
+}
+
+func NewTeamPolicyUsecase(i *do.Injector) (domain.TeamPolicyUsecase, error) {
+	return &TeamPolicyUsecase{
+		repo: do.MustInvoke[domain.TeamPolicyRepo](i),
+		cfg:  do.MustInvoke[*config.Config](i),
+	}, nil
+}
+
+func (u *TeamPolicyUsecase) GetTaskVMIdlePolicy(ctx context.Context, teamUser *domain.TeamUser) (*domain.TeamTaskVMIdlePolicy, error) {
+	team, err := u.repo.GetTeam(ctx, teamUser.GetTeamID())
+	if err != nil {
+		return nil, err
+	}
+	return domain.ResolveTeamTaskVMIdlePolicy(team, u.cfg.VMIdle)
+}
+
+func (u *TeamPolicyUsecase) UpdateTaskVMIdlePolicy(ctx context.Context, teamUser *domain.TeamUser, req *domain.UpdateTeamTaskVMIdlePolicyReq) (*domain.TeamTaskVMIdlePolicy, error) {
+	if _, err := domain.NewTeamTaskVMIdlePolicyFromReq(teamUser.GetTeamID(), req, u.cfg.VMIdle); err != nil {
+		return nil, errcode.ErrInvalidParameter.Wrap(fmt.Errorf("invalid task vm idle policy: %w", err))
+	}
+	team, err := u.repo.UpdateTaskVMIdlePolicy(ctx, teamUser.GetTeamID(), req)
+	if err != nil {
+		return nil, err
+	}
+	return domain.ResolveTeamTaskVMIdlePolicy(team, u.cfg.VMIdle)
+}

--- a/backend/biz/vmidle/usecase/policy_test.go
+++ b/backend/biz/vmidle/usecase/policy_test.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+func TestVMIdleSchedulePlanFromPolicy(t *testing.T) {
+	policy := &domain.TeamTaskVMIdlePolicy{
+		TeamID:                  uuid.New(),
+		SleepEnabled:            false,
+		EffectiveSleepSeconds:   0,
+		RecycleEnabled:          true,
+		EffectiveRecycleSeconds: 3600,
+	}
+	schedules := []notifySchedule{{name: "default", lead: 600 * time.Second, leadSeconds: 600}}
+
+	got := buildVMIdleSchedulePlan(policy, schedules)
+	if got.SleepAt != nil {
+		t.Fatalf("sleep should be disabled: %#v", got.SleepAt)
+	}
+	if got.RecycleAt == nil {
+		t.Fatal("recycle should be scheduled")
+	}
+	if len(got.NotifyJobs) != 1 || got.NotifyJobs[0].MemberSuffix != "default" {
+		t.Fatalf("notify jobs = %#v", got.NotifyJobs)
+	}
+}
+
+func TestResolvePolicyForVMFallsBackToGlobalWhenTeamMissing(t *testing.T) {
+	r := &vmIdleRefresher{
+		cfg: &config.Config{VMIdle: config.VMIdle{SleepSeconds: 600, RecycleSeconds: 604800}},
+	}
+	vm := &db.VirtualMachine{ID: "vm-1"}
+
+	got, err := r.resolvePolicyForVM(context.Background(), vm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.SleepEnabled || got.EffectiveSleepSeconds != 600 {
+		t.Fatalf("sleep policy = %#v", got)
+	}
+	if !got.RecycleEnabled || got.EffectiveRecycleSeconds != 604800 {
+		t.Fatalf("recycle policy = %#v", got)
+	}
+}

--- a/backend/biz/vmidle/usecase/vmidle.go
+++ b/backend/biz/vmidle/usecase/vmidle.go
@@ -100,11 +100,24 @@ type vmIdleRefresher struct {
 	logger           *slog.Logger
 	hostRepo         domain.HostRepo
 	taskRepo         domain.TaskRepo
+	teamPolicyRepo   domain.TeamPolicyRepo
 	notifyDispatcher *dispatcher.Dispatcher
 	sleepQueue       *delayqueue.VMSleepQueue
 	notifyQueue      *delayqueue.VMNotifyQueue
 	recycleQueue     *delayqueue.VMRecycleQueue
 	schedules        []notifySchedule
+}
+
+type vmIdleNotifyJob struct {
+	MemberSuffix string
+	RunAt        time.Time
+	LeadSeconds  int
+}
+
+type vmIdleSchedulePlan struct {
+	SleepAt    *time.Time
+	RecycleAt  *time.Time
+	NotifyJobs []vmIdleNotifyJob
 }
 
 func NewVMIdleRefresher(i *do.Injector) (VMIdleRefresher, error) {
@@ -116,6 +129,7 @@ func NewVMIdleRefresher(i *do.Injector) (VMIdleRefresher, error) {
 		logger:           do.MustInvoke[*slog.Logger](i).With("module", "VMIdleRefresher"),
 		hostRepo:         do.MustInvoke[domain.HostRepo](i),
 		taskRepo:         do.MustInvoke[domain.TaskRepo](i),
+		teamPolicyRepo:   do.MustInvoke[domain.TeamPolicyRepo](i),
 		notifyDispatcher: do.MustInvoke[*dispatcher.Dispatcher](i),
 		sleepQueue:       do.MustInvoke[*delayqueue.VMSleepQueue](i),
 		notifyQueue:      do.MustInvoke[*delayqueue.VMNotifyQueue](i),
@@ -165,6 +179,46 @@ func (r *vmIdleRefresher) notifyRemainingFor(lead time.Duration) time.Duration {
 	return lead
 }
 
+func (r *vmIdleRefresher) resolvePolicyForVM(ctx context.Context, vm *db.VirtualMachine) (*domain.TeamTaskVMIdlePolicy, error) {
+	if r.teamPolicyRepo == nil || vm == nil || vm.UserID == uuid.Nil {
+		return domain.ResolveTeamTaskVMIdlePolicy(nil, r.cfg.VMIdle)
+	}
+	team, err := r.teamPolicyRepo.GetTeamByUserID(ctx, vm.UserID)
+	if err != nil {
+		if db.IsNotFound(err) {
+			return domain.ResolveTeamTaskVMIdlePolicy(nil, r.cfg.VMIdle)
+		}
+		r.logger.ErrorContext(ctx, "failed to get team policy, fallback to global", "vm_id", vm.ID, "user_id", vm.UserID, "error", err)
+		return domain.ResolveTeamTaskVMIdlePolicy(nil, r.cfg.VMIdle)
+	}
+	return domain.ResolveTeamTaskVMIdlePolicy(team, r.cfg.VMIdle)
+}
+
+func buildVMIdleSchedulePlan(policy *domain.TeamTaskVMIdlePolicy, schedules []notifySchedule) vmIdleSchedulePlan {
+	now := time.Now()
+	var plan vmIdleSchedulePlan
+	if policy.SleepEnabled {
+		sleepAt := now.Add(time.Duration(policy.EffectiveSleepSeconds) * time.Second)
+		plan.SleepAt = &sleepAt
+	}
+	if policy.RecycleEnabled {
+		recycleAt := now.Add(time.Duration(policy.EffectiveRecycleSeconds) * time.Second)
+		plan.RecycleAt = &recycleAt
+		for _, s := range schedules {
+			delay := time.Duration(policy.EffectiveRecycleSeconds)*time.Second - s.lead
+			if delay < 0 {
+				delay = 0
+			}
+			plan.NotifyJobs = append(plan.NotifyJobs, vmIdleNotifyJob{
+				MemberSuffix: s.name,
+				RunAt:        now.Add(delay),
+				LeadSeconds:  s.leadSeconds,
+			})
+		}
+	}
+	return plan
+}
+
 func (r *vmIdleRefresher) Refresh(ctx context.Context, vmID string) error {
 	vm, err := r.hostRepo.GetVirtualMachine(ctx, vmID)
 	if err != nil {
@@ -187,8 +241,15 @@ func (r *vmIdleRefresher) Refresh(ctx context.Context, vmID string) error {
 		return nil
 	}
 
-	now := time.Now()
-	recycleAt := now.Add(r.recycleDelay())
+	policy, err := r.resolvePolicyForVM(ctx, vm)
+	if err != nil {
+		return err
+	}
+	plan := buildVMIdleSchedulePlan(policy, r.schedules)
+	recycleAt := time.Time{}
+	if plan.RecycleAt != nil {
+		recycleAt = *plan.RecycleAt
+	}
 	payload := &domain.VmIdleInfo{
 		UID:       vm.UserID,
 		VmID:      vm.ID,
@@ -198,32 +259,46 @@ func (r *vmIdleRefresher) Refresh(ctx context.Context, vmID string) error {
 	}
 
 	var errs []error
-	if _, err := r.sleepQueue.Enqueue(ctx, sleepQueueKey, payload, now.Add(r.sleepDelay()), vmID); err != nil {
-		r.logger.ErrorContext(ctx, "failed to enqueue sleep", "error", err, "vmID", vmID)
-		errs = append(errs, fmt.Errorf("enqueue sleep: %w", err))
+	if plan.SleepAt != nil {
+		if _, err := r.sleepQueue.Enqueue(ctx, sleepQueueKey, payload, *plan.SleepAt, vmID); err != nil {
+			r.logger.ErrorContext(ctx, "failed to enqueue sleep", "error", err, "vmID", vmID)
+			errs = append(errs, fmt.Errorf("enqueue sleep: %w", err))
+		}
+	} else if err := r.sleepQueue.Remove(ctx, sleepQueueKey, vmID); err != nil {
+		r.logger.ErrorContext(ctx, "failed to remove sleep", "error", err, "vmID", vmID)
+		errs = append(errs, fmt.Errorf("remove sleep: %w", err))
 	}
 	for _, s := range r.schedules {
-		// member key 带 tier name 后缀，让同一 VM 的不同档作业互不覆盖。
-		// 同档再次 Enqueue 会用新 runAt + 新 payload(含新 RecycleAt) 覆盖旧作业，
-		// 实现"每次 Refresh 重新计时"。
 		member := fmt.Sprintf("%s:%s", vmID, s.name)
-		delay := r.notifyDelayFor(s.lead)
-		runAt := now.Add(delay)
-		if _, err := r.notifyQueue.Enqueue(ctx, notifyQueueKey, payload, runAt, member); err != nil {
-			r.logger.ErrorContext(ctx, "failed to enqueue notify", "error", err, "vm_id", vmID, "tier", s.name)
-			errs = append(errs, fmt.Errorf("enqueue notify %s: %w", s.name, err))
+		if !policy.RecycleEnabled {
+			if err := r.notifyQueue.Remove(ctx, notifyQueueKey, member); err != nil {
+				r.logger.ErrorContext(ctx, "failed to remove notify", "error", err, "vm_id", vmID, "tier", s.name)
+				errs = append(errs, fmt.Errorf("remove notify %s: %w", s.name, err))
+			}
+		}
+	}
+	for _, job := range plan.NotifyJobs {
+		// member key 带 tier name 后缀，让同一 VM 的不同档作业互不覆盖。
+		member := fmt.Sprintf("%s:%s", vmID, job.MemberSuffix)
+		if _, err := r.notifyQueue.Enqueue(ctx, notifyQueueKey, payload, job.RunAt, member); err != nil {
+			r.logger.ErrorContext(ctx, "failed to enqueue notify", "error", err, "vm_id", vmID, "tier", job.MemberSuffix)
+			errs = append(errs, fmt.Errorf("enqueue notify %s: %w", job.MemberSuffix, err))
 			continue
 		}
 		r.logger.DebugContext(ctx, "notify tier scheduled",
 			"vm_id", vmID,
-			"tier", s.name,
-			"lead_seconds", s.leadSeconds,
-			"delay_seconds", int(delay.Seconds()),
-			"fire_at", runAt.Format(time.RFC3339))
+			"tier", job.MemberSuffix,
+			"lead_seconds", job.LeadSeconds,
+			"fire_at", job.RunAt.Format(time.RFC3339))
 	}
-	if _, err := r.recycleQueue.Enqueue(ctx, recycleQueueKey, payload, now.Add(r.recycleDelay()), vmID); err != nil {
-		r.logger.ErrorContext(ctx, "failed to enqueue recycle", "error", err, "vmID", vmID)
-		errs = append(errs, fmt.Errorf("enqueue recycle: %w", err))
+	if plan.RecycleAt != nil {
+		if _, err := r.recycleQueue.Enqueue(ctx, recycleQueueKey, payload, *plan.RecycleAt, vmID); err != nil {
+			r.logger.ErrorContext(ctx, "failed to enqueue recycle", "error", err, "vmID", vmID)
+			errs = append(errs, fmt.Errorf("enqueue recycle: %w", err))
+		}
+	} else if err := r.recycleQueue.Remove(ctx, recycleQueueKey, vmID); err != nil {
+		r.logger.ErrorContext(ctx, "failed to remove recycle", "error", err, "vmID", vmID)
+		errs = append(errs, fmt.Errorf("remove recycle: %w", err))
 	}
 	return errors.Join(errs...)
 }

--- a/backend/db/migrate/schema.go
+++ b/backend/db/migrate/schema.go
@@ -941,6 +941,10 @@ var (
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "name", Type: field.TypeString},
 		{Name: "member_limit", Type: field.TypeInt},
+		{Name: "task_vm_sleep_enabled", Type: field.TypeBool, Default: true},
+		{Name: "task_vm_sleep_seconds", Type: field.TypeInt, Default: 0},
+		{Name: "task_vm_recycle_enabled", Type: field.TypeBool, Default: true},
+		{Name: "task_vm_recycle_seconds", Type: field.TypeInt, Default: 0},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 	}

--- a/backend/db/mutation.go
+++ b/backend/db/mutation.go
@@ -29173,40 +29173,46 @@ func (m *TaskVirtualMachineMutation) ResetEdge(name string) error {
 // TeamMutation represents an operation that mutates the Team nodes in the graph.
 type TeamMutation struct {
 	config
-	op                  Op
-	typ                 string
-	id                  *uuid.UUID
-	deleted_at          *time.Time
-	name                *string
-	member_limit        *int
-	addmember_limit     *int
-	created_at          *time.Time
-	updated_at          *time.Time
-	clearedFields       map[string]struct{}
-	groups              map[uuid.UUID]struct{}
-	removedgroups       map[uuid.UUID]struct{}
-	clearedgroups       bool
-	members             map[uuid.UUID]struct{}
-	removedmembers      map[uuid.UUID]struct{}
-	clearedmembers      bool
-	models              map[uuid.UUID]struct{}
-	removedmodels       map[uuid.UUID]struct{}
-	clearedmodels       bool
-	images              map[uuid.UUID]struct{}
-	removedimages       map[uuid.UUID]struct{}
-	clearedimages       bool
-	team_members        map[uuid.UUID]struct{}
-	removedteam_members map[uuid.UUID]struct{}
-	clearedteam_members bool
-	team_models         map[uuid.UUID]struct{}
-	removedteam_models  map[uuid.UUID]struct{}
-	clearedteam_models  bool
-	team_images         map[uuid.UUID]struct{}
-	removedteam_images  map[uuid.UUID]struct{}
-	clearedteam_images  bool
-	done                bool
-	oldValue            func(context.Context) (*Team, error)
-	predicates          []predicate.Team
+	op                         Op
+	typ                        string
+	id                         *uuid.UUID
+	deleted_at                 *time.Time
+	name                       *string
+	member_limit               *int
+	addmember_limit            *int
+	task_vm_sleep_enabled      *bool
+	task_vm_sleep_seconds      *int
+	addtask_vm_sleep_seconds   *int
+	task_vm_recycle_enabled    *bool
+	task_vm_recycle_seconds    *int
+	addtask_vm_recycle_seconds *int
+	created_at                 *time.Time
+	updated_at                 *time.Time
+	clearedFields              map[string]struct{}
+	groups                     map[uuid.UUID]struct{}
+	removedgroups              map[uuid.UUID]struct{}
+	clearedgroups              bool
+	members                    map[uuid.UUID]struct{}
+	removedmembers             map[uuid.UUID]struct{}
+	clearedmembers             bool
+	models                     map[uuid.UUID]struct{}
+	removedmodels              map[uuid.UUID]struct{}
+	clearedmodels              bool
+	images                     map[uuid.UUID]struct{}
+	removedimages              map[uuid.UUID]struct{}
+	clearedimages              bool
+	team_members               map[uuid.UUID]struct{}
+	removedteam_members        map[uuid.UUID]struct{}
+	clearedteam_members        bool
+	team_models                map[uuid.UUID]struct{}
+	removedteam_models         map[uuid.UUID]struct{}
+	clearedteam_models         bool
+	team_images                map[uuid.UUID]struct{}
+	removedteam_images         map[uuid.UUID]struct{}
+	clearedteam_images         bool
+	done                       bool
+	oldValue                   func(context.Context) (*Team, error)
+	predicates                 []predicate.Team
 }
 
 var _ ent.Mutation = (*TeamMutation)(nil)
@@ -29452,6 +29458,190 @@ func (m *TeamMutation) AddedMemberLimit() (r int, exists bool) {
 func (m *TeamMutation) ResetMemberLimit() {
 	m.member_limit = nil
 	m.addmember_limit = nil
+}
+
+// SetTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field.
+func (m *TeamMutation) SetTaskVMSleepEnabled(b bool) {
+	m.task_vm_sleep_enabled = &b
+}
+
+// TaskVMSleepEnabled returns the value of the "task_vm_sleep_enabled" field in the mutation.
+func (m *TeamMutation) TaskVMSleepEnabled() (r bool, exists bool) {
+	v := m.task_vm_sleep_enabled
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldTaskVMSleepEnabled returns the old "task_vm_sleep_enabled" field's value of the Team entity.
+// If the Team object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TeamMutation) OldTaskVMSleepEnabled(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldTaskVMSleepEnabled is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldTaskVMSleepEnabled requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldTaskVMSleepEnabled: %w", err)
+	}
+	return oldValue.TaskVMSleepEnabled, nil
+}
+
+// ResetTaskVMSleepEnabled resets all changes to the "task_vm_sleep_enabled" field.
+func (m *TeamMutation) ResetTaskVMSleepEnabled() {
+	m.task_vm_sleep_enabled = nil
+}
+
+// SetTaskVMSleepSeconds sets the "task_vm_sleep_seconds" field.
+func (m *TeamMutation) SetTaskVMSleepSeconds(i int) {
+	m.task_vm_sleep_seconds = &i
+	m.addtask_vm_sleep_seconds = nil
+}
+
+// TaskVMSleepSeconds returns the value of the "task_vm_sleep_seconds" field in the mutation.
+func (m *TeamMutation) TaskVMSleepSeconds() (r int, exists bool) {
+	v := m.task_vm_sleep_seconds
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldTaskVMSleepSeconds returns the old "task_vm_sleep_seconds" field's value of the Team entity.
+// If the Team object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TeamMutation) OldTaskVMSleepSeconds(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldTaskVMSleepSeconds is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldTaskVMSleepSeconds requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldTaskVMSleepSeconds: %w", err)
+	}
+	return oldValue.TaskVMSleepSeconds, nil
+}
+
+// AddTaskVMSleepSeconds adds i to the "task_vm_sleep_seconds" field.
+func (m *TeamMutation) AddTaskVMSleepSeconds(i int) {
+	if m.addtask_vm_sleep_seconds != nil {
+		*m.addtask_vm_sleep_seconds += i
+	} else {
+		m.addtask_vm_sleep_seconds = &i
+	}
+}
+
+// AddedTaskVMSleepSeconds returns the value that was added to the "task_vm_sleep_seconds" field in this mutation.
+func (m *TeamMutation) AddedTaskVMSleepSeconds() (r int, exists bool) {
+	v := m.addtask_vm_sleep_seconds
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetTaskVMSleepSeconds resets all changes to the "task_vm_sleep_seconds" field.
+func (m *TeamMutation) ResetTaskVMSleepSeconds() {
+	m.task_vm_sleep_seconds = nil
+	m.addtask_vm_sleep_seconds = nil
+}
+
+// SetTaskVMRecycleEnabled sets the "task_vm_recycle_enabled" field.
+func (m *TeamMutation) SetTaskVMRecycleEnabled(b bool) {
+	m.task_vm_recycle_enabled = &b
+}
+
+// TaskVMRecycleEnabled returns the value of the "task_vm_recycle_enabled" field in the mutation.
+func (m *TeamMutation) TaskVMRecycleEnabled() (r bool, exists bool) {
+	v := m.task_vm_recycle_enabled
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldTaskVMRecycleEnabled returns the old "task_vm_recycle_enabled" field's value of the Team entity.
+// If the Team object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TeamMutation) OldTaskVMRecycleEnabled(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldTaskVMRecycleEnabled is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldTaskVMRecycleEnabled requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldTaskVMRecycleEnabled: %w", err)
+	}
+	return oldValue.TaskVMRecycleEnabled, nil
+}
+
+// ResetTaskVMRecycleEnabled resets all changes to the "task_vm_recycle_enabled" field.
+func (m *TeamMutation) ResetTaskVMRecycleEnabled() {
+	m.task_vm_recycle_enabled = nil
+}
+
+// SetTaskVMRecycleSeconds sets the "task_vm_recycle_seconds" field.
+func (m *TeamMutation) SetTaskVMRecycleSeconds(i int) {
+	m.task_vm_recycle_seconds = &i
+	m.addtask_vm_recycle_seconds = nil
+}
+
+// TaskVMRecycleSeconds returns the value of the "task_vm_recycle_seconds" field in the mutation.
+func (m *TeamMutation) TaskVMRecycleSeconds() (r int, exists bool) {
+	v := m.task_vm_recycle_seconds
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldTaskVMRecycleSeconds returns the old "task_vm_recycle_seconds" field's value of the Team entity.
+// If the Team object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TeamMutation) OldTaskVMRecycleSeconds(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldTaskVMRecycleSeconds is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldTaskVMRecycleSeconds requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldTaskVMRecycleSeconds: %w", err)
+	}
+	return oldValue.TaskVMRecycleSeconds, nil
+}
+
+// AddTaskVMRecycleSeconds adds i to the "task_vm_recycle_seconds" field.
+func (m *TeamMutation) AddTaskVMRecycleSeconds(i int) {
+	if m.addtask_vm_recycle_seconds != nil {
+		*m.addtask_vm_recycle_seconds += i
+	} else {
+		m.addtask_vm_recycle_seconds = &i
+	}
+}
+
+// AddedTaskVMRecycleSeconds returns the value that was added to the "task_vm_recycle_seconds" field in this mutation.
+func (m *TeamMutation) AddedTaskVMRecycleSeconds() (r int, exists bool) {
+	v := m.addtask_vm_recycle_seconds
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetTaskVMRecycleSeconds resets all changes to the "task_vm_recycle_seconds" field.
+func (m *TeamMutation) ResetTaskVMRecycleSeconds() {
+	m.task_vm_recycle_seconds = nil
+	m.addtask_vm_recycle_seconds = nil
 }
 
 // SetCreatedAt sets the "created_at" field.
@@ -29938,7 +30128,7 @@ func (m *TeamMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *TeamMutation) Fields() []string {
-	fields := make([]string, 0, 5)
+	fields := make([]string, 0, 9)
 	if m.deleted_at != nil {
 		fields = append(fields, team.FieldDeletedAt)
 	}
@@ -29947,6 +30137,18 @@ func (m *TeamMutation) Fields() []string {
 	}
 	if m.member_limit != nil {
 		fields = append(fields, team.FieldMemberLimit)
+	}
+	if m.task_vm_sleep_enabled != nil {
+		fields = append(fields, team.FieldTaskVMSleepEnabled)
+	}
+	if m.task_vm_sleep_seconds != nil {
+		fields = append(fields, team.FieldTaskVMSleepSeconds)
+	}
+	if m.task_vm_recycle_enabled != nil {
+		fields = append(fields, team.FieldTaskVMRecycleEnabled)
+	}
+	if m.task_vm_recycle_seconds != nil {
+		fields = append(fields, team.FieldTaskVMRecycleSeconds)
 	}
 	if m.created_at != nil {
 		fields = append(fields, team.FieldCreatedAt)
@@ -29968,6 +30170,14 @@ func (m *TeamMutation) Field(name string) (ent.Value, bool) {
 		return m.Name()
 	case team.FieldMemberLimit:
 		return m.MemberLimit()
+	case team.FieldTaskVMSleepEnabled:
+		return m.TaskVMSleepEnabled()
+	case team.FieldTaskVMSleepSeconds:
+		return m.TaskVMSleepSeconds()
+	case team.FieldTaskVMRecycleEnabled:
+		return m.TaskVMRecycleEnabled()
+	case team.FieldTaskVMRecycleSeconds:
+		return m.TaskVMRecycleSeconds()
 	case team.FieldCreatedAt:
 		return m.CreatedAt()
 	case team.FieldUpdatedAt:
@@ -29987,6 +30197,14 @@ func (m *TeamMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldName(ctx)
 	case team.FieldMemberLimit:
 		return m.OldMemberLimit(ctx)
+	case team.FieldTaskVMSleepEnabled:
+		return m.OldTaskVMSleepEnabled(ctx)
+	case team.FieldTaskVMSleepSeconds:
+		return m.OldTaskVMSleepSeconds(ctx)
+	case team.FieldTaskVMRecycleEnabled:
+		return m.OldTaskVMRecycleEnabled(ctx)
+	case team.FieldTaskVMRecycleSeconds:
+		return m.OldTaskVMRecycleSeconds(ctx)
 	case team.FieldCreatedAt:
 		return m.OldCreatedAt(ctx)
 	case team.FieldUpdatedAt:
@@ -30021,6 +30239,34 @@ func (m *TeamMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetMemberLimit(v)
 		return nil
+	case team.FieldTaskVMSleepEnabled:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetTaskVMSleepEnabled(v)
+		return nil
+	case team.FieldTaskVMSleepSeconds:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetTaskVMSleepSeconds(v)
+		return nil
+	case team.FieldTaskVMRecycleEnabled:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetTaskVMRecycleEnabled(v)
+		return nil
+	case team.FieldTaskVMRecycleSeconds:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetTaskVMRecycleSeconds(v)
+		return nil
 	case team.FieldCreatedAt:
 		v, ok := value.(time.Time)
 		if !ok {
@@ -30046,6 +30292,12 @@ func (m *TeamMutation) AddedFields() []string {
 	if m.addmember_limit != nil {
 		fields = append(fields, team.FieldMemberLimit)
 	}
+	if m.addtask_vm_sleep_seconds != nil {
+		fields = append(fields, team.FieldTaskVMSleepSeconds)
+	}
+	if m.addtask_vm_recycle_seconds != nil {
+		fields = append(fields, team.FieldTaskVMRecycleSeconds)
+	}
 	return fields
 }
 
@@ -30056,6 +30308,10 @@ func (m *TeamMutation) AddedField(name string) (ent.Value, bool) {
 	switch name {
 	case team.FieldMemberLimit:
 		return m.AddedMemberLimit()
+	case team.FieldTaskVMSleepSeconds:
+		return m.AddedTaskVMSleepSeconds()
+	case team.FieldTaskVMRecycleSeconds:
+		return m.AddedTaskVMRecycleSeconds()
 	}
 	return nil, false
 }
@@ -30071,6 +30327,20 @@ func (m *TeamMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddMemberLimit(v)
+		return nil
+	case team.FieldTaskVMSleepSeconds:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddTaskVMSleepSeconds(v)
+		return nil
+	case team.FieldTaskVMRecycleSeconds:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddTaskVMRecycleSeconds(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Team numeric field %s", name)
@@ -30116,6 +30386,18 @@ func (m *TeamMutation) ResetField(name string) error {
 		return nil
 	case team.FieldMemberLimit:
 		m.ResetMemberLimit()
+		return nil
+	case team.FieldTaskVMSleepEnabled:
+		m.ResetTaskVMSleepEnabled()
+		return nil
+	case team.FieldTaskVMSleepSeconds:
+		m.ResetTaskVMSleepSeconds()
+		return nil
+	case team.FieldTaskVMRecycleEnabled:
+		m.ResetTaskVMRecycleEnabled()
+		return nil
+	case team.FieldTaskVMRecycleSeconds:
+		m.ResetTaskVMRecycleSeconds()
 		return nil
 	case team.FieldCreatedAt:
 		m.ResetCreatedAt()

--- a/backend/db/runtime/runtime.go
+++ b/backend/db/runtime/runtime.go
@@ -756,12 +756,28 @@ func init() {
 	teamDescName := teamFields[1].Descriptor()
 	// team.NameValidator is a validator for the "name" field. It is called by the builders before save.
 	team.NameValidator = teamDescName.Validators[0].(func(string) error)
+	// teamDescTaskVMSleepEnabled is the schema descriptor for task_vm_sleep_enabled field.
+	teamDescTaskVMSleepEnabled := teamFields[3].Descriptor()
+	// team.DefaultTaskVMSleepEnabled holds the default value on creation for the task_vm_sleep_enabled field.
+	team.DefaultTaskVMSleepEnabled = teamDescTaskVMSleepEnabled.Default.(bool)
+	// teamDescTaskVMSleepSeconds is the schema descriptor for task_vm_sleep_seconds field.
+	teamDescTaskVMSleepSeconds := teamFields[4].Descriptor()
+	// team.DefaultTaskVMSleepSeconds holds the default value on creation for the task_vm_sleep_seconds field.
+	team.DefaultTaskVMSleepSeconds = teamDescTaskVMSleepSeconds.Default.(int)
+	// teamDescTaskVMRecycleEnabled is the schema descriptor for task_vm_recycle_enabled field.
+	teamDescTaskVMRecycleEnabled := teamFields[5].Descriptor()
+	// team.DefaultTaskVMRecycleEnabled holds the default value on creation for the task_vm_recycle_enabled field.
+	team.DefaultTaskVMRecycleEnabled = teamDescTaskVMRecycleEnabled.Default.(bool)
+	// teamDescTaskVMRecycleSeconds is the schema descriptor for task_vm_recycle_seconds field.
+	teamDescTaskVMRecycleSeconds := teamFields[6].Descriptor()
+	// team.DefaultTaskVMRecycleSeconds holds the default value on creation for the task_vm_recycle_seconds field.
+	team.DefaultTaskVMRecycleSeconds = teamDescTaskVMRecycleSeconds.Default.(int)
 	// teamDescCreatedAt is the schema descriptor for created_at field.
-	teamDescCreatedAt := teamFields[3].Descriptor()
+	teamDescCreatedAt := teamFields[7].Descriptor()
 	// team.DefaultCreatedAt holds the default value on creation for the created_at field.
 	team.DefaultCreatedAt = teamDescCreatedAt.Default.(func() time.Time)
 	// teamDescUpdatedAt is the schema descriptor for updated_at field.
-	teamDescUpdatedAt := teamFields[4].Descriptor()
+	teamDescUpdatedAt := teamFields[8].Descriptor()
 	// team.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	team.DefaultUpdatedAt = teamDescUpdatedAt.Default.(func() time.Time)
 	teamgroupMixin := schema.TeamGroup{}.Mixin()

--- a/backend/db/team.go
+++ b/backend/db/team.go
@@ -24,6 +24,14 @@ type Team struct {
 	Name string `json:"name,omitempty"`
 	// MemberLimit holds the value of the "member_limit" field.
 	MemberLimit int `json:"member_limit,omitempty"`
+	// TaskVMSleepEnabled holds the value of the "task_vm_sleep_enabled" field.
+	TaskVMSleepEnabled bool `json:"task_vm_sleep_enabled,omitempty"`
+	// TaskVMSleepSeconds holds the value of the "task_vm_sleep_seconds" field.
+	TaskVMSleepSeconds int `json:"task_vm_sleep_seconds,omitempty"`
+	// TaskVMRecycleEnabled holds the value of the "task_vm_recycle_enabled" field.
+	TaskVMRecycleEnabled bool `json:"task_vm_recycle_enabled,omitempty"`
+	// TaskVMRecycleSeconds holds the value of the "task_vm_recycle_seconds" field.
+	TaskVMRecycleSeconds int `json:"task_vm_recycle_seconds,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
@@ -123,7 +131,9 @@ func (*Team) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case team.FieldMemberLimit:
+		case team.FieldTaskVMSleepEnabled, team.FieldTaskVMRecycleEnabled:
+			values[i] = new(sql.NullBool)
+		case team.FieldMemberLimit, team.FieldTaskVMSleepSeconds, team.FieldTaskVMRecycleSeconds:
 			values[i] = new(sql.NullInt64)
 		case team.FieldName:
 			values[i] = new(sql.NullString)
@@ -169,6 +179,30 @@ func (_m *Team) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field member_limit", values[i])
 			} else if value.Valid {
 				_m.MemberLimit = int(value.Int64)
+			}
+		case team.FieldTaskVMSleepEnabled:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field task_vm_sleep_enabled", values[i])
+			} else if value.Valid {
+				_m.TaskVMSleepEnabled = value.Bool
+			}
+		case team.FieldTaskVMSleepSeconds:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field task_vm_sleep_seconds", values[i])
+			} else if value.Valid {
+				_m.TaskVMSleepSeconds = int(value.Int64)
+			}
+		case team.FieldTaskVMRecycleEnabled:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field task_vm_recycle_enabled", values[i])
+			} else if value.Valid {
+				_m.TaskVMRecycleEnabled = value.Bool
+			}
+		case team.FieldTaskVMRecycleSeconds:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field task_vm_recycle_seconds", values[i])
+			} else if value.Valid {
+				_m.TaskVMRecycleSeconds = int(value.Int64)
 			}
 		case team.FieldCreatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -261,6 +295,18 @@ func (_m *Team) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("member_limit=")
 	builder.WriteString(fmt.Sprintf("%v", _m.MemberLimit))
+	builder.WriteString(", ")
+	builder.WriteString("task_vm_sleep_enabled=")
+	builder.WriteString(fmt.Sprintf("%v", _m.TaskVMSleepEnabled))
+	builder.WriteString(", ")
+	builder.WriteString("task_vm_sleep_seconds=")
+	builder.WriteString(fmt.Sprintf("%v", _m.TaskVMSleepSeconds))
+	builder.WriteString(", ")
+	builder.WriteString("task_vm_recycle_enabled=")
+	builder.WriteString(fmt.Sprintf("%v", _m.TaskVMRecycleEnabled))
+	builder.WriteString(", ")
+	builder.WriteString("task_vm_recycle_seconds=")
+	builder.WriteString(fmt.Sprintf("%v", _m.TaskVMRecycleSeconds))
 	builder.WriteString(", ")
 	builder.WriteString("created_at=")
 	builder.WriteString(_m.CreatedAt.Format(time.ANSIC))

--- a/backend/db/team/team.go
+++ b/backend/db/team/team.go
@@ -21,6 +21,14 @@ const (
 	FieldName = "name"
 	// FieldMemberLimit holds the string denoting the member_limit field in the database.
 	FieldMemberLimit = "member_limit"
+	// FieldTaskVMSleepEnabled holds the string denoting the task_vm_sleep_enabled field in the database.
+	FieldTaskVMSleepEnabled = "task_vm_sleep_enabled"
+	// FieldTaskVMSleepSeconds holds the string denoting the task_vm_sleep_seconds field in the database.
+	FieldTaskVMSleepSeconds = "task_vm_sleep_seconds"
+	// FieldTaskVMRecycleEnabled holds the string denoting the task_vm_recycle_enabled field in the database.
+	FieldTaskVMRecycleEnabled = "task_vm_recycle_enabled"
+	// FieldTaskVMRecycleSeconds holds the string denoting the task_vm_recycle_seconds field in the database.
+	FieldTaskVMRecycleSeconds = "task_vm_recycle_seconds"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
 	FieldCreatedAt = "created_at"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
@@ -92,6 +100,10 @@ var Columns = []string{
 	FieldDeletedAt,
 	FieldName,
 	FieldMemberLimit,
+	FieldTaskVMSleepEnabled,
+	FieldTaskVMSleepSeconds,
+	FieldTaskVMRecycleEnabled,
+	FieldTaskVMRecycleSeconds,
 	FieldCreatedAt,
 	FieldUpdatedAt,
 }
@@ -128,6 +140,14 @@ var (
 	Interceptors [1]ent.Interceptor
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
+	// DefaultTaskVMSleepEnabled holds the default value on creation for the "task_vm_sleep_enabled" field.
+	DefaultTaskVMSleepEnabled bool
+	// DefaultTaskVMSleepSeconds holds the default value on creation for the "task_vm_sleep_seconds" field.
+	DefaultTaskVMSleepSeconds int
+	// DefaultTaskVMRecycleEnabled holds the default value on creation for the "task_vm_recycle_enabled" field.
+	DefaultTaskVMRecycleEnabled bool
+	// DefaultTaskVMRecycleSeconds holds the default value on creation for the "task_vm_recycle_seconds" field.
+	DefaultTaskVMRecycleSeconds int
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -155,6 +175,26 @@ func ByName(opts ...sql.OrderTermOption) OrderOption {
 // ByMemberLimit orders the results by the member_limit field.
 func ByMemberLimit(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMemberLimit, opts...).ToFunc()
+}
+
+// ByTaskVMSleepEnabled orders the results by the task_vm_sleep_enabled field.
+func ByTaskVMSleepEnabled(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldTaskVMSleepEnabled, opts...).ToFunc()
+}
+
+// ByTaskVMSleepSeconds orders the results by the task_vm_sleep_seconds field.
+func ByTaskVMSleepSeconds(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldTaskVMSleepSeconds, opts...).ToFunc()
+}
+
+// ByTaskVMRecycleEnabled orders the results by the task_vm_recycle_enabled field.
+func ByTaskVMRecycleEnabled(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldTaskVMRecycleEnabled, opts...).ToFunc()
+}
+
+// ByTaskVMRecycleSeconds orders the results by the task_vm_recycle_seconds field.
+func ByTaskVMRecycleSeconds(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldTaskVMRecycleSeconds, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.

--- a/backend/db/team/where.go
+++ b/backend/db/team/where.go
@@ -71,6 +71,26 @@ func MemberLimit(v int) predicate.Team {
 	return predicate.Team(sql.FieldEQ(FieldMemberLimit, v))
 }
 
+// TaskVMSleepEnabled applies equality check predicate on the "task_vm_sleep_enabled" field. It's identical to TaskVMSleepEnabledEQ.
+func TaskVMSleepEnabled(v bool) predicate.Team {
+	return predicate.Team(sql.FieldEQ(FieldTaskVMSleepEnabled, v))
+}
+
+// TaskVMSleepSeconds applies equality check predicate on the "task_vm_sleep_seconds" field. It's identical to TaskVMSleepSecondsEQ.
+func TaskVMSleepSeconds(v int) predicate.Team {
+	return predicate.Team(sql.FieldEQ(FieldTaskVMSleepSeconds, v))
+}
+
+// TaskVMRecycleEnabled applies equality check predicate on the "task_vm_recycle_enabled" field. It's identical to TaskVMRecycleEnabledEQ.
+func TaskVMRecycleEnabled(v bool) predicate.Team {
+	return predicate.Team(sql.FieldEQ(FieldTaskVMRecycleEnabled, v))
+}
+
+// TaskVMRecycleSeconds applies equality check predicate on the "task_vm_recycle_seconds" field. It's identical to TaskVMRecycleSecondsEQ.
+func TaskVMRecycleSeconds(v int) predicate.Team {
+	return predicate.Team(sql.FieldEQ(FieldTaskVMRecycleSeconds, v))
+}
+
 // CreatedAt applies equality check predicate on the "created_at" field. It's identical to CreatedAtEQ.
 func CreatedAt(v time.Time) predicate.Team {
 	return predicate.Team(sql.FieldEQ(FieldCreatedAt, v))
@@ -234,6 +254,106 @@ func MemberLimitLT(v int) predicate.Team {
 // MemberLimitLTE applies the LTE predicate on the "member_limit" field.
 func MemberLimitLTE(v int) predicate.Team {
 	return predicate.Team(sql.FieldLTE(FieldMemberLimit, v))
+}
+
+// TaskVMSleepEnabledEQ applies the EQ predicate on the "task_vm_sleep_enabled" field.
+func TaskVMSleepEnabledEQ(v bool) predicate.Team {
+	return predicate.Team(sql.FieldEQ(FieldTaskVMSleepEnabled, v))
+}
+
+// TaskVMSleepEnabledNEQ applies the NEQ predicate on the "task_vm_sleep_enabled" field.
+func TaskVMSleepEnabledNEQ(v bool) predicate.Team {
+	return predicate.Team(sql.FieldNEQ(FieldTaskVMSleepEnabled, v))
+}
+
+// TaskVMSleepSecondsEQ applies the EQ predicate on the "task_vm_sleep_seconds" field.
+func TaskVMSleepSecondsEQ(v int) predicate.Team {
+	return predicate.Team(sql.FieldEQ(FieldTaskVMSleepSeconds, v))
+}
+
+// TaskVMSleepSecondsNEQ applies the NEQ predicate on the "task_vm_sleep_seconds" field.
+func TaskVMSleepSecondsNEQ(v int) predicate.Team {
+	return predicate.Team(sql.FieldNEQ(FieldTaskVMSleepSeconds, v))
+}
+
+// TaskVMSleepSecondsIn applies the In predicate on the "task_vm_sleep_seconds" field.
+func TaskVMSleepSecondsIn(vs ...int) predicate.Team {
+	return predicate.Team(sql.FieldIn(FieldTaskVMSleepSeconds, vs...))
+}
+
+// TaskVMSleepSecondsNotIn applies the NotIn predicate on the "task_vm_sleep_seconds" field.
+func TaskVMSleepSecondsNotIn(vs ...int) predicate.Team {
+	return predicate.Team(sql.FieldNotIn(FieldTaskVMSleepSeconds, vs...))
+}
+
+// TaskVMSleepSecondsGT applies the GT predicate on the "task_vm_sleep_seconds" field.
+func TaskVMSleepSecondsGT(v int) predicate.Team {
+	return predicate.Team(sql.FieldGT(FieldTaskVMSleepSeconds, v))
+}
+
+// TaskVMSleepSecondsGTE applies the GTE predicate on the "task_vm_sleep_seconds" field.
+func TaskVMSleepSecondsGTE(v int) predicate.Team {
+	return predicate.Team(sql.FieldGTE(FieldTaskVMSleepSeconds, v))
+}
+
+// TaskVMSleepSecondsLT applies the LT predicate on the "task_vm_sleep_seconds" field.
+func TaskVMSleepSecondsLT(v int) predicate.Team {
+	return predicate.Team(sql.FieldLT(FieldTaskVMSleepSeconds, v))
+}
+
+// TaskVMSleepSecondsLTE applies the LTE predicate on the "task_vm_sleep_seconds" field.
+func TaskVMSleepSecondsLTE(v int) predicate.Team {
+	return predicate.Team(sql.FieldLTE(FieldTaskVMSleepSeconds, v))
+}
+
+// TaskVMRecycleEnabledEQ applies the EQ predicate on the "task_vm_recycle_enabled" field.
+func TaskVMRecycleEnabledEQ(v bool) predicate.Team {
+	return predicate.Team(sql.FieldEQ(FieldTaskVMRecycleEnabled, v))
+}
+
+// TaskVMRecycleEnabledNEQ applies the NEQ predicate on the "task_vm_recycle_enabled" field.
+func TaskVMRecycleEnabledNEQ(v bool) predicate.Team {
+	return predicate.Team(sql.FieldNEQ(FieldTaskVMRecycleEnabled, v))
+}
+
+// TaskVMRecycleSecondsEQ applies the EQ predicate on the "task_vm_recycle_seconds" field.
+func TaskVMRecycleSecondsEQ(v int) predicate.Team {
+	return predicate.Team(sql.FieldEQ(FieldTaskVMRecycleSeconds, v))
+}
+
+// TaskVMRecycleSecondsNEQ applies the NEQ predicate on the "task_vm_recycle_seconds" field.
+func TaskVMRecycleSecondsNEQ(v int) predicate.Team {
+	return predicate.Team(sql.FieldNEQ(FieldTaskVMRecycleSeconds, v))
+}
+
+// TaskVMRecycleSecondsIn applies the In predicate on the "task_vm_recycle_seconds" field.
+func TaskVMRecycleSecondsIn(vs ...int) predicate.Team {
+	return predicate.Team(sql.FieldIn(FieldTaskVMRecycleSeconds, vs...))
+}
+
+// TaskVMRecycleSecondsNotIn applies the NotIn predicate on the "task_vm_recycle_seconds" field.
+func TaskVMRecycleSecondsNotIn(vs ...int) predicate.Team {
+	return predicate.Team(sql.FieldNotIn(FieldTaskVMRecycleSeconds, vs...))
+}
+
+// TaskVMRecycleSecondsGT applies the GT predicate on the "task_vm_recycle_seconds" field.
+func TaskVMRecycleSecondsGT(v int) predicate.Team {
+	return predicate.Team(sql.FieldGT(FieldTaskVMRecycleSeconds, v))
+}
+
+// TaskVMRecycleSecondsGTE applies the GTE predicate on the "task_vm_recycle_seconds" field.
+func TaskVMRecycleSecondsGTE(v int) predicate.Team {
+	return predicate.Team(sql.FieldGTE(FieldTaskVMRecycleSeconds, v))
+}
+
+// TaskVMRecycleSecondsLT applies the LT predicate on the "task_vm_recycle_seconds" field.
+func TaskVMRecycleSecondsLT(v int) predicate.Team {
+	return predicate.Team(sql.FieldLT(FieldTaskVMRecycleSeconds, v))
+}
+
+// TaskVMRecycleSecondsLTE applies the LTE predicate on the "task_vm_recycle_seconds" field.
+func TaskVMRecycleSecondsLTE(v int) predicate.Team {
+	return predicate.Team(sql.FieldLTE(FieldTaskVMRecycleSeconds, v))
 }
 
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.

--- a/backend/db/team_create.go
+++ b/backend/db/team_create.go
@@ -57,6 +57,62 @@ func (_c *TeamCreate) SetMemberLimit(v int) *TeamCreate {
 	return _c
 }
 
+// SetTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field.
+func (_c *TeamCreate) SetTaskVMSleepEnabled(v bool) *TeamCreate {
+	_c.mutation.SetTaskVMSleepEnabled(v)
+	return _c
+}
+
+// SetNillableTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field if the given value is not nil.
+func (_c *TeamCreate) SetNillableTaskVMSleepEnabled(v *bool) *TeamCreate {
+	if v != nil {
+		_c.SetTaskVMSleepEnabled(*v)
+	}
+	return _c
+}
+
+// SetTaskVMSleepSeconds sets the "task_vm_sleep_seconds" field.
+func (_c *TeamCreate) SetTaskVMSleepSeconds(v int) *TeamCreate {
+	_c.mutation.SetTaskVMSleepSeconds(v)
+	return _c
+}
+
+// SetNillableTaskVMSleepSeconds sets the "task_vm_sleep_seconds" field if the given value is not nil.
+func (_c *TeamCreate) SetNillableTaskVMSleepSeconds(v *int) *TeamCreate {
+	if v != nil {
+		_c.SetTaskVMSleepSeconds(*v)
+	}
+	return _c
+}
+
+// SetTaskVMRecycleEnabled sets the "task_vm_recycle_enabled" field.
+func (_c *TeamCreate) SetTaskVMRecycleEnabled(v bool) *TeamCreate {
+	_c.mutation.SetTaskVMRecycleEnabled(v)
+	return _c
+}
+
+// SetNillableTaskVMRecycleEnabled sets the "task_vm_recycle_enabled" field if the given value is not nil.
+func (_c *TeamCreate) SetNillableTaskVMRecycleEnabled(v *bool) *TeamCreate {
+	if v != nil {
+		_c.SetTaskVMRecycleEnabled(*v)
+	}
+	return _c
+}
+
+// SetTaskVMRecycleSeconds sets the "task_vm_recycle_seconds" field.
+func (_c *TeamCreate) SetTaskVMRecycleSeconds(v int) *TeamCreate {
+	_c.mutation.SetTaskVMRecycleSeconds(v)
+	return _c
+}
+
+// SetNillableTaskVMRecycleSeconds sets the "task_vm_recycle_seconds" field if the given value is not nil.
+func (_c *TeamCreate) SetNillableTaskVMRecycleSeconds(v *int) *TeamCreate {
+	if v != nil {
+		_c.SetTaskVMRecycleSeconds(*v)
+	}
+	return _c
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (_c *TeamCreate) SetCreatedAt(v time.Time) *TeamCreate {
 	_c.mutation.SetCreatedAt(v)
@@ -233,6 +289,22 @@ func (_c *TeamCreate) ExecX(ctx context.Context) {
 
 // defaults sets the default values of the builder before save.
 func (_c *TeamCreate) defaults() error {
+	if _, ok := _c.mutation.TaskVMSleepEnabled(); !ok {
+		v := team.DefaultTaskVMSleepEnabled
+		_c.mutation.SetTaskVMSleepEnabled(v)
+	}
+	if _, ok := _c.mutation.TaskVMSleepSeconds(); !ok {
+		v := team.DefaultTaskVMSleepSeconds
+		_c.mutation.SetTaskVMSleepSeconds(v)
+	}
+	if _, ok := _c.mutation.TaskVMRecycleEnabled(); !ok {
+		v := team.DefaultTaskVMRecycleEnabled
+		_c.mutation.SetTaskVMRecycleEnabled(v)
+	}
+	if _, ok := _c.mutation.TaskVMRecycleSeconds(); !ok {
+		v := team.DefaultTaskVMRecycleSeconds
+		_c.mutation.SetTaskVMRecycleSeconds(v)
+	}
 	if _, ok := _c.mutation.CreatedAt(); !ok {
 		if team.DefaultCreatedAt == nil {
 			return fmt.Errorf("db: uninitialized team.DefaultCreatedAt (forgotten import db/runtime?)")
@@ -262,6 +334,18 @@ func (_c *TeamCreate) check() error {
 	}
 	if _, ok := _c.mutation.MemberLimit(); !ok {
 		return &ValidationError{Name: "member_limit", err: errors.New(`db: missing required field "Team.member_limit"`)}
+	}
+	if _, ok := _c.mutation.TaskVMSleepEnabled(); !ok {
+		return &ValidationError{Name: "task_vm_sleep_enabled", err: errors.New(`db: missing required field "Team.task_vm_sleep_enabled"`)}
+	}
+	if _, ok := _c.mutation.TaskVMSleepSeconds(); !ok {
+		return &ValidationError{Name: "task_vm_sleep_seconds", err: errors.New(`db: missing required field "Team.task_vm_sleep_seconds"`)}
+	}
+	if _, ok := _c.mutation.TaskVMRecycleEnabled(); !ok {
+		return &ValidationError{Name: "task_vm_recycle_enabled", err: errors.New(`db: missing required field "Team.task_vm_recycle_enabled"`)}
+	}
+	if _, ok := _c.mutation.TaskVMRecycleSeconds(); !ok {
+		return &ValidationError{Name: "task_vm_recycle_seconds", err: errors.New(`db: missing required field "Team.task_vm_recycle_seconds"`)}
 	}
 	if _, ok := _c.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`db: missing required field "Team.created_at"`)}
@@ -316,6 +400,22 @@ func (_c *TeamCreate) createSpec() (*Team, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.MemberLimit(); ok {
 		_spec.SetField(team.FieldMemberLimit, field.TypeInt, value)
 		_node.MemberLimit = value
+	}
+	if value, ok := _c.mutation.TaskVMSleepEnabled(); ok {
+		_spec.SetField(team.FieldTaskVMSleepEnabled, field.TypeBool, value)
+		_node.TaskVMSleepEnabled = value
+	}
+	if value, ok := _c.mutation.TaskVMSleepSeconds(); ok {
+		_spec.SetField(team.FieldTaskVMSleepSeconds, field.TypeInt, value)
+		_node.TaskVMSleepSeconds = value
+	}
+	if value, ok := _c.mutation.TaskVMRecycleEnabled(); ok {
+		_spec.SetField(team.FieldTaskVMRecycleEnabled, field.TypeBool, value)
+		_node.TaskVMRecycleEnabled = value
+	}
+	if value, ok := _c.mutation.TaskVMRecycleSeconds(); ok {
+		_spec.SetField(team.FieldTaskVMRecycleSeconds, field.TypeInt, value)
+		_node.TaskVMRecycleSeconds = value
 	}
 	if value, ok := _c.mutation.CreatedAt(); ok {
 		_spec.SetField(team.FieldCreatedAt, field.TypeTime, value)
@@ -549,6 +649,66 @@ func (u *TeamUpsert) AddMemberLimit(v int) *TeamUpsert {
 	return u
 }
 
+// SetTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field.
+func (u *TeamUpsert) SetTaskVMSleepEnabled(v bool) *TeamUpsert {
+	u.Set(team.FieldTaskVMSleepEnabled, v)
+	return u
+}
+
+// UpdateTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field to the value that was provided on create.
+func (u *TeamUpsert) UpdateTaskVMSleepEnabled() *TeamUpsert {
+	u.SetExcluded(team.FieldTaskVMSleepEnabled)
+	return u
+}
+
+// SetTaskVMSleepSeconds sets the "task_vm_sleep_seconds" field.
+func (u *TeamUpsert) SetTaskVMSleepSeconds(v int) *TeamUpsert {
+	u.Set(team.FieldTaskVMSleepSeconds, v)
+	return u
+}
+
+// UpdateTaskVMSleepSeconds sets the "task_vm_sleep_seconds" field to the value that was provided on create.
+func (u *TeamUpsert) UpdateTaskVMSleepSeconds() *TeamUpsert {
+	u.SetExcluded(team.FieldTaskVMSleepSeconds)
+	return u
+}
+
+// AddTaskVMSleepSeconds adds v to the "task_vm_sleep_seconds" field.
+func (u *TeamUpsert) AddTaskVMSleepSeconds(v int) *TeamUpsert {
+	u.Add(team.FieldTaskVMSleepSeconds, v)
+	return u
+}
+
+// SetTaskVMRecycleEnabled sets the "task_vm_recycle_enabled" field.
+func (u *TeamUpsert) SetTaskVMRecycleEnabled(v bool) *TeamUpsert {
+	u.Set(team.FieldTaskVMRecycleEnabled, v)
+	return u
+}
+
+// UpdateTaskVMRecycleEnabled sets the "task_vm_recycle_enabled" field to the value that was provided on create.
+func (u *TeamUpsert) UpdateTaskVMRecycleEnabled() *TeamUpsert {
+	u.SetExcluded(team.FieldTaskVMRecycleEnabled)
+	return u
+}
+
+// SetTaskVMRecycleSeconds sets the "task_vm_recycle_seconds" field.
+func (u *TeamUpsert) SetTaskVMRecycleSeconds(v int) *TeamUpsert {
+	u.Set(team.FieldTaskVMRecycleSeconds, v)
+	return u
+}
+
+// UpdateTaskVMRecycleSeconds sets the "task_vm_recycle_seconds" field to the value that was provided on create.
+func (u *TeamUpsert) UpdateTaskVMRecycleSeconds() *TeamUpsert {
+	u.SetExcluded(team.FieldTaskVMRecycleSeconds)
+	return u
+}
+
+// AddTaskVMRecycleSeconds adds v to the "task_vm_recycle_seconds" field.
+func (u *TeamUpsert) AddTaskVMRecycleSeconds(v int) *TeamUpsert {
+	u.Add(team.FieldTaskVMRecycleSeconds, v)
+	return u
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (u *TeamUpsert) SetCreatedAt(v time.Time) *TeamUpsert {
 	u.Set(team.FieldCreatedAt, v)
@@ -674,6 +834,76 @@ func (u *TeamUpsertOne) AddMemberLimit(v int) *TeamUpsertOne {
 func (u *TeamUpsertOne) UpdateMemberLimit() *TeamUpsertOne {
 	return u.Update(func(s *TeamUpsert) {
 		s.UpdateMemberLimit()
+	})
+}
+
+// SetTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field.
+func (u *TeamUpsertOne) SetTaskVMSleepEnabled(v bool) *TeamUpsertOne {
+	return u.Update(func(s *TeamUpsert) {
+		s.SetTaskVMSleepEnabled(v)
+	})
+}
+
+// UpdateTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field to the value that was provided on create.
+func (u *TeamUpsertOne) UpdateTaskVMSleepEnabled() *TeamUpsertOne {
+	return u.Update(func(s *TeamUpsert) {
+		s.UpdateTaskVMSleepEnabled()
+	})
+}
+
+// SetTaskVMSleepSeconds sets the "task_vm_sleep_seconds" field.
+func (u *TeamUpsertOne) SetTaskVMSleepSeconds(v int) *TeamUpsertOne {
+	return u.Update(func(s *TeamUpsert) {
+		s.SetTaskVMSleepSeconds(v)
+	})
+}
+
+// AddTaskVMSleepSeconds adds v to the "task_vm_sleep_seconds" field.
+func (u *TeamUpsertOne) AddTaskVMSleepSeconds(v int) *TeamUpsertOne {
+	return u.Update(func(s *TeamUpsert) {
+		s.AddTaskVMSleepSeconds(v)
+	})
+}
+
+// UpdateTaskVMSleepSeconds sets the "task_vm_sleep_seconds" field to the value that was provided on create.
+func (u *TeamUpsertOne) UpdateTaskVMSleepSeconds() *TeamUpsertOne {
+	return u.Update(func(s *TeamUpsert) {
+		s.UpdateTaskVMSleepSeconds()
+	})
+}
+
+// SetTaskVMRecycleEnabled sets the "task_vm_recycle_enabled" field.
+func (u *TeamUpsertOne) SetTaskVMRecycleEnabled(v bool) *TeamUpsertOne {
+	return u.Update(func(s *TeamUpsert) {
+		s.SetTaskVMRecycleEnabled(v)
+	})
+}
+
+// UpdateTaskVMRecycleEnabled sets the "task_vm_recycle_enabled" field to the value that was provided on create.
+func (u *TeamUpsertOne) UpdateTaskVMRecycleEnabled() *TeamUpsertOne {
+	return u.Update(func(s *TeamUpsert) {
+		s.UpdateTaskVMRecycleEnabled()
+	})
+}
+
+// SetTaskVMRecycleSeconds sets the "task_vm_recycle_seconds" field.
+func (u *TeamUpsertOne) SetTaskVMRecycleSeconds(v int) *TeamUpsertOne {
+	return u.Update(func(s *TeamUpsert) {
+		s.SetTaskVMRecycleSeconds(v)
+	})
+}
+
+// AddTaskVMRecycleSeconds adds v to the "task_vm_recycle_seconds" field.
+func (u *TeamUpsertOne) AddTaskVMRecycleSeconds(v int) *TeamUpsertOne {
+	return u.Update(func(s *TeamUpsert) {
+		s.AddTaskVMRecycleSeconds(v)
+	})
+}
+
+// UpdateTaskVMRecycleSeconds sets the "task_vm_recycle_seconds" field to the value that was provided on create.
+func (u *TeamUpsertOne) UpdateTaskVMRecycleSeconds() *TeamUpsertOne {
+	return u.Update(func(s *TeamUpsert) {
+		s.UpdateTaskVMRecycleSeconds()
 	})
 }
 
@@ -973,6 +1203,76 @@ func (u *TeamUpsertBulk) AddMemberLimit(v int) *TeamUpsertBulk {
 func (u *TeamUpsertBulk) UpdateMemberLimit() *TeamUpsertBulk {
 	return u.Update(func(s *TeamUpsert) {
 		s.UpdateMemberLimit()
+	})
+}
+
+// SetTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field.
+func (u *TeamUpsertBulk) SetTaskVMSleepEnabled(v bool) *TeamUpsertBulk {
+	return u.Update(func(s *TeamUpsert) {
+		s.SetTaskVMSleepEnabled(v)
+	})
+}
+
+// UpdateTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field to the value that was provided on create.
+func (u *TeamUpsertBulk) UpdateTaskVMSleepEnabled() *TeamUpsertBulk {
+	return u.Update(func(s *TeamUpsert) {
+		s.UpdateTaskVMSleepEnabled()
+	})
+}
+
+// SetTaskVMSleepSeconds sets the "task_vm_sleep_seconds" field.
+func (u *TeamUpsertBulk) SetTaskVMSleepSeconds(v int) *TeamUpsertBulk {
+	return u.Update(func(s *TeamUpsert) {
+		s.SetTaskVMSleepSeconds(v)
+	})
+}
+
+// AddTaskVMSleepSeconds adds v to the "task_vm_sleep_seconds" field.
+func (u *TeamUpsertBulk) AddTaskVMSleepSeconds(v int) *TeamUpsertBulk {
+	return u.Update(func(s *TeamUpsert) {
+		s.AddTaskVMSleepSeconds(v)
+	})
+}
+
+// UpdateTaskVMSleepSeconds sets the "task_vm_sleep_seconds" field to the value that was provided on create.
+func (u *TeamUpsertBulk) UpdateTaskVMSleepSeconds() *TeamUpsertBulk {
+	return u.Update(func(s *TeamUpsert) {
+		s.UpdateTaskVMSleepSeconds()
+	})
+}
+
+// SetTaskVMRecycleEnabled sets the "task_vm_recycle_enabled" field.
+func (u *TeamUpsertBulk) SetTaskVMRecycleEnabled(v bool) *TeamUpsertBulk {
+	return u.Update(func(s *TeamUpsert) {
+		s.SetTaskVMRecycleEnabled(v)
+	})
+}
+
+// UpdateTaskVMRecycleEnabled sets the "task_vm_recycle_enabled" field to the value that was provided on create.
+func (u *TeamUpsertBulk) UpdateTaskVMRecycleEnabled() *TeamUpsertBulk {
+	return u.Update(func(s *TeamUpsert) {
+		s.UpdateTaskVMRecycleEnabled()
+	})
+}
+
+// SetTaskVMRecycleSeconds sets the "task_vm_recycle_seconds" field.
+func (u *TeamUpsertBulk) SetTaskVMRecycleSeconds(v int) *TeamUpsertBulk {
+	return u.Update(func(s *TeamUpsert) {
+		s.SetTaskVMRecycleSeconds(v)
+	})
+}
+
+// AddTaskVMRecycleSeconds adds v to the "task_vm_recycle_seconds" field.
+func (u *TeamUpsertBulk) AddTaskVMRecycleSeconds(v int) *TeamUpsertBulk {
+	return u.Update(func(s *TeamUpsert) {
+		s.AddTaskVMRecycleSeconds(v)
+	})
+}
+
+// UpdateTaskVMRecycleSeconds sets the "task_vm_recycle_seconds" field to the value that was provided on create.
+func (u *TeamUpsertBulk) UpdateTaskVMRecycleSeconds() *TeamUpsertBulk {
+	return u.Update(func(s *TeamUpsert) {
+		s.UpdateTaskVMRecycleSeconds()
 	})
 }
 

--- a/backend/db/team_update.go
+++ b/backend/db/team_update.go
@@ -92,6 +92,76 @@ func (_u *TeamUpdate) AddMemberLimit(v int) *TeamUpdate {
 	return _u
 }
 
+// SetTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field.
+func (_u *TeamUpdate) SetTaskVMSleepEnabled(v bool) *TeamUpdate {
+	_u.mutation.SetTaskVMSleepEnabled(v)
+	return _u
+}
+
+// SetNillableTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field if the given value is not nil.
+func (_u *TeamUpdate) SetNillableTaskVMSleepEnabled(v *bool) *TeamUpdate {
+	if v != nil {
+		_u.SetTaskVMSleepEnabled(*v)
+	}
+	return _u
+}
+
+// SetTaskVMSleepSeconds sets the "task_vm_sleep_seconds" field.
+func (_u *TeamUpdate) SetTaskVMSleepSeconds(v int) *TeamUpdate {
+	_u.mutation.ResetTaskVMSleepSeconds()
+	_u.mutation.SetTaskVMSleepSeconds(v)
+	return _u
+}
+
+// SetNillableTaskVMSleepSeconds sets the "task_vm_sleep_seconds" field if the given value is not nil.
+func (_u *TeamUpdate) SetNillableTaskVMSleepSeconds(v *int) *TeamUpdate {
+	if v != nil {
+		_u.SetTaskVMSleepSeconds(*v)
+	}
+	return _u
+}
+
+// AddTaskVMSleepSeconds adds value to the "task_vm_sleep_seconds" field.
+func (_u *TeamUpdate) AddTaskVMSleepSeconds(v int) *TeamUpdate {
+	_u.mutation.AddTaskVMSleepSeconds(v)
+	return _u
+}
+
+// SetTaskVMRecycleEnabled sets the "task_vm_recycle_enabled" field.
+func (_u *TeamUpdate) SetTaskVMRecycleEnabled(v bool) *TeamUpdate {
+	_u.mutation.SetTaskVMRecycleEnabled(v)
+	return _u
+}
+
+// SetNillableTaskVMRecycleEnabled sets the "task_vm_recycle_enabled" field if the given value is not nil.
+func (_u *TeamUpdate) SetNillableTaskVMRecycleEnabled(v *bool) *TeamUpdate {
+	if v != nil {
+		_u.SetTaskVMRecycleEnabled(*v)
+	}
+	return _u
+}
+
+// SetTaskVMRecycleSeconds sets the "task_vm_recycle_seconds" field.
+func (_u *TeamUpdate) SetTaskVMRecycleSeconds(v int) *TeamUpdate {
+	_u.mutation.ResetTaskVMRecycleSeconds()
+	_u.mutation.SetTaskVMRecycleSeconds(v)
+	return _u
+}
+
+// SetNillableTaskVMRecycleSeconds sets the "task_vm_recycle_seconds" field if the given value is not nil.
+func (_u *TeamUpdate) SetNillableTaskVMRecycleSeconds(v *int) *TeamUpdate {
+	if v != nil {
+		_u.SetTaskVMRecycleSeconds(*v)
+	}
+	return _u
+}
+
+// AddTaskVMRecycleSeconds adds value to the "task_vm_recycle_seconds" field.
+func (_u *TeamUpdate) AddTaskVMRecycleSeconds(v int) *TeamUpdate {
+	_u.mutation.AddTaskVMRecycleSeconds(v)
+	return _u
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (_u *TeamUpdate) SetCreatedAt(v time.Time) *TeamUpdate {
 	_u.mutation.SetCreatedAt(v)
@@ -446,6 +516,24 @@ func (_u *TeamUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.AddedMemberLimit(); ok {
 		_spec.AddField(team.FieldMemberLimit, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.TaskVMSleepEnabled(); ok {
+		_spec.SetField(team.FieldTaskVMSleepEnabled, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.TaskVMSleepSeconds(); ok {
+		_spec.SetField(team.FieldTaskVMSleepSeconds, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedTaskVMSleepSeconds(); ok {
+		_spec.AddField(team.FieldTaskVMSleepSeconds, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.TaskVMRecycleEnabled(); ok {
+		_spec.SetField(team.FieldTaskVMRecycleEnabled, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.TaskVMRecycleSeconds(); ok {
+		_spec.SetField(team.FieldTaskVMRecycleSeconds, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedTaskVMRecycleSeconds(); ok {
+		_spec.AddField(team.FieldTaskVMRecycleSeconds, field.TypeInt, value)
 	}
 	if value, ok := _u.mutation.CreatedAt(); ok {
 		_spec.SetField(team.FieldCreatedAt, field.TypeTime, value)
@@ -881,6 +969,76 @@ func (_u *TeamUpdateOne) AddMemberLimit(v int) *TeamUpdateOne {
 	return _u
 }
 
+// SetTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field.
+func (_u *TeamUpdateOne) SetTaskVMSleepEnabled(v bool) *TeamUpdateOne {
+	_u.mutation.SetTaskVMSleepEnabled(v)
+	return _u
+}
+
+// SetNillableTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field if the given value is not nil.
+func (_u *TeamUpdateOne) SetNillableTaskVMSleepEnabled(v *bool) *TeamUpdateOne {
+	if v != nil {
+		_u.SetTaskVMSleepEnabled(*v)
+	}
+	return _u
+}
+
+// SetTaskVMSleepSeconds sets the "task_vm_sleep_seconds" field.
+func (_u *TeamUpdateOne) SetTaskVMSleepSeconds(v int) *TeamUpdateOne {
+	_u.mutation.ResetTaskVMSleepSeconds()
+	_u.mutation.SetTaskVMSleepSeconds(v)
+	return _u
+}
+
+// SetNillableTaskVMSleepSeconds sets the "task_vm_sleep_seconds" field if the given value is not nil.
+func (_u *TeamUpdateOne) SetNillableTaskVMSleepSeconds(v *int) *TeamUpdateOne {
+	if v != nil {
+		_u.SetTaskVMSleepSeconds(*v)
+	}
+	return _u
+}
+
+// AddTaskVMSleepSeconds adds value to the "task_vm_sleep_seconds" field.
+func (_u *TeamUpdateOne) AddTaskVMSleepSeconds(v int) *TeamUpdateOne {
+	_u.mutation.AddTaskVMSleepSeconds(v)
+	return _u
+}
+
+// SetTaskVMRecycleEnabled sets the "task_vm_recycle_enabled" field.
+func (_u *TeamUpdateOne) SetTaskVMRecycleEnabled(v bool) *TeamUpdateOne {
+	_u.mutation.SetTaskVMRecycleEnabled(v)
+	return _u
+}
+
+// SetNillableTaskVMRecycleEnabled sets the "task_vm_recycle_enabled" field if the given value is not nil.
+func (_u *TeamUpdateOne) SetNillableTaskVMRecycleEnabled(v *bool) *TeamUpdateOne {
+	if v != nil {
+		_u.SetTaskVMRecycleEnabled(*v)
+	}
+	return _u
+}
+
+// SetTaskVMRecycleSeconds sets the "task_vm_recycle_seconds" field.
+func (_u *TeamUpdateOne) SetTaskVMRecycleSeconds(v int) *TeamUpdateOne {
+	_u.mutation.ResetTaskVMRecycleSeconds()
+	_u.mutation.SetTaskVMRecycleSeconds(v)
+	return _u
+}
+
+// SetNillableTaskVMRecycleSeconds sets the "task_vm_recycle_seconds" field if the given value is not nil.
+func (_u *TeamUpdateOne) SetNillableTaskVMRecycleSeconds(v *int) *TeamUpdateOne {
+	if v != nil {
+		_u.SetTaskVMRecycleSeconds(*v)
+	}
+	return _u
+}
+
+// AddTaskVMRecycleSeconds adds value to the "task_vm_recycle_seconds" field.
+func (_u *TeamUpdateOne) AddTaskVMRecycleSeconds(v int) *TeamUpdateOne {
+	_u.mutation.AddTaskVMRecycleSeconds(v)
+	return _u
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (_u *TeamUpdateOne) SetCreatedAt(v time.Time) *TeamUpdateOne {
 	_u.mutation.SetCreatedAt(v)
@@ -1265,6 +1423,24 @@ func (_u *TeamUpdateOne) sqlSave(ctx context.Context) (_node *Team, err error) {
 	}
 	if value, ok := _u.mutation.AddedMemberLimit(); ok {
 		_spec.AddField(team.FieldMemberLimit, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.TaskVMSleepEnabled(); ok {
+		_spec.SetField(team.FieldTaskVMSleepEnabled, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.TaskVMSleepSeconds(); ok {
+		_spec.SetField(team.FieldTaskVMSleepSeconds, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedTaskVMSleepSeconds(); ok {
+		_spec.AddField(team.FieldTaskVMSleepSeconds, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.TaskVMRecycleEnabled(); ok {
+		_spec.SetField(team.FieldTaskVMRecycleEnabled, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.TaskVMRecycleSeconds(); ok {
+		_spec.SetField(team.FieldTaskVMRecycleSeconds, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedTaskVMRecycleSeconds(); ok {
+		_spec.AddField(team.FieldTaskVMRecycleSeconds, field.TypeInt, value)
 	}
 	if value, ok := _u.mutation.CreatedAt(); ok {
 		_spec.SetField(team.FieldCreatedAt, field.TypeTime, value)

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1911,6 +1911,95 @@
                 }
             }
         },
+        "/api/v1/teams/task-vm-idle-policy": {
+            "get": {
+                "security": [
+                    {
+                        "MonkeyCodeAITeamAuth": []
+                    }
+                ],
+                "description": "获取当前团队任务创建开发环境的空闲休眠和回收策略",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "【Team 管理员】开发环境管理"
+                ],
+                "summary": "获取任务开发环境空闲策略",
+                "responses": {
+                    "200": {
+                        "description": "成功",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/web.Resp"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/domain.TeamTaskVMIdlePolicy"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "MonkeyCodeAITeamAuth": []
+                    }
+                ],
+                "description": "更新当前团队任务创建开发环境的空闲休眠和回收策略",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "【Team 管理员】开发环境管理"
+                ],
+                "summary": "更新任务开发环境空闲策略",
+                "parameters": [
+                    {
+                        "description": "请求参数",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/domain.UpdateTeamTaskVMIdlePolicyReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "成功",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/web.Resp"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/domain.TeamTaskVMIdlePolicy"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/teams/tasks": {
             "get": {
                 "security": [
@@ -11695,6 +11784,38 @@
                 }
             }
         },
+        "domain.TeamTaskVMIdlePolicy": {
+            "type": "object",
+            "properties": {
+                "effective_recycle_seconds": {
+                    "type": "integer"
+                },
+                "effective_sleep_seconds": {
+                    "type": "integer"
+                },
+                "recycle_enabled": {
+                    "type": "boolean"
+                },
+                "recycle_inherited": {
+                    "type": "boolean"
+                },
+                "recycle_seconds": {
+                    "type": "integer"
+                },
+                "sleep_enabled": {
+                    "type": "boolean"
+                },
+                "sleep_inherited": {
+                    "type": "boolean"
+                },
+                "sleep_seconds": {
+                    "type": "integer"
+                },
+                "team_id": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.TeamUser": {
             "type": "object",
             "properties": {
@@ -12043,6 +12164,23 @@
                 },
                 "temperature": {
                     "type": "number"
+                }
+            }
+        },
+        "domain.UpdateTeamTaskVMIdlePolicyReq": {
+            "type": "object",
+            "properties": {
+                "recycle_enabled": {
+                    "type": "boolean"
+                },
+                "recycle_seconds": {
+                    "type": "integer"
+                },
+                "sleep_enabled": {
+                    "type": "boolean"
+                },
+                "sleep_seconds": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/domain/team.go
+++ b/backend/domain/team.go
@@ -35,6 +35,11 @@ type TeamGroupUserUsecase interface {
 	UpdateUser(ctx context.Context, req *UpdateTeamUserReq) (*UpdateTeamUserResp, error)
 }
 
+type TeamPolicyUsecase interface {
+	GetTaskVMIdlePolicy(ctx context.Context, teamUser *TeamUser) (*TeamTaskVMIdlePolicy, error)
+	UpdateTaskVMIdlePolicy(ctx context.Context, teamUser *TeamUser, req *UpdateTeamTaskVMIdlePolicyReq) (*TeamTaskVMIdlePolicy, error)
+}
+
 // TeamGroupUserRepo 团队分组成员数据访问接口
 type TeamGroupUserRepo interface {
 	List(ctx context.Context, teamID uuid.UUID) ([]*db.TeamGroup, error)
@@ -54,6 +59,13 @@ type TeamGroupUserRepo interface {
 	GetMembersByIDs(ctx context.Context, teamID uuid.UUID, userIDs []uuid.UUID) ([]*db.TeamMember, error)
 	GetMember(ctx context.Context, teamID, userID uuid.UUID) (*db.TeamMember, error)
 	InitTeam(ctx context.Context, email, name, password, image string) error
+}
+
+type TeamPolicyRepo interface {
+	GetTeam(ctx context.Context, teamID uuid.UUID) (*db.Team, error)
+	GetTeamByUserID(ctx context.Context, userID uuid.UUID) (*db.Team, error)
+	UpdateTaskVMIdlePolicy(ctx context.Context, teamID uuid.UUID, req *UpdateTeamTaskVMIdlePolicyReq) (*db.Team, error)
+	GetMember(ctx context.Context, teamID, userID uuid.UUID) (*db.TeamMember, error)
 }
 
 type Team struct {

--- a/backend/domain/team_policy.go
+++ b/backend/domain/team_policy.go
@@ -1,0 +1,99 @@
+package domain
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/db"
+)
+
+type TeamTaskVMIdlePolicy struct {
+	TeamID                  uuid.UUID `json:"team_id"`
+	SleepEnabled            bool      `json:"sleep_enabled"`
+	SleepSeconds            int       `json:"sleep_seconds"`
+	EffectiveSleepSeconds   int       `json:"effective_sleep_seconds"`
+	SleepInherited          bool      `json:"sleep_inherited"`
+	RecycleEnabled          bool      `json:"recycle_enabled"`
+	RecycleSeconds          int       `json:"recycle_seconds"`
+	EffectiveRecycleSeconds int       `json:"effective_recycle_seconds"`
+	RecycleInherited        bool      `json:"recycle_inherited"`
+}
+
+type UpdateTeamTaskVMIdlePolicyReq struct {
+	SleepEnabled   bool `json:"sleep_enabled"`
+	SleepSeconds   int  `json:"sleep_seconds"`
+	RecycleEnabled bool `json:"recycle_enabled"`
+	RecycleSeconds int  `json:"recycle_seconds"`
+}
+
+func ResolveTeamTaskVMIdlePolicy(team *db.Team, cfg config.VMIdle) (*TeamTaskVMIdlePolicy, error) {
+	p := &TeamTaskVMIdlePolicy{
+		SleepEnabled:   true,
+		SleepSeconds:   0,
+		RecycleEnabled: true,
+		RecycleSeconds: 0,
+	}
+	if team != nil {
+		p.TeamID = team.ID
+		p.SleepEnabled = team.TaskVMSleepEnabled
+		p.SleepSeconds = team.TaskVMSleepSeconds
+		p.RecycleEnabled = team.TaskVMRecycleEnabled
+		p.RecycleSeconds = team.TaskVMRecycleSeconds
+	}
+	if err := fillEffectiveTeamTaskVMIdlePolicy(p, cfg); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func NewTeamTaskVMIdlePolicyFromReq(teamID uuid.UUID, req *UpdateTeamTaskVMIdlePolicyReq, cfg config.VMIdle) (*TeamTaskVMIdlePolicy, error) {
+	p := &TeamTaskVMIdlePolicy{
+		TeamID:         teamID,
+		SleepEnabled:   req.SleepEnabled,
+		SleepSeconds:   req.SleepSeconds,
+		RecycleEnabled: req.RecycleEnabled,
+		RecycleSeconds: req.RecycleSeconds,
+	}
+	if err := fillEffectiveTeamTaskVMIdlePolicy(p, cfg); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func fillEffectiveTeamTaskVMIdlePolicy(p *TeamTaskVMIdlePolicy, cfg config.VMIdle) error {
+	if p.SleepSeconds < 0 {
+		return fmt.Errorf("sleep seconds must be greater than or equal to 0")
+	}
+	if p.RecycleSeconds < 0 {
+		return fmt.Errorf("recycle seconds must be greater than or equal to 0")
+	}
+
+	if p.SleepEnabled {
+		p.EffectiveSleepSeconds = p.SleepSeconds
+		if p.EffectiveSleepSeconds == 0 {
+			p.EffectiveSleepSeconds = cfg.SleepSeconds
+			p.SleepInherited = true
+		}
+		if p.EffectiveSleepSeconds <= 0 {
+			return fmt.Errorf("effective sleep seconds must be greater than 0")
+		}
+	}
+
+	if p.RecycleEnabled {
+		p.EffectiveRecycleSeconds = p.RecycleSeconds
+		if p.EffectiveRecycleSeconds == 0 {
+			p.EffectiveRecycleSeconds = cfg.RecycleSeconds
+			p.RecycleInherited = true
+		}
+		if p.EffectiveRecycleSeconds <= 0 {
+			return fmt.Errorf("effective recycle seconds must be greater than 0")
+		}
+	}
+
+	if p.SleepEnabled && p.RecycleEnabled && p.EffectiveSleepSeconds >= p.EffectiveRecycleSeconds {
+		return fmt.Errorf("effective sleep seconds must be less than effective recycle seconds")
+	}
+	return nil
+}

--- a/backend/domain/team_policy_test.go
+++ b/backend/domain/team_policy_test.go
@@ -1,0 +1,86 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/db"
+)
+
+func TestResolveTeamTaskVMIdlePolicyInheritsGlobalDefaults(t *testing.T) {
+	team := &db.Team{
+		ID:                   uuid.New(),
+		TaskVMSleepEnabled:   true,
+		TaskVMSleepSeconds:   0,
+		TaskVMRecycleEnabled: true,
+		TaskVMRecycleSeconds: 0,
+	}
+
+	got, err := ResolveTeamTaskVMIdlePolicy(team, config.VMIdle{
+		SleepSeconds:   600,
+		RecycleSeconds: 604800,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.SleepEnabled || got.SleepSeconds != 0 || got.EffectiveSleepSeconds != 600 || !got.SleepInherited {
+		t.Fatalf("sleep policy = %#v", got)
+	}
+	if !got.RecycleEnabled || got.RecycleSeconds != 0 || got.EffectiveRecycleSeconds != 604800 || !got.RecycleInherited {
+		t.Fatalf("recycle policy = %#v", got)
+	}
+}
+
+func TestResolveTeamTaskVMIdlePolicyCanDisableQueues(t *testing.T) {
+	team := &db.Team{
+		ID:                   uuid.New(),
+		TaskVMSleepEnabled:   false,
+		TaskVMSleepSeconds:   1200,
+		TaskVMRecycleEnabled: false,
+		TaskVMRecycleSeconds: 86400,
+	}
+
+	got, err := ResolveTeamTaskVMIdlePolicy(team, config.VMIdle{
+		SleepSeconds:   600,
+		RecycleSeconds: 604800,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SleepEnabled || got.EffectiveSleepSeconds != 0 {
+		t.Fatalf("sleep policy = %#v", got)
+	}
+	if got.RecycleEnabled || got.EffectiveRecycleSeconds != 0 {
+		t.Fatalf("recycle policy = %#v", got)
+	}
+}
+
+func TestResolveTeamTaskVMIdlePolicyRejectsInvalidDurations(t *testing.T) {
+	cases := []struct {
+		name string
+		team *db.Team
+	}{
+		{
+			name: "negative sleep",
+			team: &db.Team{TaskVMSleepEnabled: true, TaskVMSleepSeconds: -1, TaskVMRecycleEnabled: true, TaskVMRecycleSeconds: 604800},
+		},
+		{
+			name: "negative recycle",
+			team: &db.Team{TaskVMSleepEnabled: true, TaskVMSleepSeconds: 600, TaskVMRecycleEnabled: true, TaskVMRecycleSeconds: -1},
+		},
+		{
+			name: "sleep not less than recycle",
+			team: &db.Team{TaskVMSleepEnabled: true, TaskVMSleepSeconds: 3600, TaskVMRecycleEnabled: true, TaskVMRecycleSeconds: 3600},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ResolveTeamTaskVMIdlePolicy(tt.team, config.VMIdle{SleepSeconds: 600, RecycleSeconds: 604800}); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}

--- a/backend/ent/schema/team.go
+++ b/backend/ent/schema/team.go
@@ -36,6 +36,10 @@ func (Team) Fields() []ent.Field {
 		field.UUID("id", uuid.UUID{}).Unique(),
 		field.String("name").NotEmpty(),
 		field.Int("member_limit"),
+		field.Bool("task_vm_sleep_enabled").Default(true),
+		field.Int("task_vm_sleep_seconds").Default(0),
+		field.Bool("task_vm_recycle_enabled").Default(true),
+		field.Int("task_vm_recycle_seconds").Default(0),
 		field.Time("created_at").Default(time.Now),
 		field.Time("updated_at").Default(time.Now),
 	}

--- a/backend/migration/000012_alter_teams_add_task_vm_idle_policy.down.sql
+++ b/backend/migration/000012_alter_teams_add_task_vm_idle_policy.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE teams
+    DROP COLUMN IF EXISTS task_vm_recycle_seconds,
+    DROP COLUMN IF EXISTS task_vm_recycle_enabled,
+    DROP COLUMN IF EXISTS task_vm_sleep_seconds,
+    DROP COLUMN IF EXISTS task_vm_sleep_enabled;

--- a/backend/migration/000012_alter_teams_add_task_vm_idle_policy.up.sql
+++ b/backend/migration/000012_alter_teams_add_task_vm_idle_policy.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE teams
+    ADD COLUMN IF NOT EXISTS task_vm_sleep_enabled boolean DEFAULT true NOT NULL,
+    ADD COLUMN IF NOT EXISTS task_vm_sleep_seconds integer DEFAULT 0 NOT NULL,
+    ADD COLUMN IF NOT EXISTS task_vm_recycle_enabled boolean DEFAULT true NOT NULL,
+    ADD COLUMN IF NOT EXISTS task_vm_recycle_seconds integer DEFAULT 0 NOT NULL;

--- a/frontend/src/api/Api.ts
+++ b/frontend/src/api/Api.ts
@@ -1647,6 +1647,18 @@ export interface DomainTeamTaskStats {
   total?: number;
 }
 
+export interface DomainTeamTaskVMIdlePolicy {
+  effective_recycle_seconds?: number;
+  effective_sleep_seconds?: number;
+  recycle_enabled?: boolean;
+  recycle_inherited?: boolean;
+  recycle_seconds?: number;
+  sleep_enabled?: boolean;
+  sleep_inherited?: boolean;
+  sleep_seconds?: number;
+  team_id?: string;
+}
+
 export interface DomainTeamImage {
   created_at?: number;
   groups?: DomainTeamGroup[];
@@ -1874,6 +1886,13 @@ export interface DomainUpdateTeamModelReq {
   remark?: string;
   support_image?: boolean;
   temperature?: number;
+}
+
+export interface DomainUpdateTeamTaskVMIdlePolicyReq {
+  recycle_enabled?: boolean;
+  recycle_seconds?: number;
+  sleep_enabled?: boolean;
+  sleep_seconds?: number;
 }
 
 export interface DomainUpdateTeamOAuthSiteReq {
@@ -3183,6 +3202,55 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         GithubComGoYokoWebResp
       >({
         path: `/api/v1/teams/groups/${groupId}/users`,
+        method: "PUT",
+        body: req,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description 获取当前团队任务创建开发环境的空闲休眠和回收策略
+     *
+     * @tags 【Team 管理员】开发环境管理
+     * @name V1TeamsTaskVmIdlePolicyList
+     * @summary 获取任务开发环境空闲策略
+     * @request GET:/api/v1/teams/task-vm-idle-policy
+     * @secure
+     */
+    v1TeamsTaskVmIdlePolicyList: (params: RequestParams = {}) =>
+      this.request<
+        GithubComGoYokoWebResp & {
+          data?: DomainTeamTaskVMIdlePolicy;
+        },
+        GithubComGoYokoWebResp
+      >({
+        path: `/api/v1/teams/task-vm-idle-policy`,
+        method: "GET",
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description 更新当前团队任务创建开发环境的空闲休眠和回收策略
+     *
+     * @tags 【Team 管理员】开发环境管理
+     * @name V1TeamsTaskVmIdlePolicyUpdate
+     * @summary 更新任务开发环境空闲策略
+     * @request PUT:/api/v1/teams/task-vm-idle-policy
+     * @secure
+     */
+    v1TeamsTaskVmIdlePolicyUpdate: (req: DomainUpdateTeamTaskVMIdlePolicyReq, params: RequestParams = {}) =>
+      this.request<
+        GithubComGoYokoWebResp & {
+          data?: DomainTeamTaskVMIdlePolicy;
+        },
+        GithubComGoYokoWebResp
+      >({
+        path: `/api/v1/teams/task-vm-idle-policy`,
         method: "PUT",
         body: req,
         secure: true,

--- a/frontend/src/pages/console/manager/hosts.tsx
+++ b/frontend/src/pages/console/manager/hosts.tsx
@@ -2,11 +2,11 @@ import { Button } from "@/components/ui/button";
 import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Box, MoreVertical } from "lucide-react";
+import { Box, Clock3, MoreVertical, Save } from "lucide-react";
 import { useState, useEffect } from "react";
 import { apiRequest } from "@/utils/requestUtils";
 import { toast } from "sonner";
-import { TaskflowVirtualMachineStatus, type DomainHost, type DomainTeamGroup, type DomainVirtualMachine } from "@/api/Api";
+import { TaskflowVirtualMachineStatus, type DomainHost, type DomainTeamGroup, type DomainTeamTaskVMIdlePolicy, type DomainVirtualMachine } from "@/api/Api";
 import { Empty, EmptyHeader, EmptyMedia } from "@/components/ui/empty";
 import { Spinner } from "@/components/ui/spinner";
 import { Item, ItemActions, ItemContent, ItemDescription, ItemFooter, ItemGroup, ItemTitle } from "@/components/ui/item";
@@ -17,7 +17,32 @@ import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
 import EditHost from "@/components/manager/edit-host";
 import { formatMemory, getHostStatusBadge } from "@/utils/common";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 
+const secondsToHours = (seconds?: number) => {
+  if (!seconds) {
+    return ""
+  }
+  return String(Math.round((seconds / 3600) * 100) / 100)
+}
+
+const hoursToSeconds = (hours: string) => {
+  const value = Number(hours)
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0
+  }
+  return Math.round(value * 3600)
+}
+
+const formatPolicyDuration = (seconds?: number) => {
+  if (!seconds) {
+    return "未配置"
+  }
+  const hours = seconds / 3600
+  return Number.isInteger(hours) ? `${hours} 小时` : `${Math.round(hours * 100) / 100} 小时`
+}
 
 export default function TeamManagerHosts() {
   const [open, setOpen] = useState(false)
@@ -29,6 +54,13 @@ export default function TeamManagerHosts() {
   
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
   const [editingHost, setEditingHost] = useState<DomainHost | null>(null)
+  const [policy, setPolicy] = useState<DomainTeamTaskVMIdlePolicy | null>(null)
+  const [loadingPolicy, setLoadingPolicy] = useState(false)
+  const [savingPolicy, setSavingPolicy] = useState(false)
+  const [sleepEnabled, setSleepEnabled] = useState(true)
+  const [sleepHours, setSleepHours] = useState("")
+  const [recycleEnabled, setRecycleEnabled] = useState(true)
+  const [recycleHours, setRecycleHours] = useState("")
   
 
 
@@ -42,6 +74,26 @@ export default function TeamManagerHosts() {
       }
     })
     setLoadingHosts(false)
+  }
+
+  const syncPolicyForm = (nextPolicy: DomainTeamTaskVMIdlePolicy) => {
+    setPolicy(nextPolicy)
+    setSleepEnabled(nextPolicy.sleep_enabled ?? true)
+    setSleepHours(secondsToHours(nextPolicy.sleep_seconds))
+    setRecycleEnabled(nextPolicy.recycle_enabled ?? true)
+    setRecycleHours(secondsToHours(nextPolicy.recycle_seconds))
+  }
+
+  const fetchPolicy = async () => {
+    setLoadingPolicy(true)
+    await apiRequest('v1TeamsTaskVmIdlePolicyList', {}, [], (resp) => {
+      if (resp.code === 0 && resp.data) {
+        syncPolicyForm(resp.data)
+      } else {
+        toast.error("获取任务开发环境策略失败: " + resp.message)
+      }
+    })
+    setLoadingPolicy(false)
   }
 
   const fetchInstallCommand = async () => {
@@ -64,7 +116,26 @@ export default function TeamManagerHosts() {
 
   useEffect(() => {
     fetchHosts()
+    fetchPolicy()
   }, [])
+
+  const handleSavePolicy = async () => {
+    setSavingPolicy(true)
+    await apiRequest('v1TeamsTaskVmIdlePolicyUpdate', {
+      sleep_enabled: sleepEnabled,
+      sleep_seconds: hoursToSeconds(sleepHours),
+      recycle_enabled: recycleEnabled,
+      recycle_seconds: hoursToSeconds(recycleHours),
+    }, [], (resp) => {
+      if (resp.code === 0 && resp.data) {
+        syncPolicyForm(resp.data)
+        toast.success("任务开发环境策略已保存")
+      } else {
+        toast.error("保存任务开发环境策略失败: " + resp.message)
+      }
+    })
+    setSavingPolicy(false)
+  }
 
   const handleCopyCommand = async () => {
     try {
@@ -101,6 +172,101 @@ export default function TeamManagerHosts() {
 
   return (
     <div className="flex flex-col gap-4">
+      <Card className="w-full shadow-none">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Clock3 />
+            任务开发环境策略
+          </CardTitle>
+          <CardDescription>
+            只影响通过任务创建的开发环境，手动创建的开发环境不受此配置影响
+          </CardDescription>
+          <CardAction>
+            <Button size="sm" onClick={handleSavePolicy} disabled={savingPolicy || loadingPolicy}>
+              {savingPolicy ? <Spinner className="size-4" /> : <Save className="size-4" />}
+              保存
+            </Button>
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          {loadingPolicy ? (
+            <Empty className="bg-muted">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <Spinner className="size-6" />
+                </EmptyMedia>
+              </EmptyHeader>
+            </Empty>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="rounded-lg border p-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="space-y-1">
+                    <Label htmlFor="task-vm-sleep-enabled">自动休眠</Label>
+                    <p className="text-sm text-muted-foreground">
+                      空闲达到设置时长后休眠任务开发环境
+                    </p>
+                  </div>
+                  <Switch
+                    id="task-vm-sleep-enabled"
+                    checked={sleepEnabled}
+                    onCheckedChange={setSleepEnabled}
+                  />
+                </div>
+                <div className="mt-4 space-y-2">
+                  <Label htmlFor="task-vm-sleep-hours">休眠时长（小时）</Label>
+                  <Input
+                    id="task-vm-sleep-hours"
+                    type="number"
+                    min="0"
+                    step="0.5"
+                    value={sleepHours}
+                    disabled={!sleepEnabled}
+                    placeholder={policy?.sleep_inherited ? `继承默认 ${formatPolicyDuration(policy.effective_sleep_seconds)}` : "继承全局默认"}
+                    onChange={(e) => setSleepHours(e.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    留空或填 0 表示继承全局默认，当前生效：{sleepEnabled ? formatPolicyDuration(policy?.effective_sleep_seconds) : "已关闭"}
+                  </p>
+                </div>
+              </div>
+
+              <div className="rounded-lg border p-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="space-y-1">
+                    <Label htmlFor="task-vm-recycle-enabled">自动回收</Label>
+                    <p className="text-sm text-muted-foreground">
+                      空闲达到设置时长后回收任务开发环境
+                    </p>
+                  </div>
+                  <Switch
+                    id="task-vm-recycle-enabled"
+                    checked={recycleEnabled}
+                    onCheckedChange={setRecycleEnabled}
+                  />
+                </div>
+                <div className="mt-4 space-y-2">
+                  <Label htmlFor="task-vm-recycle-hours">回收时长（小时）</Label>
+                  <Input
+                    id="task-vm-recycle-hours"
+                    type="number"
+                    min="0"
+                    step="0.5"
+                    value={recycleHours}
+                    disabled={!recycleEnabled}
+                    placeholder={policy?.recycle_inherited ? `继承默认 ${formatPolicyDuration(policy.effective_recycle_seconds)}` : "继承全局默认"}
+                    onChange={(e) => setRecycleHours(e.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    留空或填 0 表示继承全局默认，当前生效：{recycleEnabled ? formatPolicyDuration(policy?.effective_recycle_seconds) : "已关闭"}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
       <Card className="w-full shadow-none">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- 增加团队级任务开发环境休眠/回收策略字段、接口与 swagger/API 类型
- vmidle 刷新按团队策略调度 sleep、notify、recycle 队列，只影响任务创建的开发环境
- 团队管理开发环境页增加策略配置区，支持开关和小时级时长配置

## Test Plan
- [x] cd backend && go test ./domain ./biz/team/... ./biz/vmidle/... -count=1
- [x] cd backend && go test ./...
- [x] cd frontend && pnpm build:offline

## Notes
- `pnpm lint` 当前受仓库既有 ESLint 配置/规则问题阻断，未纳入本次治理范围。
- monkeycode-ai 另有配套迁移 SQL 分支：feat-team-task-vm-idle-policy。