### PR TITLE
fix: 延长宿主机安装 token 过期时间

### DIFF
--- a/backend/biz/host/usecase/host.go
+++ b/backend/biz/host/usecase/host.go
@@ -176,7 +176,7 @@ func (h *HostUsecase) GetInstallCommand(ctx context.Context, user *domain.User) 
 		return "", err
 	}
 	key := fmt.Sprintf("host:token:%s", token)
-	if err := h.redis.Set(ctx, key, string(ub), 15*time.Minute).Err(); err != nil {
+	if err := h.redis.Set(ctx, key, string(ub), 2*time.Hour).Err(); err != nil {
 		return "", err
 	}
 

--- a/backend/biz/host/usecase/host_test.go
+++ b/backend/biz/host/usecase/host_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -20,6 +21,38 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
 )
+
+func TestGetInstallCommandStoresTokenForTwoHours(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	u := &HostUsecase{
+		cfg: &config.Config{
+			Server: struct {
+				Addr    string `mapstructure:"addr"`
+				BaseURL string `mapstructure:"base_url"`
+			}{BaseURL: "http://monkeycode.local"},
+		},
+		redis: rdb,
+	}
+
+	cmd, err := u.GetInstallCommand(ctx, &domain.User{ID: uuid.New(), Name: "tester"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := installTokenFromCommand(t, cmd)
+	ttl, err := rdb.TTL(ctx, "host:token:"+token).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ttl != 2*time.Hour {
+		t.Fatalf("host install token ttl = %s, want %s", ttl, 2*time.Hour)
+	}
+}
 
 func TestInstallScriptDefaultsToOnlineInstaller(t *testing.T) {
 	t.Parallel()
@@ -134,6 +167,25 @@ func assertInstallScriptChecksAVX(t *testing.T, script string) {
 	if checkIndex == -1 || curlIndex == -1 || checkIndex > curlIndex {
 		t.Fatalf("install script should check AVX before downloading installer:\n%s", script)
 	}
+}
+
+func installTokenFromCommand(t *testing.T, cmd string) string {
+	t.Helper()
+
+	start := strings.Index(cmd, "'")
+	end := strings.LastIndex(cmd, "'")
+	if start == -1 || end <= start {
+		t.Fatalf("install command missing quoted url: %s", cmd)
+	}
+	u, err := url.Parse(cmd[start+1 : end])
+	if err != nil {
+		t.Fatalf("parse install command url: %v", err)
+	}
+	token := u.Query().Get("token")
+	if token == "" {
+		t.Fatalf("install command missing token: %s", cmd)
+	}
+	return token
 }
 
 func TestHostUsecase_markRecycledTasksFinished(t *testing.T) {

--- a/backend/biz/team/usecase/host.go
+++ b/backend/biz/team/usecase/host.go
@@ -50,7 +50,7 @@ func (u *TeamHostUsecase) GetInstallCommand(ctx context.Context, teamUser *domai
 		return "", err
 	}
 	key := fmt.Sprintf("host:token:%s", token)
-	if err := u.redis.Set(ctx, key, string(ub), 15*time.Minute).Err(); err != nil {
+	if err := u.redis.Set(ctx, key, string(ub), 2*time.Hour).Err(); err != nil {
 		return "", err
 	}
 

--- a/backend/biz/team/usecase/host_test.go
+++ b/backend/biz/team/usecase/host_test.go
@@ -1,0 +1,70 @@
+package usecase
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+func TestGetInstallCommandStoresTokenForTwoHours(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	u := &TeamHostUsecase{
+		cfg: &config.Config{
+			Server: struct {
+				Addr    string `mapstructure:"addr"`
+				BaseURL string `mapstructure:"base_url"`
+			}{BaseURL: "http://monkeycode.local"},
+		},
+		redis: rdb,
+	}
+
+	cmd, err := u.GetInstallCommand(ctx, &domain.TeamUser{
+		User: &domain.User{ID: uuid.New(), Name: "tester"},
+		Team: &domain.Team{ID: uuid.New(), Name: "team"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := installTokenFromCommand(t, cmd)
+	ttl, err := rdb.TTL(ctx, "host:token:"+token).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ttl != 2*time.Hour {
+		t.Fatalf("team host install token ttl = %s, want %s", ttl, 2*time.Hour)
+	}
+}
+
+func installTokenFromCommand(t *testing.T, cmd string) string {
+	t.Helper()
+
+	start := strings.Index(cmd, "'")
+	end := strings.LastIndex(cmd, "'")
+	if start == -1 || end <= start {
+		t.Fatalf("install command missing quoted url: %s", cmd)
+	}
+	u, err := url.Parse(cmd[start+1 : end])
+	if err != nil {
+		t.Fatalf("parse install command url: %v", err)
+	}
+	token := u.Query().Get("token")
+	if token == "" {
+		t.Fatalf("install command missing token: %s", cmd)
+	}
+	return token
+}


### PR DESCRIPTION
## Summary
- 将个人宿主机安装 token 的 Redis TTL 从 15 分钟延长到 2 小时
- 将团队宿主机安装 token 的 Redis TTL 同步延长到 2 小时
- 增加个人和团队安装命令生成入口的 TTL 单元测试

## Test Plan
- [x] go test -count=1 ./biz/host/usecase ./biz/team/usecase
- [x] git diff --check