### PR TITLE
feat: 团队管理支持配置任务并发数

### DIFF
--- a/backend/biz/task/usecase/task.go
+++ b/backend/biz/task/usecase/task.go
@@ -50,6 +50,7 @@ type TaskUsecase struct {
 	redis                 *redis.Client
 	notifyDispatcher      *dispatcher.Dispatcher
 	taskHook              domain.TaskHook
+	teamPolicyRepo        domain.TeamPolicyRepo
 	privilegeChecker      domain.PrivilegeChecker
 	modelHook             domain.ModelHook
 	taskLifecycle         *lifecycle.Manager[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata]
@@ -86,6 +87,10 @@ func NewTaskUsecase(i *do.Injector) (domain.TaskUsecase, error) {
 		u.taskHook = hook
 	}
 
+	if repo, err := do.Invoke[domain.TeamPolicyRepo](i); err == nil {
+		u.teamPolicyRepo = repo
+	}
+
 	// 可选注入 PrivilegeChecker
 	if pc, err := do.Invoke[domain.PrivilegeChecker](i); err == nil {
 		u.privilegeChecker = pc
@@ -110,6 +115,29 @@ func (a *TaskUsecase) isPrivileged(ctx context.Context, uid uuid.UUID) bool {
 		return false
 	}
 	return ok
+}
+
+func (a *TaskUsecase) resolveTaskConcurrencyLimit(ctx context.Context, userID uuid.UUID) (int, error) {
+	const defaultLimit = 3
+	if a.teamPolicyRepo != nil {
+		team, err := a.teamPolicyRepo.GetTeamByUserID(ctx, userID)
+		if err == nil && team != nil && team.TaskConcurrencyLimit > 0 {
+			return team.TaskConcurrencyLimit, nil
+		}
+		if err != nil && !db.IsNotFound(err) {
+			return 0, err
+		}
+	}
+	if a.taskHook != nil {
+		n, err := a.taskHook.GetMaxConcurrent(ctx, userID)
+		if err != nil {
+			return 0, err
+		}
+		if n > 0 {
+			return n, nil
+		}
+	}
+	return defaultLimit, nil
 }
 
 // AutoApprove implements domain.TaskUsecase.
@@ -481,7 +509,6 @@ func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.
 
 	a.logger.InfoContext(ctx, "resolved git identity for task", slog.Any("git", git))
 
-	limit := 1
 	if a.taskHook != nil {
 		if req.SystemPrompt == "" {
 			// 如果有 TaskHook，获取系统提示词
@@ -489,14 +516,12 @@ func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.
 				req.SystemPrompt = prompt
 			}
 		}
-
-		n, err := a.taskHook.GetMaxConcurrent(ctx, user.ID)
-		if err != nil {
-			return nil, err
-		}
-		limit = cmp.Or(n, limit)
 	}
 
+	limit, err := a.resolveTaskConcurrencyLimit(ctx, user.ID)
+	if err != nil {
+		return nil, err
+	}
 	ctx = entx.WithTaskConcurrencyLimit(ctx, limit)
 
 	var createdVm *taskflow.VirtualMachine

