### PR TITLE
fix: 降低 VM token 缺失查询压力

### DIFF
--- a/backend/biz/host/handler/v1/internal.go
+++ b/backend/biz/host/handler/v1/internal.go
@@ -222,7 +222,7 @@ func (h *InternalHostHandler) CheckToken(c *web.Context, req taskflow.CheckToken
 	}
 
 	if err != nil {
-		logger.With("error", err).ErrorContext(c.Request().Context(), "failed to check token")
+		h.logCheckTokenError(c.Request().Context(), logger, err)
 		return err
 	}
 
@@ -272,8 +272,14 @@ func (h *InternalHostHandler) agentAuth(ctx context.Context, token, mid string) 
 
 	// 2) Redis miss 时按 access_token 查询数据库
 	// 注意：migration 已将旧 VM 的 access_token 回填为 id，因此旧 VM 也能通过此查询找到
+	if h.isAgentVMNotFoundCached(ctx, token) {
+		return nil, errAgentVMNotFoundCached
+	}
 	vm, err := h.repo.GetVirtualMachineByAccessToken(h.skipSoftDelete(ctx), token)
 	if err != nil {
+		if db.IsNotFound(err) {
+			h.cacheAgentVMNotFound(ctx, token)
+		}
 		return nil, err
 	}
 

--- a/backend/biz/host/handler/v1/internal_auth.go
+++ b/backend/biz/host/handler/v1/internal_auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -15,9 +16,13 @@ import (
 const (
 	recycledDeleteRetryTTL = 30 * time.Second
 	recycledDeleteTimeout  = 5 * time.Second
+	agentVMNotFoundTTL     = 30 * time.Second
 )
 
-var errAgentVMRecycled = errors.New("agent vm is recycled")
+var (
+	errAgentVMRecycled       = errors.New("agent vm is recycled")
+	errAgentVMNotFoundCached = errors.New("agent vm not found")
+)
 
 type agentTokenGetter func(ctx context.Context, key string) (string, error)
 
@@ -41,6 +46,39 @@ return nil
 			return "", redis.Nil
 		}
 		return b, nil
+	}
+}
+
+func (h *InternalHostHandler) logCheckTokenError(ctx context.Context, logger *slog.Logger, err error) {
+	if db.IsNotFound(err) || errors.Is(err, errAgentVMNotFoundCached) {
+		logger.With("error", err).DebugContext(ctx, "failed to check token")
+		return
+	}
+	logger.With("error", err).ErrorContext(ctx, "failed to check token")
+}
+
+func agentVMNotFoundCacheKey(token string) string {
+	return fmt.Sprintf("agent:vm:not-found:%s", token)
+}
+
+func (h *InternalHostHandler) isAgentVMNotFoundCached(ctx context.Context, token string) bool {
+	if h.redis == nil {
+		return false
+	}
+	ok, err := h.redis.Exists(ctx, agentVMNotFoundCacheKey(token)).Result()
+	if err != nil {
+		h.logger.WarnContext(ctx, "check agent vm not found cache failed", "error", err)
+		return false
+	}
+	return ok > 0
+}
+
+func (h *InternalHostHandler) cacheAgentVMNotFound(ctx context.Context, token string) {
+	if h.redis == nil {
+		return
+	}
+	if err := h.redis.Set(ctx, agentVMNotFoundCacheKey(token), "1", agentVMNotFoundTTL).Err(); err != nil {
+		h.logger.WarnContext(ctx, "cache agent vm not found failed", "error", err)
 	}
 }
 

--- a/backend/biz/host/handler/v1/internal_auth_test.go
+++ b/backend/biz/host/handler/v1/internal_auth_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"slices"
 	"testing"
 	"time"
 
@@ -126,9 +127,58 @@ func TestAgentAuthSoftDeletedRecycledVMStillTriggersDelete(t *testing.T) {
 	}
 }
 
