### PR TITLE
feat: 初始化团队普通成员

### DIFF
--- a/backend/biz/team/repo/user.go
+++ b/backend/biz/team/repo/user.go
@@ -265,11 +265,17 @@ func (r *TeamGroupUserRepo) GetMember(ctx context.Context, teamID, userID uuid.U
 		First(ctx)
 }
 
-// InitTeam 初始化团队：创建用户（如果不存在）、创建团队、并将用户设为管理员。
+// InitTeam 初始化团队：创建管理员、普通成员、团队和默认资源。
 func (r *TeamGroupUserRepo) InitTeam(ctx context.Context, email string, name string, password string, imageName string) error {
 	return entx.WithTx2(ctx, r.db, func(tx *db.Tx) error {
-		// 检查用户是否已存在
-		existingUser, err := tx.User.Query().Where(user.EmailEQ(email)).First(ctx)
+		hashedPassword, err := crypto.HashPassword(password)
+		if err != nil {
+			return err
+		}
+
+		existingUser, err := tx.User.Query().
+			Where(user.EmailEQ(email), user.RoleEQ(consts.UserRoleEnterprise)).
+			First(ctx)
 		if err != nil {
 			if !db.IsNotFound(err) {
 				return err
@@ -279,13 +285,6 @@ func (r *TeamGroupUserRepo) InitTeam(ctx context.Context, email string, name str
 		var initUser *db.User
 		var initTeam *db.Team
 		if existingUser == nil {
-			// 哈希密码
-			hashedPassword, err := crypto.HashPassword(password)
-			if err != nil {
-				return err
-			}
-
-			// 创建用户
 			initUser, err = tx.User.Create().
 				SetID(uuid.New()).
 				SetName(name).
@@ -338,8 +337,62 @@ func (r *TeamGroupUserRepo) InitTeam(ctx context.Context, email string, name str
 		if err != nil {
 			return err
 		}
+		if err := r.ensureInitTeamMember(ctx, tx, initTeam.ID, email, name, hashedPassword, defaultGroup.ID); err != nil {
+			return err
+		}
 		return r.initTeamImage(ctx, tx, initTeam.ID, defaultGroup.ID, initUser.ID, imageName)
 	})
+}
+
+func (r *TeamGroupUserRepo) ensureInitTeamMember(ctx context.Context, tx *db.Tx, teamID uuid.UUID, email, name, hashedPassword string, groupID uuid.UUID) error {
+	memberUser, err := tx.User.Query().
+		Where(user.EmailEQ(email), user.RoleEQ(consts.UserRoleSubAccount)).
+		First(ctx)
+	if err != nil {
+		if !db.IsNotFound(err) {
+			return err
+		}
+		memberUser, err = tx.User.Create().
+			SetID(uuid.New()).
+			SetName(name).
+			SetEmail(email).
+			SetStatus(consts.UserStatusActive).
+			SetPassword(hashedPassword).
+			SetRole(consts.UserRoleSubAccount).
+			Save(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	exists, err := tx.TeamMember.Query().
+		Where(teammember.TeamIDEQ(teamID), teammember.UserIDEQ(memberUser.ID)).
+		Exist(ctx)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		if _, err := tx.TeamMember.Create().
+			SetID(uuid.New()).
+			SetTeamID(teamID).
+			SetUserID(memberUser.ID).
+			SetRole(consts.TeamMemberRoleUser).
+			Save(ctx); err != nil {
+			return err
+		}
+	}
+
+	exists, err = tx.TeamGroupMember.Query().
+		Where(teamgroupmember.GroupIDEQ(groupID), teamgroupmember.UserIDEQ(memberUser.ID)).
+		Exist(ctx)
+	if err != nil || exists {
+		return err
+	}
+	return tx.TeamGroupMember.Create().
+		SetID(uuid.New()).
+		SetGroupID(groupID).
+		SetUserID(memberUser.ID).
+		Exec(ctx)
 }
 
 func (r *TeamGroupUserRepo) ensureDefaultTeamGroup(ctx context.Context, tx *db.Tx, teamID uuid.UUID) (*db.TeamGroup, error) {

--- a/backend/biz/team/repo/user_test.go
+++ b/backend/biz/team/repo/user_test.go
@@ -15,8 +15,10 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/db/image"
 	"github.com/chaitin/MonkeyCode/backend/db/teamgroup"
 	"github.com/chaitin/MonkeyCode/backend/db/teamgroupimage"
+	"github.com/chaitin/MonkeyCode/backend/db/teamgroupmember"
 	"github.com/chaitin/MonkeyCode/backend/db/teamimage"
 	"github.com/chaitin/MonkeyCode/backend/db/teammember"
+	"github.com/chaitin/MonkeyCode/backend/db/user"
 	"github.com/chaitin/MonkeyCode/backend/pkg/crypto"
 	"github.com/chaitin/MonkeyCode/backend/pkg/entx"
 )
@@ -115,6 +117,89 @@ func TestInitTeamSkipsImageWhenConfigEmpty(t *testing.T) {
 	}
 }
 
+func TestInitTeamCreatesMemberInDefaultGroup(t *testing.T) {
+	ctx := context.Background()
+	client := newTeamRepoTestDB(t)
+	repo := &TeamGroupUserRepo{
+		db:     client,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	if err := repo.InitTeam(ctx, "admin@example.com", "MonkeyCode", "password", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	admin, err := client.User.Query().
+		Where(user.EmailEQ("admin@example.com"), user.RoleEQ(consts.UserRoleEnterprise)).
+		First(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	memberUser, err := client.User.Query().
+		Where(user.EmailEQ("admin@example.com"), user.RoleEQ(consts.UserRoleSubAccount)).
+		First(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if admin.ID == memberUser.ID {
+		t.Fatal("admin and member should be different users")
+	}
+	if err := crypto.VerifyPassword(memberUser.Password, "password"); err != nil {
+		t.Fatalf("verify member password failed: %v", err)
+	}
+
+	adminMember, err := client.TeamMember.Query().
+		Where(teammember.UserIDEQ(admin.ID), teammember.RoleEQ(consts.TeamMemberRoleAdmin)).
+		First(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := client.TeamMember.Query().
+		Where(
+			teammember.TeamIDEQ(adminMember.TeamID),
+			teammember.UserIDEQ(memberUser.ID),
+			teammember.RoleEQ(consts.TeamMemberRoleUser),
+		).
+		First(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	group, err := client.TeamGroup.Query().
+		Where(teamgroup.TeamIDEQ(member.TeamID), teamgroup.NameEQ(defaultTeamGroupName)).
+		First(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exists, err := client.TeamGroupMember.Query().
+		Where(teamgroupmember.GroupIDEQ(group.ID), teamgroupmember.UserIDEQ(memberUser.ID)).
+		Exist(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("member was not added to default group")
+	}
+
+	if err := repo.InitTeam(ctx, "admin@example.com", "MonkeyCode", "password", ""); err != nil {
+		t.Fatal(err)
+	}
+	if count, err := client.User.Query().Where(user.EmailEQ("admin@example.com")).Count(ctx); err != nil {
+		t.Fatal(err)
+	} else if count != 2 {
+		t.Fatalf("user count = %d, want 2", count)
+	}
+	if count, err := client.TeamMember.Query().Where(teammember.TeamIDEQ(adminMember.TeamID)).Count(ctx); err != nil {
+		t.Fatal(err)
+	} else if count != 2 {
+		t.Fatalf("team member count = %d, want 2", count)
+	}
+	if count, err := client.TeamGroupMember.Query().Where(teamgroupmember.GroupIDEQ(group.ID)).Count(ctx); err != nil {
+		t.Fatal(err)
+	} else if count != 1 {
+		t.Fatalf("default group member count = %d, want 1", count)
+	}
+}
+
 func TestInitTeamAddsImageForExistingTeam(t *testing.T) {
 	ctx := context.Background()
 	client := newTeamRepoTestDB(t)
@@ -158,6 +243,35 @@ func TestInitTeamAddsImageForExistingTeam(t *testing.T) {
 		t.Fatal(err)
 	} else if count != 1 {
 		t.Fatalf("team image count = %d, want 1", count)
+	}
+	memberUser, err := client.User.Query().
+		Where(user.EmailEQ("admin@example.com"), user.RoleEQ(consts.UserRoleSubAccount)).
+		First(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := crypto.VerifyPassword(memberUser.Password, "password"); err != nil {
+		t.Fatalf("verify member password failed: %v", err)
+	}
+	if count, err := client.TeamMember.Query().
+		Where(teammember.TeamIDEQ(teamID), teammember.UserIDEQ(memberUser.ID), teammember.RoleEQ(consts.TeamMemberRoleUser)).
+		Count(ctx); err != nil {
+		t.Fatal(err)
+	} else if count != 1 {
+		t.Fatalf("team member count = %d, want 1", count)
+	}
+	group, err := client.TeamGroup.Query().
+		Where(teamgroup.TeamIDEQ(teamID), teamgroup.NameEQ(defaultTeamGroupName)).
+		First(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count, err := client.TeamGroupMember.Query().
+		Where(teamgroupmember.GroupIDEQ(group.ID), teamgroupmember.UserIDEQ(memberUser.ID)).
+		Count(ctx); err != nil {
+		t.Fatal(err)
+	} else if count != 1 {
+		t.Fatalf("default group member count = %d, want 1", count)
 	}
 }
 


### PR DESCRIPTION
## 摘要
- 初始化团队管理员时，同步初始化同邮箱、同密码的普通成员账号
- 普通成员会加入同一团队，并自动加入默认分组
- 保持初始化幂等，覆盖新团队和已有团队补齐场景

## 测试
- go test ./... -count=1