--- a/backend/biz/task/usecase/task_concurrency_config_test.go
+++ b/backend/biz/task/usecase/task_concurrency_config_test.go
@@ -1,0 +1,115 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+func TestResolveTaskConcurrencyLimitPrefersTeamPolicy(t *testing.T) {
+	userID := uuid.New()
+	u := &TaskUsecase{
+		teamPolicyRepo: &taskConcurrencyTeamPolicyRepoStub{
+			team: &db.Team{ID: uuid.New(), TaskConcurrencyLimit: 7},
+		},
+		taskHook: taskConcurrencyHookStub{limit: 3},
+	}
+
+	got, err := u.resolveTaskConcurrencyLimit(context.Background(), userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 7 {
+		t.Fatalf("limit = %d, want 7", got)
+	}
+}
+
+func TestResolveTaskConcurrencyLimitFallsBackWhenTeamNotFound(t *testing.T) {
+	userID := uuid.New()
+	u := &TaskUsecase{
+		teamPolicyRepo: &taskConcurrencyTeamPolicyRepoStub{err: &db.NotFoundError{}},
+		taskHook:       taskConcurrencyHookStub{limit: 4},
+	}
+
+	got, err := u.resolveTaskConcurrencyLimit(context.Background(), userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 4 {
+		t.Fatalf("limit = %d, want 4", got)
+	}
+}
+
+func TestResolveTaskConcurrencyLimitReturnsTeamRepoError(t *testing.T) {
+	userID := uuid.New()
+	wantErr := errors.New("database down")
+	u := &TaskUsecase{
+		teamPolicyRepo: &taskConcurrencyTeamPolicyRepoStub{err: wantErr},
+		taskHook:       taskConcurrencyHookStub{limit: 4},
+	}
+
+	_, err := u.resolveTaskConcurrencyLimit(context.Background(), userID)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestResolveTaskConcurrencyLimitDefaultsWhenNoPolicyOrHookLimit(t *testing.T) {
+	got, err := (&TaskUsecase{}).resolveTaskConcurrencyLimit(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 3 {
+		t.Fatalf("limit = %d, want 3", got)
+	}
+}
+
+type taskConcurrencyTeamPolicyRepoStub struct {
+	team *db.Team
+	err  error
+}
+
+func (s *taskConcurrencyTeamPolicyRepoStub) GetTeam(context.Context, uuid.UUID) (*db.Team, error) {
+	return nil, nil
+}
+
+func (s *taskConcurrencyTeamPolicyRepoStub) GetTeamByUserID(context.Context, uuid.UUID) (*db.Team, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.team, nil
+}
+
+func (s *taskConcurrencyTeamPolicyRepoStub) UpdateTaskVMIdlePolicy(context.Context, uuid.UUID, *domain.UpdateTeamTaskVMIdlePolicyReq) (*db.Team, error) {
+	return nil, nil
+}
+
+func (s *taskConcurrencyTeamPolicyRepoStub) GetMember(context.Context, uuid.UUID, uuid.UUID) (*db.TeamMember, error) {
+	return nil, nil
+}
+
+type taskConcurrencyHookStub struct {
+	limit int
+}
+
+func (s taskConcurrencyHookStub) GetSystemPrompt(context.Context, consts.TaskType, consts.TaskSubType) (string, error) {
+	return "", nil
+}
+
+func (s taskConcurrencyHookStub) OnTaskCreated(context.Context, *domain.ProjectTask) error {
+	return nil
+}
+
+func (s taskConcurrencyHookStub) GitTask(context.Context, uuid.UUID) (*domain.GitTask, error) {
+	return nil, nil
+}
+
+func (s taskConcurrencyHookStub) GetMaxConcurrent(context.Context, uuid.UUID) (int, error) {
+	return s.limit, nil
+}

--- a/backend/biz/team/repo/policy.go
+++ b/backend/biz/team/repo/policy.go
@@ -34,6 +34,7 @@ func (r *TeamPolicyRepo) GetTeamByUserID(ctx context.Context, userID uuid.UUID) 
 
 func (r *TeamPolicyRepo) UpdateTaskVMIdlePolicy(ctx context.Context, teamID uuid.UUID, req *domain.UpdateTeamTaskVMIdlePolicyReq) (*db.Team, error) {
 	return r.db.Team.UpdateOneID(teamID).
+		SetTaskConcurrencyLimit(req.TaskConcurrencyLimit).
 		SetTaskVMSleepEnabled(req.SleepEnabled).
 		SetTaskVMSleepSeconds(req.SleepSeconds).
 		SetTaskVMRecycleEnabled(req.RecycleEnabled).

--- a/backend/biz/team/repo/policy_test.go
+++ b/backend/biz/team/repo/policy_test.go
@@ -1,0 +1,48 @@
+package repo
+
+import (
+	"context"
+	"testing"
+
+	"entgo.io/ent/dialect/sql/schema"
+	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestTeamPolicyRepoUpdateTaskVMIdlePolicyUpdatesTaskConcurrencyLimit(t *testing.T) {
+	ctx := context.Background()
+	client, err := db.Open("sqlite3", "file:team_policy_repo?mode=memory&cache=shared&_fk=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	if err := client.Schema.Create(ctx, schema.WithForeignKeys(false)); err != nil {
+		t.Fatal(err)
+	}
+	teamID := uuid.New()
+	if _, err := client.Team.Create().
+		SetID(teamID).
+		SetName("研发团队").
+		SetMemberLimit(10).
+		Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &TeamPolicyRepo{db: client}
+	got, err := r.UpdateTaskVMIdlePolicy(ctx, teamID, &domain.UpdateTeamTaskVMIdlePolicyReq{
+		TaskConcurrencyLimit: 6,
+		SleepEnabled:         true,
+		SleepSeconds:         1200,
+		RecycleEnabled:       true,
+		RecycleSeconds:       7200,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.TaskConcurrencyLimit != 6 {
+		t.Fatalf("task concurrency limit = %d, want 6", got.TaskConcurrencyLimit)
+	}
+}

--- a/backend/db/migrate/schema.go
+++ b/backend/db/migrate/schema.go
@@ -973,6 +973,7 @@ var (
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "name", Type: field.TypeString},
 		{Name: "member_limit", Type: field.TypeInt},
+		{Name: "task_concurrency_limit", Type: field.TypeInt, Default: 3},
 		{Name: "task_vm_sleep_enabled", Type: field.TypeBool, Default: true},
 		{Name: "task_vm_sleep_seconds", Type: field.TypeInt, Default: 0},
 		{Name: "task_vm_recycle_enabled", Type: field.TypeBool, Default: true},

--- a/backend/db/mutation.go
+++ b/backend/db/mutation.go
@@ -30744,6 +30744,8 @@ type TeamMutation struct {
 	name                       *string
 	member_limit               *int
 	addmember_limit            *int
+	task_concurrency_limit     *int
+	addtask_concurrency_limit  *int
 	task_vm_sleep_enabled      *bool
 	task_vm_sleep_seconds      *int
 	addtask_vm_sleep_seconds   *int
@@ -31028,6 +31030,62 @@ func (m *TeamMutation) AddedMemberLimit() (r int, exists bool) {
 func (m *TeamMutation) ResetMemberLimit() {
 	m.member_limit = nil
 	m.addmember_limit = nil
+}
+
+// SetTaskConcurrencyLimit sets the "task_concurrency_limit" field.
+func (m *TeamMutation) SetTaskConcurrencyLimit(i int) {
+	m.task_concurrency_limit = &i
+	m.addtask_concurrency_limit = nil
+}
+
+// TaskConcurrencyLimit returns the value of the "task_concurrency_limit" field in the mutation.
+func (m *TeamMutation) TaskConcurrencyLimit() (r int, exists bool) {
+	v := m.task_concurrency_limit
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldTaskConcurrencyLimit returns the old "task_concurrency_limit" field's value of the Team entity.
+// If the Team object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TeamMutation) OldTaskConcurrencyLimit(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldTaskConcurrencyLimit is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldTaskConcurrencyLimit requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldTaskConcurrencyLimit: %w", err)
+	}
+	return oldValue.TaskConcurrencyLimit, nil
+}
+
+// AddTaskConcurrencyLimit adds i to the "task_concurrency_limit" field.
+func (m *TeamMutation) AddTaskConcurrencyLimit(i int) {
+	if m.addtask_concurrency_limit != nil {
+		*m.addtask_concurrency_limit += i
+	} else {
+		m.addtask_concurrency_limit = &i
+	}
+}
+
+// AddedTaskConcurrencyLimit returns the value that was added to the "task_concurrency_limit" field in this mutation.
+func (m *TeamMutation) AddedTaskConcurrencyLimit() (r int, exists bool) {
+	v := m.addtask_concurrency_limit
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetTaskConcurrencyLimit resets all changes to the "task_concurrency_limit" field.
+func (m *TeamMutation) ResetTaskConcurrencyLimit() {
+	m.task_concurrency_limit = nil
+	m.addtask_concurrency_limit = nil
 }
 
 // SetTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field.
@@ -31806,7 +31864,7 @@ func (m *TeamMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *TeamMutation) Fields() []string {
-	fields := make([]string, 0, 9)
+	fields := make([]string, 0, 10)
 	if m.deleted_at != nil {
 		fields = append(fields, team.FieldDeletedAt)
 	}
@@ -31815,6 +31873,9 @@ func (m *TeamMutation) Fields() []string {
 	}
 	if m.member_limit != nil {
 		fields = append(fields, team.FieldMemberLimit)
+	}
+	if m.task_concurrency_limit != nil {
+		fields = append(fields, team.FieldTaskConcurrencyLimit)
 	}
 	if m.task_vm_sleep_enabled != nil {
 		fields = append(fields, team.FieldTaskVMSleepEnabled)
@@ -31848,6 +31909,8 @@ func (m *TeamMutation) Field(name string) (ent.Value, bool) {
 		return m.Name()
 	case team.FieldMemberLimit:
 		return m.MemberLimit()
+	case team.FieldTaskConcurrencyLimit:
+		return m.TaskConcurrencyLimit()
 	case team.FieldTaskVMSleepEnabled:
 		return m.TaskVMSleepEnabled()
 	case team.FieldTaskVMSleepSeconds:
@@ -31875,6 +31938,8 @@ func (m *TeamMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldName(ctx)
 	case team.FieldMemberLimit:
 		return m.OldMemberLimit(ctx)
+	case team.FieldTaskConcurrencyLimit:
+		return m.OldTaskConcurrencyLimit(ctx)
 	case team.FieldTaskVMSleepEnabled:
 		return m.OldTaskVMSleepEnabled(ctx)
 	case team.FieldTaskVMSleepSeconds:
@@ -31916,6 +31981,13 @@ func (m *TeamMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetMemberLimit(v)
+		return nil
+	case team.FieldTaskConcurrencyLimit:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetTaskConcurrencyLimit(v)
 		return nil
 	case team.FieldTaskVMSleepEnabled:
 		v, ok := value.(bool)
@@ -31970,6 +32042,9 @@ func (m *TeamMutation) AddedFields() []string {
 	if m.addmember_limit != nil {
 		fields = append(fields, team.FieldMemberLimit)
 	}
+	if m.addtask_concurrency_limit != nil {
+		fields = append(fields, team.FieldTaskConcurrencyLimit)
+	}
 	if m.addtask_vm_sleep_seconds != nil {
 		fields = append(fields, team.FieldTaskVMSleepSeconds)
 	}
@@ -31986,6 +32061,8 @@ func (m *TeamMutation) AddedField(name string) (ent.Value, bool) {
 	switch name {
 	case team.FieldMemberLimit:
 		return m.AddedMemberLimit()
+	case team.FieldTaskConcurrencyLimit:
+		return m.AddedTaskConcurrencyLimit()
 	case team.FieldTaskVMSleepSeconds:
 		return m.AddedTaskVMSleepSeconds()
 	case team.FieldTaskVMRecycleSeconds:
@@ -32005,6 +32082,13 @@ func (m *TeamMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddMemberLimit(v)
+		return nil
+	case team.FieldTaskConcurrencyLimit:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddTaskConcurrencyLimit(v)
 		return nil
 	case team.FieldTaskVMSleepSeconds:
 		v, ok := value.(int)
@@ -32064,6 +32148,9 @@ func (m *TeamMutation) ResetField(name string) error {
 		return nil
 	case team.FieldMemberLimit:
 		m.ResetMemberLimit()
+		return nil
+	case team.FieldTaskConcurrencyLimit:
+		m.ResetTaskConcurrencyLimit()
 		return nil
 	case team.FieldTaskVMSleepEnabled:
 		m.ResetTaskVMSleepEnabled()

--- a/backend/db/runtime/runtime.go
+++ b/backend/db/runtime/runtime.go
@@ -797,28 +797,34 @@ func init() {
 	teamDescName := teamFields[1].Descriptor()
 	// team.NameValidator is a validator for the "name" field. It is called by the builders before save.
 	team.NameValidator = teamDescName.Validators[0].(func(string) error)
+	// teamDescTaskConcurrencyLimit is the schema descriptor for task_concurrency_limit field.
+	teamDescTaskConcurrencyLimit := teamFields[3].Descriptor()
+	// team.DefaultTaskConcurrencyLimit holds the default value on creation for the task_concurrency_limit field.
+	team.DefaultTaskConcurrencyLimit = teamDescTaskConcurrencyLimit.Default.(int)
+	// team.TaskConcurrencyLimitValidator is a validator for the "task_concurrency_limit" field. It is called by the builders before save.
+	team.TaskConcurrencyLimitValidator = teamDescTaskConcurrencyLimit.Validators[0].(func(int) error)
 	// teamDescTaskVMSleepEnabled is the schema descriptor for task_vm_sleep_enabled field.
-	teamDescTaskVMSleepEnabled := teamFields[3].Descriptor()
+	teamDescTaskVMSleepEnabled := teamFields[4].Descriptor()
 	// team.DefaultTaskVMSleepEnabled holds the default value on creation for the task_vm_sleep_enabled field.
 	team.DefaultTaskVMSleepEnabled = teamDescTaskVMSleepEnabled.Default.(bool)
 	// teamDescTaskVMSleepSeconds is the schema descriptor for task_vm_sleep_seconds field.
-	teamDescTaskVMSleepSeconds := teamFields[4].Descriptor()
+	teamDescTaskVMSleepSeconds := teamFields[5].Descriptor()
 	// team.DefaultTaskVMSleepSeconds holds the default value on creation for the task_vm_sleep_seconds field.
 	team.DefaultTaskVMSleepSeconds = teamDescTaskVMSleepSeconds.Default.(int)
 	// teamDescTaskVMRecycleEnabled is the schema descriptor for task_vm_recycle_enabled field.
-	teamDescTaskVMRecycleEnabled := teamFields[5].Descriptor()
+	teamDescTaskVMRecycleEnabled := teamFields[6].Descriptor()
 	// team.DefaultTaskVMRecycleEnabled holds the default value on creation for the task_vm_recycle_enabled field.
 	team.DefaultTaskVMRecycleEnabled = teamDescTaskVMRecycleEnabled.Default.(bool)
 	// teamDescTaskVMRecycleSeconds is the schema descriptor for task_vm_recycle_seconds field.
-	teamDescTaskVMRecycleSeconds := teamFields[6].Descriptor()
+	teamDescTaskVMRecycleSeconds := teamFields[7].Descriptor()
 	// team.DefaultTaskVMRecycleSeconds holds the default value on creation for the task_vm_recycle_seconds field.
 	team.DefaultTaskVMRecycleSeconds = teamDescTaskVMRecycleSeconds.Default.(int)
 	// teamDescCreatedAt is the schema descriptor for created_at field.
-	teamDescCreatedAt := teamFields[7].Descriptor()
+	teamDescCreatedAt := teamFields[8].Descriptor()
 	// team.DefaultCreatedAt holds the default value on creation for the created_at field.
 	team.DefaultCreatedAt = teamDescCreatedAt.Default.(func() time.Time)
 	// teamDescUpdatedAt is the schema descriptor for updated_at field.
-	teamDescUpdatedAt := teamFields[8].Descriptor()
+	teamDescUpdatedAt := teamFields[9].Descriptor()
 	// team.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	team.DefaultUpdatedAt = teamDescUpdatedAt.Default.(func() time.Time)
 	teamgroupMixin := schema.TeamGroup{}.Mixin()

--- a/backend/db/team.go
+++ b/backend/db/team.go
@@ -24,6 +24,8 @@ type Team struct {
 	Name string `json:"name,omitempty"`
 	// MemberLimit holds the value of the "member_limit" field.
 	MemberLimit int `json:"member_limit,omitempty"`
+	// TaskConcurrencyLimit holds the value of the "task_concurrency_limit" field.
+	TaskConcurrencyLimit int `json:"task_concurrency_limit,omitempty"`
 	// TaskVMSleepEnabled holds the value of the "task_vm_sleep_enabled" field.
 	TaskVMSleepEnabled bool `json:"task_vm_sleep_enabled,omitempty"`
 	// TaskVMSleepSeconds holds the value of the "task_vm_sleep_seconds" field.
@@ -155,7 +157,7 @@ func (*Team) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case team.FieldTaskVMSleepEnabled, team.FieldTaskVMRecycleEnabled:
 			values[i] = new(sql.NullBool)
-		case team.FieldMemberLimit, team.FieldTaskVMSleepSeconds, team.FieldTaskVMRecycleSeconds:
+		case team.FieldMemberLimit, team.FieldTaskConcurrencyLimit, team.FieldTaskVMSleepSeconds, team.FieldTaskVMRecycleSeconds:
 			values[i] = new(sql.NullInt64)
 		case team.FieldName:
 			values[i] = new(sql.NullString)
@@ -201,6 +203,12 @@ func (_m *Team) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field member_limit", values[i])
 			} else if value.Valid {
 				_m.MemberLimit = int(value.Int64)
+			}
+		case team.FieldTaskConcurrencyLimit:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field task_concurrency_limit", values[i])
+			} else if value.Valid {
+				_m.TaskConcurrencyLimit = int(value.Int64)
 			}
 		case team.FieldTaskVMSleepEnabled:
 			if value, ok := values[i].(*sql.NullBool); !ok {
@@ -327,6 +335,9 @@ func (_m *Team) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("member_limit=")
 	builder.WriteString(fmt.Sprintf("%v", _m.MemberLimit))
+	builder.WriteString(", ")
+	builder.WriteString("task_concurrency_limit=")
+	builder.WriteString(fmt.Sprintf("%v", _m.TaskConcurrencyLimit))
 	builder.WriteString(", ")
 	builder.WriteString("task_vm_sleep_enabled=")
 	builder.WriteString(fmt.Sprintf("%v", _m.TaskVMSleepEnabled))

--- a/backend/db/team/team.go
+++ b/backend/db/team/team.go
@@ -21,6 +21,8 @@ const (
 	FieldName = "name"
 	// FieldMemberLimit holds the string denoting the member_limit field in the database.
 	FieldMemberLimit = "member_limit"
+	// FieldTaskConcurrencyLimit holds the string denoting the task_concurrency_limit field in the database.
+	FieldTaskConcurrencyLimit = "task_concurrency_limit"
 	// FieldTaskVMSleepEnabled holds the string denoting the task_vm_sleep_enabled field in the database.
 	FieldTaskVMSleepEnabled = "task_vm_sleep_enabled"
 	// FieldTaskVMSleepSeconds holds the string denoting the task_vm_sleep_seconds field in the database.
@@ -116,6 +118,7 @@ var Columns = []string{
 	FieldDeletedAt,
 	FieldName,
 	FieldMemberLimit,
+	FieldTaskConcurrencyLimit,
 	FieldTaskVMSleepEnabled,
 	FieldTaskVMSleepSeconds,
 	FieldTaskVMRecycleEnabled,
@@ -159,6 +162,10 @@ var (
 	Interceptors [1]ent.Interceptor
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
+	// DefaultTaskConcurrencyLimit holds the default value on creation for the "task_concurrency_limit" field.
+	DefaultTaskConcurrencyLimit int
+	// TaskConcurrencyLimitValidator is a validator for the "task_concurrency_limit" field. It is called by the builders before save.
+	TaskConcurrencyLimitValidator func(int) error
 	// DefaultTaskVMSleepEnabled holds the default value on creation for the "task_vm_sleep_enabled" field.
 	DefaultTaskVMSleepEnabled bool
 	// DefaultTaskVMSleepSeconds holds the default value on creation for the "task_vm_sleep_seconds" field.
@@ -194,6 +201,11 @@ func ByName(opts ...sql.OrderTermOption) OrderOption {
 // ByMemberLimit orders the results by the member_limit field.
 func ByMemberLimit(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMemberLimit, opts...).ToFunc()
+}
+
+// ByTaskConcurrencyLimit orders the results by the task_concurrency_limit field.
+func ByTaskConcurrencyLimit(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldTaskConcurrencyLimit, opts...).ToFunc()
 }
 
 // ByTaskVMSleepEnabled orders the results by the task_vm_sleep_enabled field.

--- a/backend/db/team/where.go
+++ b/backend/db/team/where.go
@@ -71,6 +71,11 @@ func MemberLimit(v int) predicate.Team {
 	return predicate.Team(sql.FieldEQ(FieldMemberLimit, v))
 }
 
+// TaskConcurrencyLimit applies equality check predicate on the "task_concurrency_limit" field. It's identical to TaskConcurrencyLimitEQ.
+func TaskConcurrencyLimit(v int) predicate.Team {
+	return predicate.Team(sql.FieldEQ(FieldTaskConcurrencyLimit, v))
+}
+
 // TaskVMSleepEnabled applies equality check predicate on the "task_vm_sleep_enabled" field. It's identical to TaskVMSleepEnabledEQ.
 func TaskVMSleepEnabled(v bool) predicate.Team {
 	return predicate.Team(sql.FieldEQ(FieldTaskVMSleepEnabled, v))
@@ -254,6 +259,46 @@ func MemberLimitLT(v int) predicate.Team {
 // MemberLimitLTE applies the LTE predicate on the "member_limit" field.
 func MemberLimitLTE(v int) predicate.Team {
 	return predicate.Team(sql.FieldLTE(FieldMemberLimit, v))
+}
+
+// TaskConcurrencyLimitEQ applies the EQ predicate on the "task_concurrency_limit" field.
+func TaskConcurrencyLimitEQ(v int) predicate.Team {
+	return predicate.Team(sql.FieldEQ(FieldTaskConcurrencyLimit, v))
+}
+
+// TaskConcurrencyLimitNEQ applies the NEQ predicate on the "task_concurrency_limit" field.
+func TaskConcurrencyLimitNEQ(v int) predicate.Team {
+	return predicate.Team(sql.FieldNEQ(FieldTaskConcurrencyLimit, v))
+}
+
+// TaskConcurrencyLimitIn applies the In predicate on the "task_concurrency_limit" field.
+func TaskConcurrencyLimitIn(vs ...int) predicate.Team {
+	return predicate.Team(sql.FieldIn(FieldTaskConcurrencyLimit, vs...))
+}
+
+// TaskConcurrencyLimitNotIn applies the NotIn predicate on the "task_concurrency_limit" field.
+func TaskConcurrencyLimitNotIn(vs ...int) predicate.Team {
+	return predicate.Team(sql.FieldNotIn(FieldTaskConcurrencyLimit, vs...))
+}
+
+// TaskConcurrencyLimitGT applies the GT predicate on the "task_concurrency_limit" field.
+func TaskConcurrencyLimitGT(v int) predicate.Team {
+	return predicate.Team(sql.FieldGT(FieldTaskConcurrencyLimit, v))
+}
+
+// TaskConcurrencyLimitGTE applies the GTE predicate on the "task_concurrency_limit" field.
+func TaskConcurrencyLimitGTE(v int) predicate.Team {
+	return predicate.Team(sql.FieldGTE(FieldTaskConcurrencyLimit, v))
+}
+
+// TaskConcurrencyLimitLT applies the LT predicate on the "task_concurrency_limit" field.
+func TaskConcurrencyLimitLT(v int) predicate.Team {
+	return predicate.Team(sql.FieldLT(FieldTaskConcurrencyLimit, v))
+}
+
+// TaskConcurrencyLimitLTE applies the LTE predicate on the "task_concurrency_limit" field.
+func TaskConcurrencyLimitLTE(v int) predicate.Team {
+	return predicate.Team(sql.FieldLTE(FieldTaskConcurrencyLimit, v))
 }
 
 // TaskVMSleepEnabledEQ applies the EQ predicate on the "task_vm_sleep_enabled" field.

--- a/backend/db/team_create.go
+++ b/backend/db/team_create.go
@@ -59,6 +59,20 @@ func (_c *TeamCreate) SetMemberLimit(v int) *TeamCreate {
 	return _c
 }
 
+// SetTaskConcurrencyLimit sets the "task_concurrency_limit" field.
+func (_c *TeamCreate) SetTaskConcurrencyLimit(v int) *TeamCreate {
+	_c.mutation.SetTaskConcurrencyLimit(v)
+	return _c
+}
+
+// SetNillableTaskConcurrencyLimit sets the "task_concurrency_limit" field if the given value is not nil.
+func (_c *TeamCreate) SetNillableTaskConcurrencyLimit(v *int) *TeamCreate {
+	if v != nil {
+		_c.SetTaskConcurrencyLimit(*v)
+	}
+	return _c
+}
+
 // SetTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field.
 func (_c *TeamCreate) SetTaskVMSleepEnabled(v bool) *TeamCreate {
 	_c.mutation.SetTaskVMSleepEnabled(v)
@@ -321,6 +335,10 @@ func (_c *TeamCreate) ExecX(ctx context.Context) {
 
 // defaults sets the default values of the builder before save.
 func (_c *TeamCreate) defaults() error {
+	if _, ok := _c.mutation.TaskConcurrencyLimit(); !ok {
+		v := team.DefaultTaskConcurrencyLimit
+		_c.mutation.SetTaskConcurrencyLimit(v)
+	}
 	if _, ok := _c.mutation.TaskVMSleepEnabled(); !ok {
 		v := team.DefaultTaskVMSleepEnabled
 		_c.mutation.SetTaskVMSleepEnabled(v)
@@ -366,6 +384,14 @@ func (_c *TeamCreate) check() error {
 	}
 	if _, ok := _c.mutation.MemberLimit(); !ok {
 		return &ValidationError{Name: "member_limit", err: errors.New(`db: missing required field "Team.member_limit"`)}
+	}
+	if _, ok := _c.mutation.TaskConcurrencyLimit(); !ok {
+		return &ValidationError{Name: "task_concurrency_limit", err: errors.New(`db: missing required field "Team.task_concurrency_limit"`)}
+	}
+	if v, ok := _c.mutation.TaskConcurrencyLimit(); ok {
+		if err := team.TaskConcurrencyLimitValidator(v); err != nil {
+			return &ValidationError{Name: "task_concurrency_limit", err: fmt.Errorf(`db: validator failed for field "Team.task_concurrency_limit": %w`, err)}
+		}
 	}
 	if _, ok := _c.mutation.TaskVMSleepEnabled(); !ok {
 		return &ValidationError{Name: "task_vm_sleep_enabled", err: errors.New(`db: missing required field "Team.task_vm_sleep_enabled"`)}
@@ -432,6 +458,10 @@ func (_c *TeamCreate) createSpec() (*Team, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.MemberLimit(); ok {
 		_spec.SetField(team.FieldMemberLimit, field.TypeInt, value)
 		_node.MemberLimit = value
+	}
+	if value, ok := _c.mutation.TaskConcurrencyLimit(); ok {
+		_spec.SetField(team.FieldTaskConcurrencyLimit, field.TypeInt, value)
+		_node.TaskConcurrencyLimit = value
 	}
 	if value, ok := _c.mutation.TaskVMSleepEnabled(); ok {
 		_spec.SetField(team.FieldTaskVMSleepEnabled, field.TypeBool, value)
@@ -717,6 +747,24 @@ func (u *TeamUpsert) AddMemberLimit(v int) *TeamUpsert {
 	return u
 }
 
+// SetTaskConcurrencyLimit sets the "task_concurrency_limit" field.
+func (u *TeamUpsert) SetTaskConcurrencyLimit(v int) *TeamUpsert {
+	u.Set(team.FieldTaskConcurrencyLimit, v)
+	return u
+}
+
+// UpdateTaskConcurrencyLimit sets the "task_concurrency_limit" field to the value that was provided on create.
+func (u *TeamUpsert) UpdateTaskConcurrencyLimit() *TeamUpsert {
+	u.SetExcluded(team.FieldTaskConcurrencyLimit)
+	return u
+}
+
+// AddTaskConcurrencyLimit adds v to the "task_concurrency_limit" field.
+func (u *TeamUpsert) AddTaskConcurrencyLimit(v int) *TeamUpsert {
+	u.Add(team.FieldTaskConcurrencyLimit, v)
+	return u
+}
+
 // SetTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field.
 func (u *TeamUpsert) SetTaskVMSleepEnabled(v bool) *TeamUpsert {
 	u.Set(team.FieldTaskVMSleepEnabled, v)
@@ -902,6 +950,27 @@ func (u *TeamUpsertOne) AddMemberLimit(v int) *TeamUpsertOne {
 func (u *TeamUpsertOne) UpdateMemberLimit() *TeamUpsertOne {
 	return u.Update(func(s *TeamUpsert) {
 		s.UpdateMemberLimit()
+	})
+}
+
+// SetTaskConcurrencyLimit sets the "task_concurrency_limit" field.
+func (u *TeamUpsertOne) SetTaskConcurrencyLimit(v int) *TeamUpsertOne {
+	return u.Update(func(s *TeamUpsert) {
+		s.SetTaskConcurrencyLimit(v)
+	})
+}
+
+// AddTaskConcurrencyLimit adds v to the "task_concurrency_limit" field.
+func (u *TeamUpsertOne) AddTaskConcurrencyLimit(v int) *TeamUpsertOne {
+	return u.Update(func(s *TeamUpsert) {
+		s.AddTaskConcurrencyLimit(v)
+	})
+}
+
+// UpdateTaskConcurrencyLimit sets the "task_concurrency_limit" field to the value that was provided on create.
+func (u *TeamUpsertOne) UpdateTaskConcurrencyLimit() *TeamUpsertOne {
+	return u.Update(func(s *TeamUpsert) {
+		s.UpdateTaskConcurrencyLimit()
 	})
 }
 
@@ -1271,6 +1340,27 @@ func (u *TeamUpsertBulk) AddMemberLimit(v int) *TeamUpsertBulk {
 func (u *TeamUpsertBulk) UpdateMemberLimit() *TeamUpsertBulk {
 	return u.Update(func(s *TeamUpsert) {
 		s.UpdateMemberLimit()
+	})
+}
+
+// SetTaskConcurrencyLimit sets the "task_concurrency_limit" field.
+func (u *TeamUpsertBulk) SetTaskConcurrencyLimit(v int) *TeamUpsertBulk {
+	return u.Update(func(s *TeamUpsert) {
+		s.SetTaskConcurrencyLimit(v)
+	})
+}
+
+// AddTaskConcurrencyLimit adds v to the "task_concurrency_limit" field.
+func (u *TeamUpsertBulk) AddTaskConcurrencyLimit(v int) *TeamUpsertBulk {
+	return u.Update(func(s *TeamUpsert) {
+		s.AddTaskConcurrencyLimit(v)
+	})
+}
+
+// UpdateTaskConcurrencyLimit sets the "task_concurrency_limit" field to the value that was provided on create.
+func (u *TeamUpsertBulk) UpdateTaskConcurrencyLimit() *TeamUpsertBulk {
+	return u.Update(func(s *TeamUpsert) {
+		s.UpdateTaskConcurrencyLimit()
 	})
 }
 

--- a/backend/db/team_update.go
+++ b/backend/db/team_update.go
@@ -94,6 +94,27 @@ func (_u *TeamUpdate) AddMemberLimit(v int) *TeamUpdate {
 	return _u
 }
 
+// SetTaskConcurrencyLimit sets the "task_concurrency_limit" field.
+func (_u *TeamUpdate) SetTaskConcurrencyLimit(v int) *TeamUpdate {
+	_u.mutation.ResetTaskConcurrencyLimit()
+	_u.mutation.SetTaskConcurrencyLimit(v)
+	return _u
+}
+
+// SetNillableTaskConcurrencyLimit sets the "task_concurrency_limit" field if the given value is not nil.
+func (_u *TeamUpdate) SetNillableTaskConcurrencyLimit(v *int) *TeamUpdate {
+	if v != nil {
+		_u.SetTaskConcurrencyLimit(*v)
+	}
+	return _u
+}
+
+// AddTaskConcurrencyLimit adds value to the "task_concurrency_limit" field.
+func (_u *TeamUpdate) AddTaskConcurrencyLimit(v int) *TeamUpdate {
+	_u.mutation.AddTaskConcurrencyLimit(v)
+	return _u
+}
+
 // SetTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field.
 func (_u *TeamUpdate) SetTaskVMSleepEnabled(v bool) *TeamUpdate {
 	_u.mutation.SetTaskVMSleepEnabled(v)
@@ -555,6 +576,11 @@ func (_u *TeamUpdate) check() error {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`db: validator failed for field "Team.name": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.TaskConcurrencyLimit(); ok {
+		if err := team.TaskConcurrencyLimitValidator(v); err != nil {
+			return &ValidationError{Name: "task_concurrency_limit", err: fmt.Errorf(`db: validator failed for field "Team.task_concurrency_limit": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -590,6 +616,12 @@ func (_u *TeamUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.AddedMemberLimit(); ok {
 		_spec.AddField(team.FieldMemberLimit, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.TaskConcurrencyLimit(); ok {
+		_spec.SetField(team.FieldTaskConcurrencyLimit, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedTaskConcurrencyLimit(); ok {
+		_spec.AddField(team.FieldTaskConcurrencyLimit, field.TypeInt, value)
 	}
 	if value, ok := _u.mutation.TaskVMSleepEnabled(); ok {
 		_spec.SetField(team.FieldTaskVMSleepEnabled, field.TypeBool, value)
@@ -1145,6 +1177,27 @@ func (_u *TeamUpdateOne) AddMemberLimit(v int) *TeamUpdateOne {
 	return _u
 }
 
+// SetTaskConcurrencyLimit sets the "task_concurrency_limit" field.
+func (_u *TeamUpdateOne) SetTaskConcurrencyLimit(v int) *TeamUpdateOne {
+	_u.mutation.ResetTaskConcurrencyLimit()
+	_u.mutation.SetTaskConcurrencyLimit(v)
+	return _u
+}
+
+// SetNillableTaskConcurrencyLimit sets the "task_concurrency_limit" field if the given value is not nil.
+func (_u *TeamUpdateOne) SetNillableTaskConcurrencyLimit(v *int) *TeamUpdateOne {
+	if v != nil {
+		_u.SetTaskConcurrencyLimit(*v)
+	}
+	return _u
+}
+
+// AddTaskConcurrencyLimit adds value to the "task_concurrency_limit" field.
+func (_u *TeamUpdateOne) AddTaskConcurrencyLimit(v int) *TeamUpdateOne {
+	_u.mutation.AddTaskConcurrencyLimit(v)
+	return _u
+}
+
 // SetTaskVMSleepEnabled sets the "task_vm_sleep_enabled" field.
 func (_u *TeamUpdateOne) SetTaskVMSleepEnabled(v bool) *TeamUpdateOne {
 	_u.mutation.SetTaskVMSleepEnabled(v)
@@ -1619,6 +1672,11 @@ func (_u *TeamUpdateOne) check() error {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`db: validator failed for field "Team.name": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.TaskConcurrencyLimit(); ok {
+		if err := team.TaskConcurrencyLimitValidator(v); err != nil {
+			return &ValidationError{Name: "task_concurrency_limit", err: fmt.Errorf(`db: validator failed for field "Team.task_concurrency_limit": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -1671,6 +1729,12 @@ func (_u *TeamUpdateOne) sqlSave(ctx context.Context) (_node *Team, err error) {
 	}
 	if value, ok := _u.mutation.AddedMemberLimit(); ok {
 		_spec.AddField(team.FieldMemberLimit, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.TaskConcurrencyLimit(); ok {
+		_spec.SetField(team.FieldTaskConcurrencyLimit, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedTaskConcurrencyLimit(); ok {
+		_spec.AddField(team.FieldTaskConcurrencyLimit, field.TypeInt, value)
 	}
 	if value, ok := _u.mutation.TaskVMSleepEnabled(); ok {
 		_spec.SetField(team.FieldTaskVMSleepEnabled, field.TypeBool, value)

--- a/backend/domain/team_policy.go
+++ b/backend/domain/team_policy.go
@@ -9,8 +9,11 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/db"
 )
 
+const defaultTaskConcurrencyLimit = 3
+
 type TeamTaskVMIdlePolicy struct {
 	TeamID                  uuid.UUID `json:"team_id"`
+	TaskConcurrencyLimit    int       `json:"task_concurrency_limit"`
 	SleepEnabled            bool      `json:"sleep_enabled"`
 	SleepSeconds            int       `json:"sleep_seconds"`
 	EffectiveSleepSeconds   int       `json:"effective_sleep_seconds"`
@@ -22,21 +25,27 @@ type TeamTaskVMIdlePolicy struct {
 }
 
 type UpdateTeamTaskVMIdlePolicyReq struct {
-	SleepEnabled   bool `json:"sleep_enabled"`
-	SleepSeconds   int  `json:"sleep_seconds"`
-	RecycleEnabled bool `json:"recycle_enabled"`
-	RecycleSeconds int  `json:"recycle_seconds"`
+	TaskConcurrencyLimit int  `json:"task_concurrency_limit"`
+	SleepEnabled         bool `json:"sleep_enabled"`
+	SleepSeconds         int  `json:"sleep_seconds"`
+	RecycleEnabled       bool `json:"recycle_enabled"`
+	RecycleSeconds       int  `json:"recycle_seconds"`
 }
 
 func ResolveTeamTaskVMIdlePolicy(team *db.Team, cfg config.VMIdle) (*TeamTaskVMIdlePolicy, error) {
 	p := &TeamTaskVMIdlePolicy{
-		SleepEnabled:   true,
-		SleepSeconds:   0,
-		RecycleEnabled: true,
-		RecycleSeconds: 0,
+		TaskConcurrencyLimit: defaultTaskConcurrencyLimit,
+		SleepEnabled:         true,
+		SleepSeconds:         0,
+		RecycleEnabled:       true,
+		RecycleSeconds:       0,
 	}
 	if team != nil {
 		p.TeamID = team.ID
+		p.TaskConcurrencyLimit = team.TaskConcurrencyLimit
+		if p.TaskConcurrencyLimit <= 0 {
+			p.TaskConcurrencyLimit = defaultTaskConcurrencyLimit
+		}
 		p.SleepEnabled = team.TaskVMSleepEnabled
 		p.SleepSeconds = team.TaskVMSleepSeconds
 		p.RecycleEnabled = team.TaskVMRecycleEnabled
@@ -50,11 +59,12 @@ func ResolveTeamTaskVMIdlePolicy(team *db.Team, cfg config.VMIdle) (*TeamTaskVMI
 
 func NewTeamTaskVMIdlePolicyFromReq(teamID uuid.UUID, req *UpdateTeamTaskVMIdlePolicyReq, cfg config.VMIdle) (*TeamTaskVMIdlePolicy, error) {
 	p := &TeamTaskVMIdlePolicy{
-		TeamID:         teamID,
-		SleepEnabled:   req.SleepEnabled,
-		SleepSeconds:   req.SleepSeconds,
-		RecycleEnabled: req.RecycleEnabled,
-		RecycleSeconds: req.RecycleSeconds,
+		TeamID:               teamID,
+		TaskConcurrencyLimit: req.TaskConcurrencyLimit,
+		SleepEnabled:         req.SleepEnabled,
+		SleepSeconds:         req.SleepSeconds,
+		RecycleEnabled:       req.RecycleEnabled,
+		RecycleSeconds:       req.RecycleSeconds,
 	}
 	if err := fillEffectiveTeamTaskVMIdlePolicy(p, cfg); err != nil {
 		return nil, err
@@ -63,6 +73,9 @@ func NewTeamTaskVMIdlePolicyFromReq(teamID uuid.UUID, req *UpdateTeamTaskVMIdleP
 }
 
 func fillEffectiveTeamTaskVMIdlePolicy(p *TeamTaskVMIdlePolicy, cfg config.VMIdle) error {
+	if p.TaskConcurrencyLimit <= 0 {
+		return fmt.Errorf("task concurrency limit must be greater than 0")
+	}
 	if p.SleepSeconds < 0 {
 		return fmt.Errorf("sleep seconds must be greater than or equal to 0")
 	}

--- a/backend/domain/team_policy_test.go
+++ b/backend/domain/team_policy_test.go
@@ -33,6 +33,58 @@ func TestResolveTeamTaskVMIdlePolicyInheritsGlobalDefaults(t *testing.T) {
 	}
 }
 
+func TestResolveTeamTaskVMIdlePolicyIncludesTaskConcurrencyLimit(t *testing.T) {
+	teamID := uuid.New()
+	team := &db.Team{
+		ID:                   teamID,
+		TaskConcurrencyLimit: 5,
+		TaskVMSleepEnabled:   true,
+		TaskVMSleepSeconds:   0,
+		TaskVMRecycleEnabled: true,
+		TaskVMRecycleSeconds: 0,
+	}
+
+	got, err := ResolveTeamTaskVMIdlePolicy(team, config.VMIdle{
+		SleepSeconds:   600,
+		RecycleSeconds: 604800,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.TeamID != teamID {
+		t.Fatalf("team id = %s, want %s", got.TeamID, teamID)
+	}
+	if got.TaskConcurrencyLimit != 5 {
+		t.Fatalf("task concurrency limit = %d, want 5", got.TaskConcurrencyLimit)
+	}
+}
+
+func TestResolveTeamTaskVMIdlePolicyDefaultsTaskConcurrencyLimit(t *testing.T) {
+	got, err := ResolveTeamTaskVMIdlePolicy(nil, config.VMIdle{
+		SleepSeconds:   600,
+		RecycleSeconds: 604800,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.TaskConcurrencyLimit != 3 {
+		t.Fatalf("task concurrency limit = %d, want 3", got.TaskConcurrencyLimit)
+	}
+}
+
+func TestNewTeamTaskVMIdlePolicyFromReqRejectsInvalidTaskConcurrencyLimit(t *testing.T) {
+	_, err := NewTeamTaskVMIdlePolicyFromReq(uuid.New(), &UpdateTeamTaskVMIdlePolicyReq{
+		TaskConcurrencyLimit: 0,
+		SleepEnabled:         true,
+		SleepSeconds:         600,
+		RecycleEnabled:       true,
+		RecycleSeconds:       604800,
+	}, config.VMIdle{SleepSeconds: 600, RecycleSeconds: 604800})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func TestResolveTeamTaskVMIdlePolicyCanDisableQueues(t *testing.T) {
 	team := &db.Team{
 		ID:                   uuid.New(),

--- a/backend/ent/schema/team.go
+++ b/backend/ent/schema/team.go
@@ -36,6 +36,7 @@ func (Team) Fields() []ent.Field {
 		field.UUID("id", uuid.UUID{}).Unique(),
 		field.String("name").NotEmpty(),
 		field.Int("member_limit"),
+		field.Int("task_concurrency_limit").Default(3).Positive(),
 		field.Bool("task_vm_sleep_enabled").Default(true),
 		field.Int("task_vm_sleep_seconds").Default(0),
 		field.Bool("task_vm_recycle_enabled").Default(true),

--- a/backend/migration/000017_alter_teams_add_task_concurrency_limit.down.sql
+++ b/backend/migration/000017_alter_teams_add_task_concurrency_limit.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE teams
+    DROP COLUMN IF EXISTS task_concurrency_limit;

--- a/backend/migration/000017_alter_teams_add_task_concurrency_limit.up.sql
+++ b/backend/migration/000017_alter_teams_add_task_concurrency_limit.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE teams
+    ADD COLUMN IF NOT EXISTS task_concurrency_limit integer DEFAULT 3 NOT NULL;

--- a/frontend/src/api/Api.ts
+++ b/frontend/src/api/Api.ts
@@ -1705,6 +1705,7 @@ export interface DomainTeamTaskVMIdlePolicy {
   sleep_enabled?: boolean;
   sleep_inherited?: boolean;
   sleep_seconds?: number;
+  task_concurrency_limit?: number;
   team_id?: string;
 }
 
@@ -1969,6 +1970,7 @@ export interface DomainUpdateTeamTaskVMIdlePolicyReq {
   recycle_seconds?: number;
   sleep_enabled?: boolean;
   sleep_seconds?: number;
+  task_concurrency_limit?: number;
 }
 
 export interface DomainUpdateTeamOAuthSiteReq {

--- a/frontend/src/pages/console/manager/hosts.tsx
+++ b/frontend/src/pages/console/manager/hosts.tsx
@@ -73,6 +73,7 @@ export default function TeamManagerHosts() {
   const [sleepHours, setSleepHours] = useState("")
   const [recycleEnabled, setRecycleEnabled] = useState(true)
   const [recycleHours, setRecycleHours] = useState("")
+  const [taskConcurrencyLimit, setTaskConcurrencyLimit] = useState("3")
   
 
 
@@ -94,6 +95,7 @@ export default function TeamManagerHosts() {
     setSleepHours(secondsToHours(nextPolicy.sleep_seconds))
     setRecycleEnabled(nextPolicy.recycle_enabled ?? true)
     setRecycleHours(secondsToHours(nextPolicy.recycle_seconds))
+    setTaskConcurrencyLimit(String(nextPolicy.task_concurrency_limit ?? 3))
   }
 
   const fetchPolicy = async () => {
@@ -132,8 +134,15 @@ export default function TeamManagerHosts() {
   }, [])
 
   const handleSavePolicy = async () => {
+    const parsedTaskConcurrencyLimit = Number(taskConcurrencyLimit)
+    if (!Number.isInteger(parsedTaskConcurrencyLimit) || parsedTaskConcurrencyLimit <= 0) {
+      toast.error("任务并发数必须为正整数")
+      return
+    }
+
     setSavingPolicy(true)
     await apiRequest('v1TeamsTaskVmIdlePolicyUpdate', {
+      task_concurrency_limit: parsedTaskConcurrencyLimit,
       sleep_enabled: sleepEnabled,
       sleep_seconds: hoursToSeconds(sleepHours),
       recycle_enabled: recycleEnabled,
@@ -141,9 +150,9 @@ export default function TeamManagerHosts() {
     }, [], (resp) => {
       if (resp.code === 0 && resp.data) {
         syncPolicyForm(resp.data)
-        toast.success("任务开发环境策略已保存")
+        toast.success("任务策略已保存")
       } else {
-        toast.error("保存任务开发环境策略失败: " + resp.message)
+        toast.error("保存任务策略失败: " + resp.message)
       }
     })
     setSavingPolicy(false)
@@ -188,7 +197,7 @@ export default function TeamManagerHosts() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Clock3 />
-            开发环境自动回收
+            任务策略
           </CardTitle>
           <CardAction>
             <Button variant="outline" size="sm" onClick={() => setPolicyDialogOpen(true)}>
@@ -206,7 +215,11 @@ export default function TeamManagerHosts() {
               </EmptyHeader>
             </Empty>
           ) : (
-            <div className="grid gap-4 md:grid-cols-2">
+            <div className="grid gap-4 md:grid-cols-3">
+              <PolicySummaryItem
+                label="任务并发数"
+                value={`${policy?.task_concurrency_limit ?? 3} 个任务`}
+              />
               <PolicySummaryItem
                 label="自动休眠"
                 value={sleepEnabled ? `${formatPolicyDuration(policy?.effective_sleep_seconds)} 后休眠` : "已关闭"}
@@ -223,7 +236,7 @@ export default function TeamManagerHosts() {
       <Dialog open={policyDialogOpen} onOpenChange={setPolicyDialogOpen}>
         <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-3xl">
           <DialogHeader>
-            <DialogTitle>开发环境自动回收</DialogTitle>
+            <DialogTitle>任务策略</DialogTitle>
           </DialogHeader>
           {loadingPolicy ? (
             <Empty className="bg-muted">
@@ -235,7 +248,26 @@ export default function TeamManagerHosts() {
             </Empty>
           ) : (
             <>
-              <div className="grid gap-4 md:grid-cols-2">
+              <div className="grid gap-4 md:grid-cols-3">
+                <div className="rounded-lg border p-4">
+                  <div className="space-y-1">
+                    <Label htmlFor="task-concurrency-limit">任务并发数</Label>
+                    <p className="text-sm text-muted-foreground">
+                      同一成员可同时运行的任务数量
+                    </p>
+                  </div>
+                  <div className="mt-4 space-y-2">
+                    <Input
+                      id="task-concurrency-limit"
+                      type="number"
+                      min="1"
+                      step="1"
+                      value={taskConcurrencyLimit}
+                      onChange={(e) => setTaskConcurrencyLimit(e.target.value)}
+                    />
+                  </div>
+                </div>
+
                 <div className="rounded-lg border p-4">
                   <div className="flex items-start justify-between gap-4">
                     <div className="space-y-1">


### PR DESCRIPTION
## Summary
- 在团队表新增 `task_concurrency_limit`，默认值为 3，并补充迁移和 Ent 生成代码
- 团队任务策略接口支持读取和保存任务并发数
- 创建任务时优先使用用户所属团队配置，前端团队管理页增加配置入口

## Test Plan
- [x] `cd backend && go test ./domain ./biz/team/repo ./biz/team/usecase ./biz/task/usecase ./pkg/entx`
- [x] `cd frontend && pnpm build`
- [x] 本地 Vite HTTP 冒烟返回 `200 OK`

## Notes
- 内置浏览器 `iab` 当前不可用，未做可视化截图验证
