### PR TITLE
fix(backend): 补齐错误码国际化文案

### DIFF
--- a/backend/errcode/errcode_test.go
+++ b/backend/errcode/errcode_test.go
@@ -1,6 +1,12 @@
 package errcode_test
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/GoYoko/web/locale"
@@ -16,4 +22,62 @@ func TestTeamMemberLimitExceededHasChineseMessage(t *testing.T) {
 	if got != "团队成员数量已达上限" {
 		t.Fatalf("message = %q, want %q", got, "团队成员数量已达上限")
 	}
+}
+
+func TestErrCodeMessagesHaveLocaleEntries(t *testing.T) {
+	keys := errCodeKeys(t)
+	localizer := locale.NewLocalizerWithFile(language.Chinese, errcode.LocalFS, []string{"locale.zh.toml", "locale.en.toml"})
+
+	for _, lang := range []string{"zh", "en"} {
+		for _, key := range keys {
+			t.Run(lang+"/"+key, func(t *testing.T) {
+				got := localizer.Message(lang, key, nil)
+				if strings.Contains(got, "message \"") {
+					t.Fatalf("missing locale message: %s", got)
+				}
+			})
+		}
+	}
+}
+
+func errCodeKeys(t *testing.T) []string {
+	t.Helper()
+
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, "errcode.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keySet := make(map[string]struct{})
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if len(call.Args) < 3 {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "NewErr" {
+			return true
+		}
+		key, ok := call.Args[2].(*ast.BasicLit)
+		if !ok || key.Kind != token.STRING {
+			return true
+		}
+		value, err := strconv.Unquote(key.Value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		keySet[value] = struct{}{}
+		return true
+	})
+
+	keys := make([]string, 0, len(keySet))
+	for key := range keySet {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/backend/errcode/locale.en.toml
+++ b/backend/errcode/locale.en.toml
@@ -233,3 +233,33 @@ other = "Account is not a member of this team"
 
 [err-password-login-disabled]
 other = "Password login is disabled for this team"
+
+[err-has-invalid-entry]
+other = "Invalid entry exists"
+
+[err-stream-disconnect]
+other = "Disconnected from development environment, please try again later"
+
+[err-file-op]
+other = "File operation failed"
+
+[err-vm-removed]
+other = "VM has been recycled"
+
+[err-forbidden-base-url]
+other = "Base URL is not allowed"
+
+[err-user-already-exists]
+other = "User already exists"
+
+[err-change-password-failed]
+other = "Change password failed"
+
+[err-password-hash-failed]
+other = "Password hash failed"
+
+[err-captcha-verify-failed]
+other = "Captcha verification failed"
+
+[err-wechat-mp-not-bound]
+other = "WeChat official account is not bound"

--- a/backend/errcode/locale.zh.toml
+++ b/backend/errcode/locale.zh.toml
@@ -240,3 +240,24 @@ other = "账号未加入该团队"
 
 [err-password-login-disabled]
 other = "该团队已关闭账号密码登录"
+
+[err-has-invalid-entry]
+other = "存在无效条目"
+
+[err-forbidden-base-url]
+other = "不允许访问该地址"
+
+[err-user-already-exists]
+other = "用户已存在"
+
+[err-change-password-failed]
+other = "修改密码失败"
+
+[err-password-hash-failed]
+other = "密码加密失败"
+
+[err-captcha-verify-failed]
+other = "验证码校验失败"
+
+[err-wechat-mp-not-bound]
+other = "未绑定微信公众号"


### PR DESCRIPTION
## Summary
- 补齐后端 errcode 中缺失的中文、英文国际化文案
- 新增错误码文案完整性测试，覆盖 `web.NewErr` 定义的 zh/en 文案缺失问题
- 确认 `err-login-failed`、`err-oidc-email-not-verified` 在中文 locale 中可正常解析

## Test Plan
- [x] `cd backend && go test ./...`
- [x] `git diff --check`
