### PR TITLE
fix: 团队概览成员统计排除管理员

### DIFF
--- a/backend/biz/team/repo/dashboard.go
+++ b/backend/biz/team/repo/dashboard.go
@@ -399,11 +399,11 @@ func (r *TeamDashboardRepo) fillInsights(ctx context.Context, resp *domain.TeamD
 		})
 	}
 
-	usage, err := r.usageSummary(ctx, teamID, req.Start, req.End)
+	usage, err := r.usageSummary(ctx, teamID, req.Start, req.End, memberIDs...)
 	if err != nil {
 		return err
 	}
-	topUsers, err := r.topUsers(ctx, teamID, req.Start, req.End, 5)
+	topUsers, err := r.topUsers(ctx, teamID, memberIDs, req.Start, req.End, 5)
 	if err != nil {
 		return err
 	}
@@ -480,26 +480,39 @@ func (r *TeamDashboardRepo) fillInsights(ctx context.Context, resp *domain.TeamD
 	return nil
 }
 
-func (r *TeamDashboardRepo) usageSummary(ctx context.Context, teamID uuid.UUID, start, end time.Time) (clickhouse.ModelUsageSummary, error) {
+func (r *TeamDashboardRepo) usageSummary(ctx context.Context, teamID uuid.UUID, start, end time.Time, memberIDs ...uuid.UUID) (clickhouse.ModelUsageSummary, error) {
 	if r.usageReader == nil {
 		return clickhouse.ModelUsageSummary{}, nil
 	}
 	return r.usageReader.QueryModelUsageSummary(ctx, clickhouse.ModelUsageQuery{
-		TeamID: teamID.String(),
-		Start:  start,
-		End:    end,
+		TeamID:  teamID.String(),
+		UserIDs: uuidStrings(memberIDs),
+		Start:   start,
+		End:     end,
 	})
 }
 
-func (r *TeamDashboardRepo) topUsers(ctx context.Context, teamID uuid.UUID, start, end time.Time, limit int) ([]clickhouse.ModelUsageTopUser, error) {
+func (r *TeamDashboardRepo) topUsers(ctx context.Context, teamID uuid.UUID, memberIDs []uuid.UUID, start, end time.Time, limit int) ([]clickhouse.ModelUsageTopUser, error) {
 	if r.usageReader == nil {
 		return nil, nil
 	}
 	return r.usageReader.QueryModelUsageTopUsers(ctx, clickhouse.ModelUsageQuery{
-		TeamID: teamID.String(),
-		Start:  start,
-		End:    end,
+		TeamID:  teamID.String(),
+		UserIDs: uuidStrings(memberIDs),
+		Start:   start,
+		End:     end,
 	}, limit)
+}
+
+func uuidStrings(ids []uuid.UUID) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	values := make([]string, 0, len(ids))
+	for _, id := range ids {
+		values = append(values, id.String())
+	}
+	return values
 }
 
 func (r *TeamDashboardRepo) ListProjects(ctx context.Context, teamID uuid.UUID, req domain.TeamDashboardListReq) (*domain.TeamProjectListResp, error) {

--- a/backend/biz/team/repo/dashboard_test.go
+++ b/backend/biz/team/repo/dashboard_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -102,9 +103,16 @@ func TestTeamDashboardOverviewExcludesAdminsFromMemberMetrics(t *testing.T) {
 	memberID := uuid.New()
 	adminID := uuid.New()
 	repo := &TeamDashboardRepo{
-		db:          client,
-		usageReader: &dashboardUsageReaderStub{},
-		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		db: client,
+		usageReader: &dashboardUsageReaderStub{
+			summary: clickhouse.ModelUsageSummary{TotalTokens: 300, Requests: 2},
+			topUsers: []clickhouse.ModelUsageTopUser{
+				{UserID: adminID.String(), TotalTokens: 200, Requests: 1},
+				{UserID: memberID.String(), TotalTokens: 100, Requests: 1},
+			},
+			filterTopUsersByQuery: true,
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
 	createDashboardTeamUser(t, client, teamID, memberID, "林航", "前端组")
@@ -127,6 +135,12 @@ func TestTeamDashboardOverviewExcludesAdminsFromMemberMetrics(t *testing.T) {
 	}
 	if resp.Metrics.TaskCount != 1 {
 		t.Fatalf("task count = %d, want 1", resp.Metrics.TaskCount)
+	}
+	if len(resp.Insights.HighConsumption) != 1 || resp.Insights.HighConsumption[0].ID != memberID.String() {
+		t.Fatalf("high consumption = %#v, want only non-admin member", resp.Insights.HighConsumption)
+	}
+	if got := repo.usageReader.(*dashboardUsageReaderStub).topUserQueries[0].UserIDs; !slices.Equal(got, []string{memberID.String()}) {
+		t.Fatalf("top user query user ids = %#v, want only member id", got)
 	}
 }
 
@@ -289,8 +303,10 @@ func TestTeamDashboardListsOnlyCurrentTeamData(t *testing.T) {
 }
 
 type dashboardUsageReaderStub struct {
-	summary  clickhouse.ModelUsageSummary
-	topUsers []clickhouse.ModelUsageTopUser
+	summary               clickhouse.ModelUsageSummary
+	topUsers              []clickhouse.ModelUsageTopUser
+	topUserQueries        []clickhouse.ModelUsageQuery
+	filterTopUsersByQuery bool
 }
 
 func (s *dashboardUsageReaderStub) QueryModelUsageSummary(ctx context.Context, q clickhouse.ModelUsageQuery) (clickhouse.ModelUsageSummary, error) {
@@ -298,6 +314,16 @@ func (s *dashboardUsageReaderStub) QueryModelUsageSummary(ctx context.Context, q
 }
 
 func (s *dashboardUsageReaderStub) QueryModelUsageTopUsers(ctx context.Context, q clickhouse.ModelUsageQuery, limit int) ([]clickhouse.ModelUsageTopUser, error) {
+	s.topUserQueries = append(s.topUserQueries, q)
+	if s.filterTopUsersByQuery {
+		users := make([]clickhouse.ModelUsageTopUser, 0, len(s.topUsers))
+		for _, item := range s.topUsers {
+			if slices.Contains(q.UserIDs, item.UserID) {
+				users = append(users, item)
+			}
+		}
+		return users, nil
+	}
 	return s.topUsers, nil
 }
 

--- a/backend/pkg/clickhouse/client.go
+++ b/backend/pkg/clickhouse/client.go
@@ -175,9 +175,10 @@ type ModelUsageEvent struct {
 }
 
 type ModelUsageQuery struct {
-	TeamID string
-	Start  time.Time
-	End    time.Time
+	TeamID  string
+	UserIDs []string
+	Start   time.Time
+	End     time.Time
 }
 
 type ModelUsageSummary struct {
@@ -221,12 +222,12 @@ type TeamConversationListQuery struct {
 }
 
 type TeamConversationRow struct {
-	TaskID    string
-	TS        time.Time
-	Event     string
-	Kind      string
-	TurnSeq   uint32
-	Data      string
+	TaskID      string
+	TS          time.Time
+	Event       string
+	Kind        string
+	TurnSeq     uint32
+	Data        string
 	MsgSeqStart uint64
 	MsgSeqEnd   uint64
 }
@@ -278,6 +279,7 @@ func (c *Client) QueryModelUsageSummary(ctx context.Context, q ModelUsageQuery) 
 	if err != nil {
 		return summary, err
 	}
+	where, args := modelUsageWhere(q)
 	query := fmt.Sprintf(`SELECT
 	coalesce(sum(input_tokens), 0) AS input_tokens,
 	coalesce(sum(output_tokens), 0) AS output_tokens,
@@ -285,8 +287,8 @@ func (c *Client) QueryModelUsageSummary(ctx context.Context, q ModelUsageQuery) 
 	coalesce(sum(total_tokens), 0) AS total_tokens,
 	coalesce(sum(request_count), 0) AS requests
 FROM %s
-WHERE team_id = ? AND event_time >= ? AND event_time < ?`, tableIdentifier)
-	err = c.db.QueryRowContext(ctx, query, q.TeamID, q.Start, q.End).Scan(
+%s`, tableIdentifier, where)
+	err = c.db.QueryRowContext(ctx, query, args...).Scan(
 		&summary.InputTokens,
 		&summary.OutputTokens,
 		&summary.CachedTokens,
@@ -307,16 +309,18 @@ func (c *Client) QueryModelUsageTopUsers(ctx context.Context, q ModelUsageQuery,
 	if err != nil {
 		return nil, err
 	}
+	where, args := modelUsageWhere(q)
 	query := fmt.Sprintf(`SELECT
 	user_id,
 	coalesce(sum(total_tokens), 0) AS total_tokens,
 	coalesce(sum(request_count), 0) AS requests
 FROM %s
-WHERE team_id = ? AND event_time >= ? AND event_time < ?
+%s
 GROUP BY user_id
 ORDER BY total_tokens DESC
-LIMIT ?`, tableIdentifier)
-	rows, err := c.db.QueryContext(ctx, query, q.TeamID, q.Start, q.End, limit)
+LIMIT ?`, tableIdentifier, where)
+	args = append(args, limit)
+	rows, err := c.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -333,6 +337,17 @@ LIMIT ?`, tableIdentifier)
 		return nil, err
 	}
 	return users, nil
+}
+
+func modelUsageWhere(q ModelUsageQuery) (string, []any) {
+	where := "WHERE team_id = ? AND event_time >= ? AND event_time < ?"
+	args := []any{q.TeamID, q.Start, q.End}
+	if len(q.UserIDs) > 0 {
+		inClause, inArgs := buildInClause(q.UserIDs)
+		where += fmt.Sprintf(" AND user_id IN (%s)", inClause)
+		args = append(args, inArgs...)
+	}
+	return where, args
 }
 
 func (c *Client) QueryTeamConversationStats(ctx context.Context, q TeamConversationQuery) (TeamConversationStats, error) {

--- a/backend/pkg/clickhouse/client_test.go
+++ b/backend/pkg/clickhouse/client_test.go
@@ -438,8 +438,9 @@ func TestQueryModelUsageSummaryAggregatesByTeamAndTime(t *testing.T) {
 	start := time.Date(2026, 6, 4, 0, 0, 0, 0, time.UTC)
 	_, err = db.Exec(`INSERT INTO model_usage_events_test
 		(event_time, team_id, user_id, task_id, project_id, model_id, total_tokens, input_tokens, output_tokens, cached_tokens, request_count)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		start.Add(time.Hour), "team-1", "user-1", "task-1", "", "m1", 100, 60, 40, 20, 1,
+		start.Add(time.Hour), "team-1", "user-admin", "task-admin", "", "m1", 300, 200, 100, 0, 1,
 		start.Add(time.Hour), "team-2", "user-2", "task-2", "", "m1", 900, 500, 400, 0, 1,
 	)
 	if err != nil {
@@ -454,8 +455,20 @@ func TestQueryModelUsageSummaryAggregatesByTeamAndTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if summary.TotalTokens != 100 || summary.CachedTokens != 20 || summary.Requests != 1 {
+	if summary.TotalTokens != 400 || summary.CachedTokens != 20 || summary.Requests != 2 {
 		t.Fatalf("summary = %#v", summary)
+	}
+	filtered, err := client.QueryModelUsageSummary(context.Background(), ModelUsageQuery{
+		TeamID:  "team-1",
+		UserIDs: []string{"user-1"},
+		Start:   start,
+		End:     start.AddDate(0, 0, 1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filtered.TotalTokens != 100 || filtered.CachedTokens != 20 || filtered.Requests != 1 {
+		t.Fatalf("filtered summary = %#v", filtered)
 	}
 }
 
@@ -500,5 +513,17 @@ func TestQueryModelUsageTopUsersOrdersByTokens(t *testing.T) {
 	}
 	if users[0].UserID != "user-high" || users[0].TotalTokens != 300 || users[0].Requests != 2 {
 		t.Fatalf("first user = %#v", users[0])
+	}
+	filtered, err := client.QueryModelUsageTopUsers(context.Background(), ModelUsageQuery{
+		TeamID:  "team-1",
+		UserIDs: []string{"user-low"},
+		Start:   start,
+		End:     start.AddDate(0, 0, 1),
+	}, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) != 1 || filtered[0].UserID != "user-low" {
+		t.Fatalf("filtered top users = %#v, want user-low only", filtered)
 	}
 }


### PR DESCRIPTION
## Summary
- 团队管理概览的高消耗成员统计按普通成员 ID 过滤，避免 admin 被当作成员统计。
- ClickHouse 模型用量查询支持可选 UserIDs 过滤，复用到 summary 和 top users 查询。
- 补充 dashboard repo 与 ClickHouse 查询测试，覆盖 admin 排除场景。

## Test Plan
- [x] `cd backend && go test ./...`
