### PR TITLE
fix: 修正团队成员席位统计

### DIFF
--- a/backend/biz/team/repo/dashboard.go
+++ b/backend/biz/team/repo/dashboard.go
@@ -87,7 +87,10 @@ func (r *TeamDashboardRepo) Overview(ctx context.Context, teamID uuid.UUID, req 
 
 func (r *TeamDashboardRepo) teamMemberIDs(ctx context.Context, teamID uuid.UUID) ([]uuid.UUID, error) {
 	return r.db.TeamMember.Query().
-		Where(teammember.TeamIDEQ(teamID)).
+		Where(
+			teammember.TeamIDEQ(teamID),
+			teammember.RoleEQ(consts.TeamMemberRoleUser),
+		).
 		QueryUser().
 		Where(user.IsBlockedEQ(false)).
 		IDs(ctx)

--- a/backend/biz/team/repo/dashboard_test.go
+++ b/backend/biz/team/repo/dashboard_test.go
@@ -94,6 +94,42 @@ func TestTeamDashboardOverviewAggregatesMetrics(t *testing.T) {
 	}
 }
 
+func TestTeamDashboardOverviewExcludesAdminsFromMemberMetrics(t *testing.T) {
+	ctx := context.Background()
+	client := newDashboardRepoTestDB(t)
+	now := time.Date(2026, 6, 4, 10, 0, 0, 0, time.UTC)
+	teamID := uuid.New()
+	memberID := uuid.New()
+	adminID := uuid.New()
+	repo := &TeamDashboardRepo{
+		db:          client,
+		usageReader: &dashboardUsageReaderStub{},
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	createDashboardTeamUser(t, client, teamID, memberID, "林航", "前端组")
+	createDashboardTeamMember(t, client, teamID, adminID, "管理员", "管理组", consts.TeamMemberRoleAdmin)
+	createDashboardTask(t, client, uuid.New(), memberID, "成员任务", consts.TaskStatusFinished, now.Add(-2*time.Hour), now.Add(-90*time.Minute), now.Add(-30*time.Minute))
+	createDashboardTask(t, client, uuid.New(), adminID, "管理员任务", consts.TaskStatusFinished, now.Add(-2*time.Hour), now.Add(-90*time.Minute), now.Add(-30*time.Minute))
+
+	resp, err := repo.Overview(ctx, teamID, domain.TeamDashboardQuery{
+		Start: now.Add(-24 * time.Hour),
+		End:   now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Metrics.TotalMembers != 1 {
+		t.Fatalf("total members = %d, want 1", resp.Metrics.TotalMembers)
+	}
+	if resp.Metrics.ActiveMembers != 1 {
+		t.Fatalf("active members = %d, want 1", resp.Metrics.ActiveMembers)
+	}
+	if resp.Metrics.TaskCount != 1 {
+		t.Fatalf("task count = %d, want 1", resp.Metrics.TaskCount)
+	}
+}
+
 func TestTeamDashboardOverviewAggregatesUsageByTask(t *testing.T) {
 	ctx := context.Background()
 	client := newDashboardRepoTestDB(t)
@@ -289,6 +325,11 @@ func TestTeamDashboardRepoAvoidsSQLiteOnlyTimeFunction(t *testing.T) {
 
 func createDashboardTeamUser(t *testing.T, client *db.Client, teamID, userID uuid.UUID, name, groupName string) {
 	t.Helper()
+	createDashboardTeamMember(t, client, teamID, userID, name, groupName, consts.TeamMemberRoleUser)
+}
+
+func createDashboardTeamMember(t *testing.T, client *db.Client, teamID, userID uuid.UUID, name, groupName string, role consts.TeamMemberRole) {
+	t.Helper()
 	ctx := context.Background()
 	exists, err := client.Team.Query().Where(team.IDEQ(teamID)).Exist(ctx)
 	if err != nil {
@@ -302,7 +343,7 @@ func createDashboardTeamUser(t *testing.T, client *db.Client, teamID, userID uui
 	if _, err := client.User.Create().SetID(userID).SetName(name).SetEmail(name + "@example.com").SetRole(consts.UserRoleEnterprise).SetStatus(consts.UserStatusActive).Save(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := client.TeamMember.Create().SetID(uuid.New()).SetTeamID(teamID).SetUserID(userID).SetRole(consts.TeamMemberRoleUser).Save(ctx); err != nil {
+	if _, err := client.TeamMember.Create().SetID(uuid.New()).SetTeamID(teamID).SetUserID(userID).SetRole(role).Save(ctx); err != nil {
 		t.Fatal(err)
 	}
 	group, err := client.TeamGroup.Create().SetID(uuid.New()).SetTeamID(teamID).SetName(groupName).Save(ctx)

--- a/frontend/src/components/manager/team-members-card.tsx
+++ b/frontend/src/components/manager/team-members-card.tsx
@@ -19,12 +19,13 @@ import dayjs from "dayjs";
 interface TeamMembersCardProps {
   members: any[];
   memberLimit: number;
+  usedSeats: number;
   groups: any[];
   onRefreshMembers: () => void;
   onRefreshGroups?: () => void;
 }
 
-export default function TeamMembersCard({ members, memberLimit, groups, onRefreshMembers, onRefreshGroups }: TeamMembersCardProps) {
+export default function TeamMembersCard({ members, memberLimit, usedSeats, groups, onRefreshMembers, onRefreshGroups }: TeamMembersCardProps) {
   const isOfflineEdition = import.meta.env.VITE_APP_EDITION === "offline";
   const [addMemberDialogOpen, setAddMemberDialogOpen] = useState(false);
   const [emails, setEmails] = useState("");
@@ -245,12 +246,12 @@ export default function TeamMembersCard({ members, memberLimit, groups, onRefres
             团队成员
           </CardTitle>
           <CardDescription>
-            当前成员数量: {members.length} / {memberLimit}
+            当前成员数量: {usedSeats} / {memberLimit}
           </CardDescription>
           <CardAction>
             <Button 
               variant="outline" 
-              disabled={memberLimit <= members.length}
+              disabled={memberLimit <= usedSeats}
               onClick={() => setAddMemberDialogOpen(true)}
             >
               <IconCirclePlus />

--- a/frontend/src/pages/console/manager/member-seat.ts
+++ b/frontend/src/pages/console/manager/member-seat.ts
@@ -1,0 +1,15 @@
+export type LicenseSeatStatus = {
+  seats?: number;
+  used_seats?: number;
+  limits?: {
+    max_members?: number;
+  };
+};
+
+export function resolveMemberLimit(fallbackLimit: number, status?: LicenseSeatStatus | null) {
+  return status?.limits?.max_members ?? status?.seats ?? fallbackLimit;
+}
+
+export function resolveUsedSeats(memberCount: number, status?: LicenseSeatStatus | null) {
+  return status?.used_seats ?? memberCount;
+}

--- a/frontend/src/pages/console/manager/members.tsx
+++ b/frontend/src/pages/console/manager/members.tsx
@@ -3,21 +3,38 @@ import { apiRequest } from "@/utils/requestUtils";
 import TeamMembersCard from "@/components/manager/team-members-card";
 import TeamGroupsCard from "@/components/manager/team-groups-card";
 import { toast } from "sonner";
+import {
+  resolveMemberLimit,
+  resolveUsedSeats,
+  type LicenseSeatStatus,
+} from "./member-seat";
 
 export default function TeamManagerMembers() {
   const [members, setMembers] = useState<any[]>([]);
   const [groups, setGroups] = useState<any[]>([]);
-  const [memberLimit, setMemberLimit] = useState(0);
+  const [fallbackMemberLimit, setFallbackMemberLimit] = useState(0);
+  const [licenseSeatStatus, setLicenseSeatStatus] = useState<LicenseSeatStatus | null>(null);
+  const isOfflineEdition = import.meta.env.VITE_APP_EDITION === "offline";
+  const memberLimit = resolveMemberLimit(fallbackMemberLimit, licenseSeatStatus);
+  const usedSeats = resolveUsedSeats(members.length, licenseSeatStatus);
 
   const fetchMembers = async () => {
     await apiRequest('v1TeamsUsersList', { role: "user" }, [], (resp) => {
       if (resp.code === 0) {
         setMembers(resp.data?.members || []);
-        setMemberLimit(resp.data?.member_limit || 0);
+        setFallbackMemberLimit(resp.data?.member_limit || 0);
       } else {
         toast.error(resp.message || "获取成员列表失败")
       }
     })
+  }
+
+  const fetchLicenseStatus = async () => {
+    await apiRequest('v1LicenseStatusList', {}, [], (resp) => {
+      if (resp.code === 0) {
+        setLicenseSeatStatus((resp.data ?? null) as LicenseSeatStatus | null);
+      }
+    }, () => {})
   }
 
   const fetchGroups = async () => {
@@ -30,18 +47,29 @@ export default function TeamManagerMembers() {
     })
   }
 
+  const refreshMembers = async () => {
+    await fetchMembers();
+    if (isOfflineEdition) {
+      await fetchLicenseStatus();
+    }
+  }
+
   useEffect(() => {
     fetchMembers();
     fetchGroups();
-  }, []);
+    if (isOfflineEdition) {
+      fetchLicenseStatus();
+    }
+  }, [isOfflineEdition]);
 
   return (
     <div className="flex flex-row gap-4 w-full flex-1">
       <TeamMembersCard 
         members={members}
         memberLimit={memberLimit}
+        usedSeats={usedSeats}
         groups={groups}
-        onRefreshMembers={fetchMembers}
+        onRefreshMembers={refreshMembers}
         onRefreshGroups={fetchGroups}
       />
       <TeamGroupsCard 

--- a/frontend/test/member-seat.test.ts
+++ b/frontend/test/member-seat.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveMemberLimit, resolveUsedSeats } from "../src/pages/console/manager/member-seat.js";
+
+test("成员管理优先使用 license 席位上限", () => {
+  assert.equal(resolveMemberLimit(5, { seats: 12 }), 12);
+  assert.equal(resolveMemberLimit(5, { seats: 12, limits: { max_members: 20 } }), 20);
+});
+
+test("成员管理优先使用 license 已用席位", () => {
+  assert.equal(resolveUsedSeats(3, { used_seats: 8 }), 8);
+});


### PR DESCRIPTION
## Summary
- 团队管理概览统计普通成员时排除管理员，避免管理员任务和活跃数进入成员统计。
- 成员管理页在离线版优先使用 license/status 的 seats、used_seats，和 License 页保持席位口径一致。
- 增加 dashboard 回归测试和成员席位解析纯函数测试。

## Test Plan
- [x] cd backend && go test ./biz/team/...
- [x] cd frontend && rm -rf /tmp/monkeycode-member-seat-test && pnpm exec tsc --target ES2022 --module NodeNext --moduleResolution NodeNext --types node --outDir /tmp/monkeycode-member-seat-test src/pages/console/manager/member-seat.ts test/member-seat.test.ts && node --test /tmp/monkeycode-member-seat-test/test/member-seat.test.js
- [x] cd frontend && pnpm build

## Notes
- pnpm lint 当前被项目 ESLint 9 flat config 兼容问题阻塞：配置仍使用 plugins 字符串数组形式，需单独修复配置后再跑。