+func TestAgentAuthCachesMissingAccessToken(t *testing.T) {
+	rdb := newTestRedis(t)
+	repo := &internalHostRepoStub{}
+	handler := &InternalHostHandler{
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		redis:         rdb,
+		getAgentToken: func(context.Context, string) (string, error) { return "", redis.Nil },
+		repo:          repo,
+		skipSoftDelete: func(ctx context.Context) context.Context {
+			return ctx
+		},
+	}
+
+	if _, err := handler.agentAuth(context.Background(), "missing-agent", "machine-1"); err == nil {
+		t.Fatal("first agent auth error is nil")
+	}
+	if _, err := handler.agentAuth(context.Background(), "missing-agent", "machine-1"); err == nil {
+		t.Fatal("second agent auth error is nil")
+	}
+	if repo.accessTokenCalls != 1 {
+		t.Fatalf("GetVirtualMachineByAccessToken calls = %d, want 1", repo.accessTokenCalls)
+	}
+}
+
+func TestCheckTokenLogsMissingAgentVMBelowError(t *testing.T) {
+	rdb := newTestRedis(t)
+	handler := &captureSlogHandler{}
+	h := &InternalHostHandler{
+		logger:        slog.New(handler),
+		redis:         rdb,
+		getAgentToken: func(context.Context, string) (string, error) { return "", redis.Nil },
+		repo:          &internalHostRepoStub{},
+		skipSoftDelete: func(ctx context.Context) context.Context {
+			return ctx
+		},
+	}
+
+	_, err := h.agentAuth(context.Background(), "missing-agent-log", "machine-1")
+	if err == nil {
+		t.Fatal("agent auth error is nil")
+	}
+	h.logCheckTokenError(context.Background(), h.logger.With("fn", "CheckToken"), err)
+
+	if slices.Contains(handler.levels, slog.LevelError) {
+		t.Fatalf("log levels = %v, want no error level for missing vm", handler.levels)
+	}
+}
+
 type internalHostRepoStub struct {
 	vm               *db.VirtualMachine
 	accessTokenVM    *db.VirtualMachine
+	accessTokenCalls int
 	assertSkipMarker bool
 	skipMarkerKey    any
 	skipMarkerValue  string
@@ -168,6 +218,7 @@ func (s *internalHostRepoStub) GetTaskIDByVMID(context.Context, string) (string,
 }
 
 func (s *internalHostRepoStub) GetVirtualMachineByAccessToken(ctx context.Context, _ string) (*db.VirtualMachine, error) {
+	s.accessTokenCalls++
 	if s.assertSkipMarker {
 		v, ok := ctx.Value(s.skipMarkerKey).(string)
 		if !ok || v != s.skipMarkerValue {
@@ -324,4 +375,25 @@ func newTestRedis(t *testing.T) *redis.Client {
 		_ = rdb.Close()
 	})
 	return rdb
+}
+
+type captureSlogHandler struct {
+	levels []slog.Level
+}
+
+func (h *captureSlogHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *captureSlogHandler) Handle(_ context.Context, r slog.Record) error {
+	h.levels = append(h.levels, r.Level)
+	return nil
+}
+
+func (h *captureSlogHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *captureSlogHandler) WithGroup(string) slog.Handler {
+	return h
 }

--- a/backend/biz/vmidle/usecase/policy_test.go
+++ b/backend/biz/vmidle/usecase/policy_test.go
@@ -2,14 +2,23 @@ package usecase
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/google/uuid"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/chaitin/MonkeyCode/backend/config"
 	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/db/enttest"
+	"github.com/chaitin/MonkeyCode/backend/db/virtualmachine"
 	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
 )
 
 func TestVMIdleSchedulePlanFromPolicy(t *testing.T) {
@@ -50,4 +59,163 @@ func TestResolvePolicyForVMFallsBackToGlobalWhenTeamMissing(t *testing.T) {
 	if !got.RecycleEnabled || got.EffectiveRecycleSeconds != 604800 {
 		t.Fatalf("recycle policy = %#v", got)
 	}
+}
+
+func TestRefreshDebouncesBeforeVMQuery(t *testing.T) {
+	ctx := context.Background()
+	redisClient := newTestRedis(t)
+	repo := &refreshHostRepoStub{
+		vm: &db.VirtualMachine{ID: "vm-activity", UserID: uuid.New()},
+	}
+	r := &vmIdleRefresher{
+		cfg:      &config.Config{VMIdle: config.VMIdle{SleepSeconds: 600, RecycleSeconds: 604800}},
+		redis:    redisClient,
+		logger:   slog.Default(),
+		hostRepo: repo,
+	}
+
+	if err := r.Refresh(ctx, "vm-activity"); err != nil {
+		t.Fatalf("first refresh: %v", err)
+	}
+	if err := r.Refresh(ctx, "vm-activity"); err != nil {
+		t.Fatalf("second refresh: %v", err)
+	}
+	if repo.getVirtualMachineCalls != 1 {
+		t.Fatalf("GetVirtualMachine calls = %d, want 1", repo.getVirtualMachineCalls)
+	}
+}
+
+func TestRefreshCachesNotFoundVM(t *testing.T) {
+	ctx := context.Background()
+	redisClient := newTestRedis(t)
+	repo := &refreshHostRepoStub{err: newVirtualMachineNotFoundErr(t)}
+	r := &vmIdleRefresher{
+		cfg:      &config.Config{VMIdle: config.VMIdle{SleepSeconds: 600, RecycleSeconds: 604800}},
+		redis:    redisClient,
+		logger:   slog.Default(),
+		hostRepo: repo,
+	}
+
+	if err := r.Refresh(ctx, "missing-vm"); err != nil {
+		t.Fatalf("first refresh: %v", err)
+	}
+	if err := r.Refresh(ctx, "missing-vm"); err != nil {
+		t.Fatalf("second refresh: %v", err)
+	}
+	if repo.getVirtualMachineCalls != 1 {
+		t.Fatalf("GetVirtualMachine calls = %d, want 1", repo.getVirtualMachineCalls)
+	}
+}
+
+func newTestRedis(t *testing.T) *redis.Client {
+	t.Helper()
+	srv := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: srv.Addr()})
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+	return client
+}
+
+func newVirtualMachineNotFoundErr(t *testing.T) error {
+	t.Helper()
+	client := enttest.Open(t, "sqlite3", fmt.Sprintf("file:vmidle-not-found-%s?mode=memory&cache=shared&_fk=1", uuid.NewString()))
+	defer client.Close()
+	_, err := client.VirtualMachine.Query().
+		Where(virtualmachine.ID("missing-vm")).
+		First(context.Background())
+	if err == nil {
+		t.Fatal("expected not found error")
+	}
+	if !db.IsNotFound(err) {
+		t.Fatalf("err = %v, want db not found", err)
+	}
+	return err
+}
+
+type refreshHostRepoStub struct {
+	vm                     *db.VirtualMachine
+	err                    error
+	getVirtualMachineCalls int
+}
+
+func (s *refreshHostRepoStub) List(context.Context, uuid.UUID) ([]*db.Host, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) GetHost(context.Context, uuid.UUID, string) (*domain.Host, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) GetByID(context.Context, string) (*db.Host, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) GetVirtualMachine(context.Context, string) (*db.VirtualMachine, error) {
+	s.getVirtualMachineCalls++
+	return s.vm, s.err
+}
+
+func (s *refreshHostRepoStub) GetVirtualMachineByAccessToken(context.Context, string) (*db.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) GetVirtualMachineByEnvID(context.Context, string) (*db.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) GetTaskIDByVMID(context.Context, string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) BatchGetVmIDsByEnvironmentIDs(context.Context, []string) (map[string]string, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) GetVirtualMachineWithUser(context.Context, uuid.UUID, string) (*db.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) CreateVirtualMachine(context.Context, *domain.User, *domain.CreateVMReq, func(context.Context) (string, error), func(*db.Model, *db.Image) (*domain.VirtualMachine, error)) (*domain.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) PastHourVirtualMachine(context.Context) ([]*db.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) AllCountDownVirtualMachine(context.Context) ([]*db.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) DeleteVirtualMachine(context.Context, uuid.UUID, string, string, func(*db.VirtualMachine) error) error {
+	return errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) UpsertVirtualMachine(context.Context, *taskflow.VirtualMachine) error {
+	return errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) UpdateVirtualMachine(context.Context, string, func(*db.VirtualMachineUpdateOne) error) error {
+	return errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) UpsertHost(context.Context, *taskflow.Host) error {
+	return errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) DeleteHost(context.Context, uuid.UUID, string) error {
+	return errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) UpdateHost(context.Context, uuid.UUID, *domain.UpdateHostReq) error {
+	return errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) UpdateVM(context.Context, domain.UpdateVMReq, func(*db.VirtualMachine) error) (*db.VirtualMachine, int64, error) {
+	return nil, 0, errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) GetGitCredentialByTask(context.Context, string) (*domain.GitCredentialInfo, error) {
+	return nil, errors.New("not implemented")
 }

