### PR TITLE
fix: 增加 License 业务错误码

### DIFF
--- a/backend/errcode/errcode.go
+++ b/backend/errcode/errcode.go
@@ -132,4 +132,11 @@ var (
 
 	// 微信公众号
 	ErrWechatMPNotBound = web.NewErr(http.StatusOK, 11200, "err-wechat-mp-not-bound")
+
+	// License 管理
+	ErrLicenseInvalid         = web.NewErr(http.StatusOK, 11300, "err-license-invalid")
+	ErrLicenseMissing         = web.NewErr(http.StatusOK, 11301, "err-license-missing")
+	ErrLicenseExpired         = web.NewErr(http.StatusOK, 11302, "err-license-expired")
+	ErrLicenseNotReady        = web.NewErr(http.StatusOK, 11303, "err-license-not-ready")
+	ErrLicenseMachineMismatch = web.NewErr(http.StatusOK, 11304, "err-license-machine-mismatch")
 )

--- a/backend/errcode/errcode_test.go
+++ b/backend/errcode/errcode_test.go
@@ -24,6 +24,16 @@ func TestTeamMemberLimitExceededHasChineseMessage(t *testing.T) {
 	}
 }
 
+func TestLicenseMachineMismatchHasChineseMessage(t *testing.T) {
+	localizer := locale.NewLocalizerWithFile(language.Chinese, errcode.LocalFS, []string{"locale.zh.toml", "locale.en.toml"})
+
+	got := localizer.Message("zh", "err-license-machine-mismatch", nil)
+
+	if got != "License 机器码不匹配" {
+		t.Fatalf("message = %q, want %q", got, "License 机器码不匹配")
+	}
+}
+
 func TestErrCodeMessagesHaveLocaleEntries(t *testing.T) {
 	keys := errCodeKeys(t)
 	localizer := locale.NewLocalizerWithFile(language.Chinese, errcode.LocalFS, []string{"locale.zh.toml", "locale.en.toml"})

--- a/backend/errcode/locale.en.toml
+++ b/backend/errcode/locale.en.toml
@@ -263,3 +263,18 @@ other = "Captcha verification failed"
 
 [err-wechat-mp-not-bound]
 other = "WeChat official account is not bound"
+
+[err-license-invalid]
+other = "License is invalid"
+
+[err-license-missing]
+other = "License has not been imported"
+
+[err-license-expired]
+other = "License has expired"
+
+[err-license-not-ready]
+other = "License is not active yet"
+
+[err-license-machine-mismatch]
+other = "License machine code does not match"

--- a/backend/errcode/locale.zh.toml
+++ b/backend/errcode/locale.zh.toml
@@ -261,3 +261,18 @@ other = "验证码校验失败"
 
 [err-wechat-mp-not-bound]
 other = "未绑定微信公众号"
+
+[err-license-invalid]
+other = "License 无效"
+
+[err-license-missing]
+other = "未导入 License"
+
+[err-license-expired]
+other = "License 已过期"
+
+[err-license-not-ready]
+other = "License 尚未生效"
+
+[err-license-machine-mismatch]
+other = "License 机器码不匹配"


### PR DESCRIPTION
## Summary
- 增加 License 无效、缺失、过期、未生效、机器码不匹配错误码
- 补充中英文 locale，避免 Pro 包 License 业务错误返回通用服务错误
- 增加机器码不匹配中文文案测试，并保留错误码 locale 覆盖测试

## Test Plan
- [x] cd backend && go test ./errcode -count=1
- [x] cd backend && go test ./...