### PR TITLE
fix: 安装宿主机前检查 AVX 指令集

### DIFF
--- a/backend/biz/host/usecase/host_test.go
+++ b/backend/biz/host/usecase/host_test.go
@@ -52,6 +52,7 @@ func TestInstallScriptDefaultsToOnlineInstaller(t *testing.T) {
 	if strings.Contains(script, "install_docker_from_bundle") {
 		t.Fatalf("online script should not include offline installer: %s", script)
 	}
+	assertInstallScriptChecksAVX(t, script)
 }
 
 func TestInstallScriptUsesOfflineBundle(t *testing.T) {
@@ -110,6 +111,28 @@ func TestInstallScriptUsesOfflineBundle(t *testing.T) {
 	}
 	if strings.Contains(script, "release.baizhi.cloud") {
 		t.Fatalf("script should not download public installer: %s", script)
+	}
+	assertInstallScriptChecksAVX(t, script)
+}
+
+func assertInstallScriptChecksAVX(t *testing.T, script string) {
+	t.Helper()
+
+	for _, want := range []string{
+		"check_avx_support",
+		"/proc/cpuinfo",
+		"grep -qiE '(^|[[:space:]])avx([[:space:]]|$)' /proc/cpuinfo",
+		"Current CPU does not support AVX instructions",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("install script missing AVX check %q:\n%s", want, script)
+		}
+	}
+
+	checkIndex := strings.Index(script, "check_avx_support\n")
+	curlIndex := strings.Index(script, "curl -4")
+	if checkIndex == -1 || curlIndex == -1 || checkIndex > curlIndex {
+		t.Fatalf("install script should check AVX before downloading installer:\n%s", script)
 	}
 }
 

--- a/backend/templates/install.sh.tmpl
+++ b/backend/templates/install.sh.tmpl
@@ -25,6 +25,16 @@ cleanup() {
     rm -f "$FILE_NAME"
 }
 
+check_avx_support() {
+    if [[ "$ARCH" != "x86_64" ]]; then
+        return
+    fi
+    if [[ ! -r /proc/cpuinfo ]] || ! grep -qiE '(^|[[:space:]])avx([[:space:]]|$)' /proc/cpuinfo; then
+        echo -e "${RED}Current CPU does not support AVX instructions. MonkeyCode Runner cannot be installed on this host.${NC}"
+        exit 1
+    fi
+}
+
 # 检查系统架构
 ARCH=$(uname -m)
 case "$ARCH" in
@@ -46,6 +56,7 @@ if [[ $EUID -ne 0 ]]; then
     echo -e "${RED}This script must be run as root${NC}"
     exit 1
 fi
+check_avx_support
 
 echo -e "${GREEN}Architecture: $ARCH${NC}"
 URL="https://release.baizhi.cloud/monkeycode/runner/$ARCH/installer"

--- a/backend/templates/install_offline.sh.tmpl
+++ b/backend/templates/install_offline.sh.tmpl
@@ -16,6 +16,16 @@ handle_error() {
     exit $exit_code
 }
 
+check_avx_support() {
+    if [[ "$ARCH" != "x86_64" ]]; then
+        return
+    fi
+    if [[ ! -r /proc/cpuinfo ]] || ! grep -qiE '(^|[[:space:]])avx([[:space:]]|$)' /proc/cpuinfo; then
+        echo -e "${RED}Current CPU does not support AVX instructions. MonkeyCode Runner cannot be installed on this host.${NC}"
+        exit 1
+    fi
+}
+
 ARCH=$(uname -m)
 case "$ARCH" in
     "x86_64"|"amd64")
@@ -35,6 +45,7 @@ if [[ $EUID -ne 0 ]]; then
     echo -e "${RED}This script must be run as root${NC}"
     exit 1
 fi
+check_avx_support
 
 TOKEN="{{.token}}"
 GRPC_URL="{{.grpc_url}}"


### PR DESCRIPTION
## Summary
- 在在线宿主机安装脚本下载 installer 前检查 x86_64 CPU 是否支持 AVX
- 在离线宿主机安装脚本中加入同样的 AVX 前置检查
- 增加安装脚本渲染测试，约束 AVX 检查存在且发生在 curl 下载前

## Test Plan
- [x] `cd backend && go test ./...`
- [x] `bash -n backend/templates/install.sh.tmpl backend/templates/install_offline.sh.tmpl`
- [x] `git diff --check`
