### PR TITLE
fix: 修复 MCP 工具开关展示状态

### DIFF
--- a/backend/biz/setting/repo/mcp.go
+++ b/backend/biz/setting/repo/mcp.go
@@ -81,7 +81,11 @@ func (r *mcpRepo) ListUserUpstreams(ctx context.Context, uid uuid.UUID, _ domain
 		if u.Scope == mcpupstream.ScopePlatform {
 			tools := cvt.Iter(u.Edges.Tools, func(_ int, t *db.MCPTool) *domain.MCPTool {
 				tmp := cvt.From(t, &domain.MCPTool{})
-				tmp.Enabled = len(settings) == 0 || settings[t.ID]
+				if enabled, ok := settings[t.ID]; ok {
+					tmp.Enabled = enabled
+				} else {
+					tmp.Enabled = true
+				}
 				return tmp
 			})
 			platform.Tools = append(platform.Tools, tools...)

--- a/backend/biz/setting/repo/mcp_test.go
+++ b/backend/biz/setting/repo/mcp_test.go
@@ -115,6 +115,101 @@ func TestListUserUpstreamsSkipsDisabledPlatformResources(t *testing.T) {
 	}
 }
 
+func TestListUserUpstreamsDefaultsUnsetPlatformToolSettingsToEnabled(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:user-mcp-upstreams-tool-settings?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	uid := uuid.New()
+	if _, err := client.User.Create().
+		SetID(uid).
+		SetName("tester").
+		SetRole(consts.UserRoleIndividual).
+		SetStatus(consts.UserStatusActive).
+		Save(ctx); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	upstreamID := uuid.New()
+	if _, err := client.MCPUpstream.Create().
+		SetID(upstreamID).
+		SetName("Platform Docs").
+		SetSlug("platform-docs").
+		SetScope("platform").
+		SetType("server").
+		SetURL("https://example.com/mcp").
+		SetHeaders(map[string]string{}).
+		Save(ctx); err != nil {
+		t.Fatalf("create upstream: %v", err)
+	}
+
+	closedToolID := uuid.New()
+	if _, err := client.MCPTool.Create().
+		SetID(closedToolID).
+		SetUpstreamID(upstreamID).
+		SetName("closed_docs").
+		SetNamespacedName("platform-docs__closed_docs").
+		SetScope("platform").
+		SetInputSchema(map[string]any{}).
+		SetEnabled(true).
+		Save(ctx); err != nil {
+		t.Fatalf("create closed tool: %v", err)
+	}
+
+	unsetToolID := uuid.New()
+	if _, err := client.MCPTool.Create().
+		SetID(unsetToolID).
+		SetUpstreamID(upstreamID).
+		SetName("search_docs").
+		SetNamespacedName("platform-docs__search_docs").
+		SetScope("platform").
+		SetInputSchema(map[string]any{}).
+		SetEnabled(true).
+		Save(ctx); err != nil {
+		t.Fatalf("create unset tool: %v", err)
+	}
+
+	if _, err := client.MCPUserToolSetting.Create().
+		SetID(uuid.New()).
+		SetUserID(uid).
+		SetToolID(closedToolID).
+		SetEnabled(false).
+		Save(ctx); err != nil {
+		t.Fatalf("create tool setting: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Server.BaseURL = "https://monkeycode.example"
+	repo := &mcpRepo{db: client, cfg: cfg}
+	upstreams, err := repo.ListUserUpstreams(ctx, uid, domain.CursorReq{})
+	if err != nil {
+		t.Fatalf("ListUserUpstreams() error = %v", err)
+	}
+	if len(upstreams) == 0 {
+		t.Fatal("upstreams is empty, want platform aggregate upstream")
+	}
+
+	toolsByID := make(map[uuid.UUID]*domain.MCPTool)
+	for _, tool := range upstreams[0].Tools {
+		toolsByID[tool.ID] = tool
+	}
+
+	if toolsByID[closedToolID] == nil {
+		t.Fatalf("closed tool %s not found", closedToolID)
+	}
+	if toolsByID[closedToolID].Enabled {
+		t.Fatal("closed tool enabled = true, want false")
+	}
+	if toolsByID[unsetToolID] == nil {
+		t.Fatalf("unset tool %s not found", unsetToolID)
+	}
+	if !toolsByID[unsetToolID].Enabled {
+		t.Fatal("unset tool enabled = false, want true")
+	}
+}
+
 func TestDeleteUserUpstreamMarksDeletedAt(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- 修复设置页聚合平台 MCP 工具时的用户开关状态默认值
- 未显式设置的工具保持默认开启，只有显式关闭记录才显示关闭
- 增加回归测试覆盖部分工具存在用户设置时的展示状态

## Test Plan
- go test -count=1 ./...（backend）