### PR TITLE
fix: 修复宿主机安装命令 HTTPS 兼容

### DIFF
--- a/backend/biz/host/usecase/host.go
+++ b/backend/biz/host/usecase/host.go
@@ -189,7 +189,7 @@ func (h *HostUsecase) GetInstallCommand(ctx context.Context, user *domain.User) 
 	values.Add("token", token)
 	baseurl.RawQuery = values.Encode()
 
-	return fmt.Sprintf(`bash -c "$(curl -fsSL '%s')"`, baseurl.String()), nil
+	return fmt.Sprintf(`bash -c "$(curl -kfsSL '%s')"`, baseurl.String()), nil
 }
 
 // InstallScript implements domain.HostUsecase.
@@ -214,7 +214,7 @@ func (h *HostUsecase) InstallScript(ctx context.Context, token *domain.InstallRe
 	param := map[string]any{
 		"token":              token.Token,
 		"grpc_url":           h.cfg.TaskFlow.GrpcURL,
-		"base_url":           h.cfg.Server.BaseURL,
+		"base_url":           internalHTTPURL(h.cfg.Server.BaseURL),
 		"installer_url":      h.installerURL(),
 		"docker_bundle_path": h.installerBundlePath("docker.tgz"),
 		"host_bundle_path":   h.hostBundlePath(),
@@ -229,7 +229,7 @@ func (h *HostUsecase) installerURL() string {
 	if h.cfg.Server.BaseURL == "" {
 		return ""
 	}
-	baseurl, err := url.Parse(h.cfg.Server.BaseURL)
+	baseurl, err := url.Parse(internalHTTPURL(h.cfg.Server.BaseURL))
 	if err != nil {
 		return ""
 	}
@@ -247,6 +247,15 @@ func (h *HostUsecase) hostBundlePath() string {
 
 func (h *HostUsecase) installerBundlePath(name string) string {
 	return "/" + strings.Trim(h.cfg.StaticFiles.RoutePrefix, "/") + "/installer/{{.arch}}/" + name
+}
+
+func internalHTTPURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "https" {
+		return raw
+	}
+	u.Scheme = "http"
+	return u.String()
 }
 
 // List implements domain.HostUsecase.

--- a/backend/biz/host/usecase/host_test.go
+++ b/backend/biz/host/usecase/host_test.go
@@ -54,6 +54,32 @@ func TestInstallScriptDefaultsToOnlineInstaller(t *testing.T) {
 	}
 }
 
+func TestGetInstallCommandSkipsTLSVerification(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	u := &HostUsecase{
+		cfg: &config.Config{
+			Server: struct {
+				Addr    string `mapstructure:"addr"`
+				BaseURL string `mapstructure:"base_url"`
+			}{BaseURL: "https://monkeycode.local"},
+		},
+		redis: rdb,
+	}
+
+	command, err := u.GetInstallCommand(context.Background(), &domain.User{ID: uuid.New()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(command, "curl -kfsSL ") {
+		t.Fatalf("command should skip tls verification: %s", command)
+	}
+}
+
 func TestInstallScriptUsesOfflineBundle(t *testing.T) {
 	t.Parallel()
 
@@ -110,6 +136,47 @@ func TestInstallScriptUsesOfflineBundle(t *testing.T) {
 	}
 	if strings.Contains(script, "release.baizhi.cloud") {
 		t.Fatalf("script should not download public installer: %s", script)
+	}
+}
+
+func TestInstallScriptUsesHTTPForInternalInstallerResources(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	token := "install-token"
+	if err := rdb.Set(context.Background(), "host:token:"+token, "1", time.Minute).Err(); err != nil {
+		t.Fatal(err)
+	}
+	u := &HostUsecase{
+		cfg: &config.Config{
+			Server: struct {
+				Addr    string `mapstructure:"addr"`
+				BaseURL string `mapstructure:"base_url"`
+			}{BaseURL: "https://47.111.27.120"},
+			TaskFlow: config.TaskFlow{GrpcURL: "121.41.208.82:50443"},
+			StaticFiles: config.StaticFilesConfig{
+				RoutePrefix: "/static",
+			},
+			HostInstaller: config.HostInstaller{
+				Mode:       "offline",
+				BundlePath: "installer/{{.arch}}/host.tgz",
+			},
+		},
+		redis: rdb,
+	}
+
+	script, err := u.InstallScript(context.Background(), &domain.InstallReq{Token: token})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(script, `BASE_URL="http://47.111.27.120"`) || !strings.Contains(script, `MCAI_BASE_URL="$BASE_URL"`) {
+		t.Fatalf("script should pass internal http base url: %s", script)
+	}
+	if !strings.Contains(script, `INSTALLER_URL="http://47.111.27.120/static/installer/{{.arch}}/installer"`) {
+		t.Fatalf("script should download installer through internal http url: %s", script)
 	}
 }
 

--- a/backend/biz/team/usecase/host.go
+++ b/backend/biz/team/usecase/host.go
@@ -63,7 +63,7 @@ func (u *TeamHostUsecase) GetInstallCommand(ctx context.Context, teamUser *domai
 	values.Add("token", token)
 	baseurl.RawQuery = values.Encode()
 
-	return fmt.Sprintf(`bash -c "$(curl -fsSL '%s')"`, baseurl.String()), nil
+	return fmt.Sprintf(`bash -c "$(curl -kfsSL '%s')"`, baseurl.String()), nil
 }
 
 // List 获取团队宿主机列表

--- a/backend/biz/team/usecase/host_test.go
+++ b/backend/biz/team/usecase/host_test.go
@@ -1,0 +1,42 @@
+package usecase
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+func TestTeamGetInstallCommandSkipsTLSVerification(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	u := &TeamHostUsecase{
+		cfg: &config.Config{
+			Server: struct {
+				Addr    string `mapstructure:"addr"`
+				BaseURL string `mapstructure:"base_url"`
+			}{BaseURL: "https://monkeycode.local"},
+		},
+		redis: rdb,
+	}
+
+	command, err := u.GetInstallCommand(context.Background(), &domain.TeamUser{
+		User: &domain.User{ID: uuid.New()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(command, "curl -kfsSL ") {
+		t.Fatalf("command should skip tls verification: %s", command)
+	}
+}


### PR DESCRIPTION
## 变更说明
- 宿主机安装命令增加 `curl -k`，兼容 HTTPS 页面入口使用自签证书的场景。
- 离线宿主机安装脚本内部资源地址改为 HTTP，避免安装器后续下载 host/docker 包时触发 TLS 校验。
- 补充个人/团队安装命令和内部 HTTP 资源地址测试。

## 验证
- `go test ./biz/host/usecase ./biz/team/usecase -count=1`