### PR TITLE
feat(task): 修改开发容器中硬编码的 agent 资源路径

### DIFF
--- a/backend/biz/task/usecase/task.go
+++ b/backend/biz/task/usecase/task.go
@@ -761,9 +761,9 @@ func modelRuntimeDefaults(m *db.Model) (thinking bool, contextLimit int, outputL
 // 后按目录结构展开；plugin 的 entry 字段再以 file:// 注入到 opencode.json 的
 // `plugin` 数组里。Claude / Codex 不消费 plugin（spec §6.3）。
 const (
-	agentRuleBaseDir   = "/tmp/codingmatrix-project-tpl/.ai-ready/rules/"
-	agentSkillBaseDir  = "/tmp/codingmatrix-project-tpl/.ai-ready/skills/"
-	agentPluginBaseDir = "/tmp/codingmatrix-project-tpl/.ai-ready/plugins/"
+	agentRuleBaseDir   = "${HOME}/.codingmatrix/project-tpl/.ai-ready/rules/"
+	agentSkillBaseDir  = "${HOME}/.codingmatrix/project-tpl/.ai-ready/skills/"
+	agentPluginBaseDir = "${HOME}/.codingmatrix/project-tpl/.ai-ready/plugins/"
 )
 
 // parseStringUUIDs 把字符串切片解析成 uuid.UUID 切片。单条解析失败时打一条

--- a/backend/templates/opencode.tmpl
+++ b/backend/templates/opencode.tmpl
@@ -39,5 +39,5 @@
   },
   "model": "monkeycode-ai/{{.model}}",
   "disabled_providers": ["openai", "opencode"],
-  "instructions": ["/tmp/codingmatrix-project-tpl/.ai-ready/rules/*.md"]
+  "instructions": ["${HOME}/.codingmatrix/project-tpl/.ai-ready/rules/*.md"]
 }

--- a/backend/templates/opencode.tmpl
+++ b/backend/templates/opencode.tmpl
@@ -39,5 +39,8 @@
   },
   "model": "monkeycode-ai/{{.model}}",
   "disabled_providers": ["openai", "opencode"],
-  "instructions": ["${HOME}/.codingmatrix/project-tpl/.ai-ready/rules/*.md"]
+  "instructions": ["${HOME}/.codingmatrix/project-tpl/.ai-ready/rules/*.md"],
+  "skills": {
+    "paths": ["${HOME}/.codingmatrix/project-tpl/.ai-ready/skills/"]
+  }
 }


### PR DESCRIPTION
1. 把之前硬编码的 rules/skills 路径 /tmp/codingmatrix-project-tpl 改为 ${HOME}/.codingmatrix/project-tpl
2. 补上 opencode 配置文件中遗漏的 skills.path 引用