### PR TITLE
fix(clickhouse): 统一模型用量表时间字段时区

### DIFF
--- a/backend/migration/clickhouse_cluster/000002_create_model_usage_events.up.sql
+++ b/backend/migration/clickhouse_cluster/000002_create_model_usage_events.up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS {{MODEL_USAGE_TABLE}}
 ON CLUSTER mcai_cluster
 (
-	event_time DateTime64(3, 'Asia/Shanghai'),
+	event_time DateTime64(3, 'UTC'),
 	team_id String,
 	user_id String,
 	task_id String,
@@ -19,7 +19,7 @@ ON CLUSTER mcai_cluster
 	trace_id String,
 	request_id String,
 	source LowCardinality(String),
-	created_at DateTime64(3, 'Asia/Shanghai') DEFAULT now64(3)
+	created_at DateTime64(3, 'UTC') DEFAULT now64(3, 'UTC')
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/mcai/{{MODEL_USAGE_TABLE_RAW}}', '{replica}')
 PARTITION BY toYYYYMM(event_time)

--- a/backend/migration/clickhouse_single/000002_create_model_usage_events.up.sql
+++ b/backend/migration/clickhouse_single/000002_create_model_usage_events.up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS {{MODEL_USAGE_TABLE}}
 (
-	event_time DateTime64(3, 'Asia/Shanghai'),
+	event_time DateTime64(3, 'UTC'),
 	team_id String,
 	user_id String,
 	task_id String,
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS {{MODEL_USAGE_TABLE}}
 	trace_id String,
 	request_id String,
 	source LowCardinality(String),
-	created_at DateTime64(3, 'Asia/Shanghai') DEFAULT now64(3)
+	created_at DateTime64(3, 'UTC') DEFAULT now64(3, 'UTC')
 )
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(event_time)

--- a/backend/pkg/clickhouse/client_test.go
+++ b/backend/pkg/clickhouse/client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-migrate/migrate/v4/source"
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/chaitin/MonkeyCode/backend/config"
@@ -244,6 +245,84 @@ func TestBuildSingleMigrationSourceIncludesModelUsageCachedTokens(t *testing.T) 
 		if !strings.Contains(query, want) {
 			t.Fatalf("query missing %q:\n%s", want, query)
 		}
+	}
+}
+
+func TestBuildMigrationSourcesUseUTCDateTimeColumns(t *testing.T) {
+	tests := []struct {
+		name string
+		new  func() (source.Driver, error)
+	}{
+		{
+			name: "single",
+			new: func() (source.Driver, error) {
+				return newSingleMigrationSource("task_logs_test", "model_usage_events_test")
+			},
+		},
+		{
+			name: "cluster",
+			new: func() (source.Driver, error) {
+				return newClusterMigrationSource("task_logs_test", "model_usage_events_test")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source, err := tt.new()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = source.Close() })
+
+			for version := uint(1); version <= 2; version++ {
+				body, _, err := source.ReadUp(version)
+				if err != nil {
+					t.Fatal(err)
+				}
+				data, err := io.ReadAll(body)
+				_ = body.Close()
+				if err != nil {
+					t.Fatal(err)
+				}
+				query := string(data)
+				if strings.Contains(query, "Asia/Shanghai") {
+					t.Fatalf("migration %d uses non-UTC timezone:\n%s", version, query)
+				}
+			}
+
+			body, _, err := source.ReadUp(1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			taskLogData, err := io.ReadAll(body)
+			_ = body.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(taskLogData), "ts DateTime64(9, 'UTC')") {
+				t.Fatalf("task log migration missing UTC ts:\n%s", string(taskLogData))
+			}
+
+			body, _, err = source.ReadUp(2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			modelUsageData, err := io.ReadAll(body)
+			_ = body.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			query := string(modelUsageData)
+			for _, want := range []string{
+				"event_time DateTime64(3, 'UTC')",
+				"created_at DateTime64(3, 'UTC') DEFAULT now64(3, 'UTC')",
+			} {
+				if !strings.Contains(query, want) {
+					t.Fatalf("model usage migration missing %q:\n%s", want, query)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- 将 ClickHouse 单机和集群初始化 DDL 中的 model_usage_events 时间字段统一为 UTC
- 将 created_at 默认值改为 now64(3, 'UTC')
- 增加 migration source 测试，覆盖 task_logs 和 model_usage_events 的 UTC 时区约束

## Test Plan
- go test ./...
- go test ./pkg/clickhouse -count=1