--- a/backend/biz/vmidle/usecase/vmidle.go
+++ b/backend/biz/vmidle/usecase/vmidle.go
@@ -31,6 +31,9 @@ const (
 	sleepQueueKey   = "vm:idle:sleep"
 	notifyQueueKey  = "vm:idle:notify"
 	recycleQueueKey = "vm:idle:recycle"
+
+	vmIdleDebounceTTL = 30 * time.Second
+	vmNotFoundTTL     = 30 * time.Second
 )
 
 // notifySchedule 描述一档"距回收还有 lead 时"要触发的提醒，及它应当落到哪些渠道。
@@ -220,24 +223,39 @@ func buildVMIdleSchedulePlan(policy *domain.TeamTaskVMIdlePolicy, schedules []no
 }
 
 func (r *vmIdleRefresher) Refresh(ctx context.Context, vmID string) error {
+	notFoundKey := fmt.Sprintf("vm:idle:not-found:%s", vmID)
+	if exists, err := r.redis.Exists(ctx, notFoundKey).Result(); err == nil && exists > 0 {
+		return nil
+	} else if err != nil {
+		r.logger.WarnContext(ctx, "redis not found cache check failed", "vmID", vmID, "error", err)
+	}
+
+	debounceKey := fmt.Sprintf("vm:idle:debounce:%s", vmID)
+	ok, err := r.redis.SetNX(ctx, debounceKey, "1", vmIdleDebounceTTL).Result()
+	if err != nil {
+		r.logger.ErrorContext(ctx, "redis SetNX failed", "vmID", vmID, "error", err)
+		return fmt.Errorf("redis debounce for vm %s: %w", vmID, err)
+	}
+	if !ok {
+		return nil
+	}
+
 	vm, err := r.hostRepo.GetVirtualMachine(ctx, vmID)
 	if err != nil {
+		if db.IsNotFound(err) {
+			if setErr := r.redis.Set(ctx, notFoundKey, "1", vmNotFoundTTL).Err(); setErr != nil {
+				r.logger.WarnContext(ctx, "redis set not found cache failed", "vmID", vmID, "error", setErr)
+			}
+			r.logger.DebugContext(ctx, "skip idle timer for missing VM", "vmID", vmID)
+			return nil
+		}
+		_ = r.redis.Del(ctx, debounceKey).Err()
 		r.logger.ErrorContext(ctx, "failed to get vm", "vmID", vmID, "error", err)
 		return fmt.Errorf("get vm %s: %w", vmID, err)
 	}
 
 	if len(vm.Edges.Tasks) == 0 {
 		r.logger.DebugContext(ctx, "skip idle timer for countdown VM", "vmID", vmID)
-		return nil
-	}
-
-	debounceKey := fmt.Sprintf("vm:idle:debounce:%s", vmID)
-	ok, err := r.redis.SetNX(ctx, debounceKey, "1", 30*time.Second).Result()
-	if err != nil {
-		r.logger.ErrorContext(ctx, "redis SetNX failed", "vmID", vmID, "error", err)
-		return fmt.Errorf("redis debounce for vm %s: %w", vmID, err)
-	}
-	if !ok {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- 为 agent check-token 的 virtual_machine not found 增加 30 秒 Redis 负缓存，减少重复 DB fallback 查询
- 将 check-token 中 VM not found 的日志降级为 debug，避免错误日志刷屏
- 将 VM activity 空闲刷新去抖前移，并缓存 missing VM，降低高频 hosts eager-load 查询

## Test Plan
- [x] cd backend && go test ./...
