### PR TITLE
fix: 修复 OIDC 身份绑定冲突错误

### DIFF
--- a/backend/biz/team/repo/oidc.go
+++ b/backend/biz/team/repo/oidc.go
@@ -114,6 +114,17 @@ func (r *TeamOIDCRepo) FindTeamMemberByEmail(ctx context.Context, teamID uuid.UU
 }
 
 func (r *TeamOIDCRepo) BindOIDCIdentity(ctx context.Context, userID uuid.UUID, external *domain.OIDCExternalUser) error {
+	identityID := oidc.IdentityID(external.Issuer, external.Subject)
+	exists, err := r.db.UserIdentity.Query().
+		Where(useridentity.PlatformEQ(consts.UserPlatformOIDC), useridentity.IdentityIDEQ(identityID)).
+		Exist(ctx)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
 	name := external.Name
 	if name == "" {
 		name = external.Username
@@ -125,14 +136,10 @@ func (r *TeamOIDCRepo) BindOIDCIdentity(ctx context.Context, userID uuid.UUID, e
 		SetID(uuid.New()).
 		SetUserID(userID).
 		SetPlatform(consts.UserPlatformOIDC).
-		SetIdentityID(oidc.IdentityID(external.Issuer, external.Subject)).
+		SetIdentityID(identityID).
 		SetUsername(name).
 		SetEmail(external.Email).
 		SetAvatarURL(external.AvatarURL).
-		OnConflict(
-			sql.ConflictColumns(useridentity.FieldPlatform, useridentity.FieldIdentityID),
-			sql.ResolveWithIgnore(),
-		).
 		Exec(ctx)
 }
 

--- a/backend/biz/team/repo/oidc_test.go
+++ b/backend/biz/team/repo/oidc_test.go
@@ -5,10 +5,16 @@ import (
 	"testing"
 	"time"
 
+	"entgo.io/ent/dialect"
+	entsql "entgo.io/ent/dialect/sql"
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/db/enttest"
 	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/pkg/oidc"
 )
 
 func TestTeamOIDCConfigSchemaPersistsDefaults(t *testing.T) {
@@ -106,6 +112,77 @@ func TestTeamOIDCRepoAutoCreateMemberHonorsLimit(t *testing.T) {
 	_, err = r.AutoCreateMember(ctx, teamID, &domain.OIDCExternalUser{Email: "new@example.com", Name: "新成员"})
 	if err == nil {
 		t.Fatal("expected member limit error")
+	}
+}
+
+func TestTeamOIDCRepoBindOIDCIdentitySkipsCreateWhenIdentityExists(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqlDB.Close()
+
+	client := db.NewClient(db.Driver(entsql.OpenDB(dialect.Postgres, sqlDB)))
+	defer client.Close()
+
+	external := &domain.OIDCExternalUser{
+		Issuer:    "https://id.example.com",
+		Subject:   "sub-1",
+		Email:     "new@example.com",
+		Name:      "新成员",
+		AvatarURL: "https://id.example.com/avatar.png",
+	}
+	identityID := oidc.IdentityID(external.Issuer, external.Subject)
+	userID := uuid.New()
+
+	mock.ExpectQuery(`SELECT .* FROM "user_identities"`).
+		WithArgs(consts.UserPlatformOIDC, identityID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	r := &TeamOIDCRepo{db: client}
+	if err := r.BindOIDCIdentity(ctx, userID, external); err != nil {
+		t.Fatal(err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTeamOIDCRepoBindOIDCIdentityCreatesAfterExplicitLookup(t *testing.T) {
+	ctx := context.Background()
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqlDB.Close()
+
+	client := db.NewClient(db.Driver(entsql.OpenDB(dialect.Postgres, sqlDB)))
+	defer client.Close()
+
+	external := &domain.OIDCExternalUser{
+		Issuer:    "https://id.example.com",
+		Subject:   "sub-1",
+		Email:     "new@example.com",
+		Name:      "新成员",
+		AvatarURL: "https://id.example.com/avatar.png",
+	}
+	identityID := oidc.IdentityID(external.Issuer, external.Subject)
+	userID := uuid.New()
+
+	mock.ExpectQuery(`SELECT .* FROM "user_identities"`).
+		WithArgs(consts.UserPlatformOIDC, identityID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectExec(`INSERT INTO "user_identities" .* VALUES`).
+		WithArgs(consts.UserPlatformOIDC, identityID, external.Name, external.Email, external.AvatarURL, sqlmock.AnyArg(), userID, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	r := &TeamOIDCRepo{db: client}
+	if err := r.BindOIDCIdentity(ctx, userID, external); err != nil {
+		t.Fatal(err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## 摘要
- 将 OIDC 身份绑定从 ON CONFLICT 改为先显式查询再插入
- 已存在绑定时直接返回，避免 PostgreSQL 部分唯一索引冲突目标不匹配
- 补充绑定已存在和查询后插入的回归测试

## 验证
- go test ./biz/team/...