### PR TITLE
feat(mobile): 新建任务选择仓库列表支持手动输入仓库地址

### DIFF
--- a/mobile/app/new-task.tsx
+++ b/mobile/app/new-task.tsx
@@ -9,13 +9,24 @@ import type { Model, Project } from '@/api/types';
 import { ConcurrentLimitModal } from '@/components/ConcurrentLimitModal';
 import { Icons, providerIconForUrl } from '@/components/Icons';
 import { MicButton } from '@/components/MicButton';
-import { ModelSheet } from '@/components/sheets';
+import { ModelSheet, RepoUrlSheet } from '@/components/sheets';
 import { Card, IconButton, MonkeyLogo, PickerSheet, PrimaryButton, type PickerOption } from '@/components/ui';
 import { useSpeechToText } from '@/speech/useSpeechToText';
 import { DEFAULT_SKILL_IDS, modelLabel, pickDefaultImage, pickDefaultModel, TASK_DEFAULTS } from '@/config';
 import { spacing, useTheme, type Theme } from '@/theme';
 
 const SUGGESTIONS = ['修复一个线上 bug', '为这个仓库写单元测试', '重构这个模块', '解释这段代码做了什么'];
+
+// 「选择仓库」列表里的「手动输入仓库地址」入口标识（区别于真实 project.id）
+const MANUAL_REPO_KEY = '__manual_repo__';
+
+/** 从 Git 地址里取 owner/repo 作为简短展示名（取不到则回退为整段地址）。 */
+function repoNameFromUrl(url: string): string {
+  const cleaned = url.trim().replace(/\.git$/i, '').replace(/\/+$/, '');
+  const m = cleaned.match(/[/:]([^/:]+\/[^/:]+)$/);
+  if (m) return m[1];
+  return cleaned.split(/[/:]/).filter(Boolean).pop() || url;
+}
 
 function ConfigRow({ icon, label, value, sub, divider, onPress, t }: { icon: string; label: string; value: string; sub?: string; divider?: boolean; onPress: () => void; t: Theme }) {
   const I = Icons[icon];
@@ -50,9 +61,11 @@ export default function NewTaskScreen() {
   const [content, setContent] = useState('');
   const [modelId, setModelId] = useState('');
   const [imageId, setImageId] = useState('');
-  const [repoKey, setRepoKey] = useState<string>(params.projectId || ''); // '' = 不关联仓库；否则为 project.id
+  const [repoKey, setRepoKey] = useState<string>(params.projectId || ''); // '' = 不关联仓库；project.id = 选中项目；MANUAL_REPO_KEY = 手动输入
+  const [manualRepo, setManualRepo] = useState(''); // 手动输入的 Git 仓库地址
 
   const [picking, setPicking] = useState<'repo' | 'model' | null>(null);
+  const [manualOpen, setManualOpen] = useState(false); // 手动输入仓库地址对话框
   const [limitOpen, setLimitOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
@@ -95,6 +108,7 @@ export default function NewTaskScreen() {
 
   const repoOptions: PickerOption[] = [
     { key: '', title: '快速开始', sub: '不关联仓库', icon: 'sparkle' },
+    { key: MANUAL_REPO_KEY, title: '手动输入仓库地址', sub: manualRepo || '填写 Git 仓库地址', icon: manualRepo ? providerIconForUrl(manualRepo) : 'git' },
     ...projects.map((p, i) => ({ key: p.id || `p${i}`, title: p.name || p.full_name || '项目', sub: p.repo_url, icon: providerIconForUrl(p.repo_url) })),
   ];
 
@@ -104,7 +118,11 @@ export default function NewTaskScreen() {
     if (!modelId) { setError('请选择模型'); return; }
     setSubmitting(true);
     try {
-      const repo = selectedProject ? { repo_url: selectedProject.repo_url || undefined } : {};
+      // 手动输入的仓库地址优先；否则用所选项目；都没有则不关联仓库（快速开始）
+      const manualUrl = repoKey === MANUAL_REPO_KEY ? manualRepo.trim() : '';
+      const repo = manualUrl
+        ? { repo_url: manualUrl }
+        : selectedProject ? { repo_url: selectedProject.repo_url || undefined } : {};
       const task = await createTask({
         content: content.trim(),
         cli_name: TASK_DEFAULTS.cliName,
@@ -114,7 +132,7 @@ export default function NewTaskScreen() {
         task_type: 'develop',
         repo,
         resource: { ...TASK_DEFAULTS.resource },
-        extra: { skill_ids: DEFAULT_SKILL_IDS, project_id: selectedProject?.id },
+        extra: { skill_ids: DEFAULT_SKILL_IDS, project_id: manualUrl ? undefined : selectedProject?.id },
       });
       if (task?.id) router.replace(`/task/${task.id}`);
       else setError('任务创建成功但未返回 ID');
@@ -124,10 +142,12 @@ export default function NewTaskScreen() {
     } finally {
       setSubmitting(false);
     }
-  }, [content, imageId, modelId, router, selectedProject]);
+  }, [content, imageId, modelId, router, selectedProject, repoKey, manualRepo]);
 
   // 仓库行只展示一处信息，避免「快速开始 / 不关联仓库」「名字 / 同名仓库路径」这种左右重复。
-  const repoValue = selectedProject ? (selectedProject.full_name || selectedProject.name || '项目') : '不关联仓库';
+  const repoValue = repoKey === MANUAL_REPO_KEY && manualRepo
+    ? repoNameFromUrl(manualRepo)
+    : selectedProject ? (selectedProject.full_name || selectedProject.name || '项目') : '不关联仓库';
 
   return (
     <KeyboardAvoidingView style={{ flex: 1, backgroundColor: t.bg }} behavior="padding">
@@ -199,7 +219,14 @@ export default function NewTaskScreen() {
       ) : null}
 
       <PickerSheet visible={picking === 'repo'} title="选择仓库" options={repoOptions} selected={repoKey}
-        onPick={(k) => { setRepoKey(k); setPicking(null); }} onClose={() => setPicking(null)} />
+        onPick={(k) => {
+          // 「手动输入仓库地址」不直接选中，而是先收起列表、弹出输入框
+          if (k === MANUAL_REPO_KEY) { setPicking(null); setManualOpen(true); return; }
+          setRepoKey(k); setPicking(null);
+        }} onClose={() => setPicking(null)} />
+      <RepoUrlSheet visible={manualOpen} initialUrl={manualRepo}
+        onConfirm={(u) => { setManualRepo(u); setRepoKey(MANUAL_REPO_KEY); setManualOpen(false); }}
+        onClose={() => setManualOpen(false)} />
       <ModelSheet visible={picking === 'model'} models={models} selectedId={modelId} plan={plan}
         onPick={(k) => { setModelId(k); setPicking(null); }} onClose={() => setPicking(null)} />
       <ConcurrentLimitModal visible={limitOpen} onClose={() => setLimitOpen(false)} onStopped={() => { setLimitOpen(false); setTimeout(() => submit(), 400); }} />

--- a/mobile/src/components/sheets.tsx
+++ b/mobile/src/components/sheets.tsx
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import { Modal, Platform, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { Model } from '@/api/types';
 import type { PortForwardInfo } from '@/api/control';
@@ -203,6 +204,70 @@ export function CopySheet({ visible, text, onClose, onCopyAll }: {
           )}
         </View>
       </SheetShell>
+    </Modal>
+  );
+}
+
+/**
+ * 手动输入仓库地址对话框：在「选择仓库」列表里点「手动输入仓库地址」后弹出，
+ * 让用户直接填写 Git 仓库地址（无需先在后台创建项目）。居中弹窗 + 键盘避让，
+ * 避免被软键盘遮挡。
+ */
+export function RepoUrlSheet({ visible, initialUrl, onConfirm, onClose }: {
+  visible: boolean; initialUrl?: string; onConfirm: (url: string) => void; onClose: () => void;
+}) {
+  const t = useTheme();
+  const inputRef = React.useRef<TextInput>(null);
+  const [url, setUrl] = React.useState(initialUrl || '');
+  const [err, setErr] = React.useState('');
+  // 打开瞬间把输入同步成外部已有地址、清掉旧报错（用「渲染期间调整 state」的写法，避免 effect 级联渲染）
+  const [wasOpen, setWasOpen] = React.useState(visible);
+  if (visible !== wasOpen) {
+    setWasOpen(visible);
+    if (visible) { setUrl(initialUrl || ''); setErr(''); }
+  }
+
+  const confirm = () => {
+    const v = url.trim();
+    if (!v) { setErr('请输入仓库地址'); return; }
+    if (!/^(https?:\/\/|ssh:\/\/|git@)/i.test(v)) { setErr('请输入有效的 Git 地址（http(s):// 或 git@）'); return; }
+    onConfirm(v);
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose} statusBarTranslucent onShow={() => inputRef.current?.focus()}>
+      {/* 居中对话框需压暗背景并拦截背景点击（点背景即关闭） */}
+      <Pressable onPress={onClose} style={[StyleSheet.absoluteFill, { backgroundColor: 'rgba(0,0,0,0.45)' }]} />
+      <KeyboardAvoidingView behavior="padding" style={StyleSheet.absoluteFill} pointerEvents="box-none">
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 26 }} pointerEvents="box-none">
+          <View style={{ width: '100%', backgroundColor: t.bg2, borderRadius: 22, borderWidth: 1, borderColor: t.line2, padding: 20, ...t.shLift }}>
+            <Text style={{ color: t.tx, fontSize: 17, fontWeight: '700' }}>手动输入仓库地址</Text>
+            <Text style={{ color: t.tx3, fontSize: 12.5, marginTop: 4, marginBottom: 14 }}>填写 Git 仓库地址，任务将基于该仓库运行</Text>
+            <TextInput
+              ref={inputRef}
+              value={url}
+              onChangeText={(v) => { setUrl(v); if (err) setErr(''); }}
+              placeholder="https://github.com/owner/repo.git"
+              placeholderTextColor={t.tx3}
+              autoCapitalize="none"
+              autoCorrect={false}
+              keyboardType="url"
+              returnKeyType="done"
+              onSubmitEditing={confirm}
+              style={{ borderWidth: 1, borderColor: err ? t.red : t.line2, borderRadius: 12, paddingHorizontal: 14, paddingVertical: 12, fontSize: 14, color: t.tx, backgroundColor: t.bg, fontFamily: 'monospace' }}
+            />
+            {err ? <Text style={{ color: t.red, fontSize: 12.5, marginTop: 8 }}>{err}</Text> : null}
+            <View style={{ flexDirection: 'row', gap: 10, marginTop: 18 }}>
+              <Pressable onPress={onClose} style={({ pressed }) => [{ flex: 1, paddingVertical: 13, borderRadius: 13, alignItems: 'center', backgroundColor: t.bg4 }, pressed && { opacity: 0.8 }]}>
+                <Text style={{ color: t.tx2, fontSize: 15, fontWeight: '600' }}>取消</Text>
+              </Pressable>
+              <Pressable onPress={confirm} style={({ pressed }) => [{ flex: 1, paddingVertical: 13, borderRadius: 13, alignItems: 'center', backgroundColor: t.ac }, pressed && { opacity: 0.85 }]}>
+                <Text style={{ color: t.acInk, fontSize: 15, fontWeight: '700' }}>确定</Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }


### PR DESCRIPTION
在「选择仓库」列表里「快速开始」之后新增「手动输入仓库地址」入口，
点击弹出居中输入框（onShow 自动聚焦 + 键盘避让），校验 Git 地址格式后
作为 repo_url 创建任务（不带 project_id），无需先在后台创建项目。