### PR TITLE
fix: 创建虚拟机前先写入本地记录

### DIFF
--- a/backend/biz/host/handler/v1/internal_auth_test.go
+++ b/backend/biz/host/handler/v1/internal_auth_test.go
@@ -255,6 +255,14 @@ func (s *internalHostRepoStub) CreateVirtualMachine(context.Context, *domain.Use
 	return nil, errors.New("not implemented")
 }
 
+func (s *internalHostRepoStub) PrepareCreateVirtualMachine(context.Context, *domain.User, *domain.CreateVMReq, string) (*domain.PreparedVirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *internalHostRepoStub) CompleteCreateVirtualMachine(context.Context, string, *taskflow.VirtualMachine) (*domain.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (s *internalHostRepoStub) PastHourVirtualMachine(context.Context) ([]*db.VirtualMachine, error) {
 	return nil, errors.New("not implemented")
 }

--- a/backend/biz/host/repo/host.go
+++ b/backend/biz/host/repo/host.go
@@ -443,6 +443,169 @@ func (h *HostRepo) CreateVirtualMachine(ctx context.Context, u *domain.User, req
 	return res, err
 }
 
+func (h *HostRepo) PrepareCreateVirtualMachine(ctx context.Context, u *domain.User, req *domain.CreateVMReq, id string) (*domain.PreparedVirtualMachine, error) {
+	var res *domain.PreparedVirtualMachine
+	err := entx.WithTx2(ctx, h.db, func(tx *db.Tx) error {
+		dbHost, err := tx.Host.Query().
+			WithUser().
+			WithGroups().
+			Where(hostWithUserPredicate(u.ID)).
+			Where(host.ID(req.HostID)).
+			First(ctx)
+		if err != nil {
+			return errcode.ErrPermision.Wrap(err)
+		}
+
+		if u := dbHost.Edges.User; u != nil && u.Role == consts.UserRoleAdmin {
+			if req.Life > 3*60*60 || req.Life <= 0 {
+				return errcode.ErrPublicHostBeyondLimit
+			}
+		}
+
+		if len(dbHost.Edges.Groups) > 0 && (req.Life <= 0 || req.Life > 7*24*60*60) {
+			return errcode.ErrVmBeyondExpireTime.Wrap(fmt.Errorf("团队宿主机不支持创建永久虚拟机"))
+		}
+
+		if req.UsePublicHost && h.cfg.PublicHost.CountLimit > 0 {
+			cnt, err := tx.VirtualMachine.Query().
+				Where(virtualmachine.UserID(u.ID)).
+				Where(virtualmachine.HasHostWith(host.HasUserWith(user.Role(consts.UserRoleAdmin)))).
+				Where(virtualmachine.ExpiredAtGT(time.Now())).
+				Count(ctx)
+			if err != nil {
+				return errcode.ErrDatabaseOperation.Wrap(err)
+			}
+			if cnt >= h.cfg.PublicHost.CountLimit {
+				return errcode.ErrPublicHostBeyondLimit.Wrap(fmt.Errorf("public host limit reached: %d", h.cfg.PublicHost.CountLimit))
+			}
+		}
+
+		var m *db.Model
+		if len(req.ModelID) > 0 {
+			switch req.ModelID {
+			case "economy":
+				m, err = tx.Model.Query().
+					WithPricing().
+					WithUser().
+					Where(model.HasUserWith(user.Role(consts.UserRoleAdmin))).
+					Where(model.Remark(req.ModelID)).
+					First(ctx)
+				if err != nil {
+					return err
+				}
+			default:
+				mid, err := uuid.Parse(req.ModelID)
+				if err != nil {
+					return err
+				}
+				m, err = tx.Model.Query().WithPricing().WithUser().Where(model.ID(mid)).First(ctx)
+				if err != nil {
+					return err
+				}
+			}
+
+			if m != nil {
+				if p := m.Edges.Pricing; p != nil {
+					apikey := uuid.NewString()
+					mak, err := tx.ModelApiKey.Create().
+						SetAPIKey(apikey).
+						SetUserID(u.ID).
+						SetModelID(m.ID).
+						SetVirtualmachineID(id).
+						Save(ctx)
+					if err != nil {
+						return err
+					}
+					m.Edges.Apikeys = append(m.Edges.Apikeys, mak)
+				}
+			}
+		}
+
+		repoURL := ""
+		repoFilename := ""
+		branch := ""
+		if req.RepoReq != nil {
+			repoURL = req.RepoReq.RepoURL
+			repoFilename = req.RepoReq.RepoFilename
+			branch = req.RepoReq.Branch
+		}
+
+		img, err := tx.Image.Get(ctx, req.ImageID)
+		if err != nil {
+			return err
+		}
+
+		var expiredAt *time.Time
+		if req.Life > 0 {
+			t := req.Now.Add(time.Duration(req.Life) * time.Second)
+			expiredAt = &t
+		}
+
+		crt := tx.VirtualMachine.Create().
+			SetID(id).
+			SetUserID(u.ID).
+			SetName(req.Name).
+			SetHostID(dbHost.ID).
+			SetCores(req.Resource.CPU).
+			SetMemory(req.Resource.Memory).
+			SetRepoURL(repoURL).
+			SetRepoFilename(repoFilename).
+			SetBranch(branch).
+			SetCreatedAt(req.Now)
+		if expiredAt != nil {
+			crt.SetExpiredAt(*expiredAt)
+		}
+		if len(req.ModelID) > 0 {
+			crt.SetModelID(m.ID)
+		}
+		if req.GitIdentityID != uuid.Nil {
+			crt.SetGitIdentityID(req.GitIdentityID)
+		}
+		if err := crt.Exec(ctx); err != nil {
+			return err
+		}
+
+		res = &domain.PreparedVirtualMachine{
+			VirtualMachine: &domain.VirtualMachine{
+				ID:              id,
+				Name:            req.Name,
+				LifeTimeSeconds: req.Life,
+				Host:            cvt.From(dbHost, &domain.Host{}),
+			},
+			Model: m,
+			Image: img,
+		}
+		return nil
+	})
+	return res, err
+}
+
+func (h *HostRepo) CompleteCreateVirtualMachine(ctx context.Context, id string, vm *taskflow.VirtualMachine) (*domain.VirtualMachine, error) {
+	var res *db.VirtualMachine
+	err := entx.WithTx2(ctx, h.db, func(tx *db.Tx) error {
+		up := tx.VirtualMachine.UpdateOneID(id).
+			SetEnvironmentID(vm.EnvironmentID)
+		if vm.AccessToken != "" {
+			up.SetAccessToken(vm.AccessToken)
+		}
+		if err := up.Exec(ctx); err != nil {
+			return err
+		}
+
+		var err error
+		res, err = tx.VirtualMachine.Query().
+			WithHost(func(hq *db.HostQuery) { hq.WithUser() }).
+			WithUser().
+			Where(virtualmachine.ID(id)).
+			First(ctx)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return cvt.From(res, &domain.VirtualMachine{}), nil
+}
+
 // DeleteVirtualMachine implements domain.HostRepo.
 func (h *HostRepo) DeleteVirtualMachine(ctx context.Context, uid uuid.UUID, hostID, id string, fn func(*db.VirtualMachine) error) error {
 	return entx.WithTx2(ctx, h.db, func(tx *db.Tx) error {

--- a/backend/biz/host/repo/host_delete_test.go
+++ b/backend/biz/host/repo/host_delete_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/db/enttest"
 	"github.com/chaitin/MonkeyCode/backend/db/virtualmachine"
+	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/pkg/entx"
 )
 
@@ -149,6 +150,69 @@ func TestHostRepo_CountDownQueriesUseExpiredAt(t *testing.T) {
 	}
 	if len(allCountdown) != 2 {
 		t.Fatalf("all countdown ids = %v, want vm-expiring and vm-old", vmIDs(allCountdown))
+	}
+}
+
+func TestHostRepo_PrepareCreateVirtualMachinePersistsBeforeTaskflowCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:host-prepare-create-vm-test?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	repo := &HostRepo{db: client}
+	uid := uuid.New()
+	imageID := uuid.New()
+	now := time.Now()
+
+	if _, err := client.User.Create().
+		SetID(uid).
+		SetName("tester").
+		SetRole(consts.UserRoleIndividual).
+		SetStatus(consts.UserStatusActive).
+		Save(ctx); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if _, err := client.Host.Create().
+		SetID("host-1").
+		SetUserID(uid).
+		SetHostname("host").
+		Save(ctx); err != nil {
+		t.Fatalf("create host: %v", err)
+	}
+	if _, err := client.Image.Create().
+		SetID(imageID).
+		SetUserID(uid).
+		SetName("image").
+		Save(ctx); err != nil {
+		t.Fatalf("create image: %v", err)
+	}
+
+	prepared, err := repo.PrepareCreateVirtualMachine(ctx, &domain.User{ID: uid}, &domain.CreateVMReq{
+		HostID:  "host-1",
+		ImageID: imageID,
+		Name:    "manual-vm",
+		Resource: &domain.Resource{
+			CPU:    2,
+			Memory: 4096,
+		},
+		Now: now,
+	}, "agent_preallocated")
+	if err != nil {
+		t.Fatalf("prepare create virtual machine: %v", err)
+	}
+	if prepared.VirtualMachine.ID != "agent_preallocated" {
+		t.Fatalf("prepared vm id = %q, want agent_preallocated", prepared.VirtualMachine.ID)
+	}
+
+	vm, err := client.VirtualMachine.Query().
+		Where(virtualmachine.ID("agent_preallocated")).
+		Only(ctx)
+	if err != nil {
+		t.Fatalf("query prepared vm before taskflow create: %v", err)
+	}
+	if vm.EnvironmentID != "" {
+		t.Fatalf("prepared vm environment_id = %q, want empty before taskflow create", vm.EnvironmentID)
 	}
 }
 

--- a/backend/biz/host/usecase/host.go
+++ b/backend/biz/host/usecase/host.go
@@ -412,110 +412,117 @@ func (h *HostUsecase) CreateVM(ctx context.Context, user *domain.User, req *doma
 	}
 
 	req.Now = time.Now()
-	vm, err := h.repo.CreateVirtualMachine(ctx, user, req, nil, func(model *db.Model, image *db.Image) (*domain.VirtualMachine, error) {
-		kind := taskflow.TTLCountDown
-		if req.Life == 0 {
-			kind = taskflow.TTLForever
-		}
-
-		h.logger.InfoContext(ctx, "create vm", "req", req, "kind", kind, "seconds", req.Life)
-
-		temperature := new(float32)
-		if model != nil {
-			if keys := model.Edges.Apikeys; len(keys) > 0 {
-				model.APIKey = keys[0].APIKey
-				model.BaseURL = h.cfg.LLMProxy.BaseURL + "/v1"
-			}
-		}
-		var LLMConfig taskflow.LLMProviderReq
-		if model != nil {
-			LLMConfig = taskflow.LLMProviderReq{
-				Provider:    taskflow.LlmProviderOpenAI,
-				ApiKey:      model.APIKey,
-				Model:       model.Model,
-				Temperature: temperature,
-				BaseURL:     model.BaseURL,
-			}
-		}
-
-		repoURL := ""
-		branch := ""
-		zipURL := ""
-		if req.RepoReq != nil {
-			repoURL = req.RepoReq.RepoURL
-			branch = req.RepoReq.Branch
-			zipURL = req.RepoReq.ZipURL
-		}
-
-		git := taskflow.Git{
-			URL:    repoURL,
-			Branch: branch,
-		}
-		if req.GitIdentityID != uuid.Nil {
-			identity, err := h.girepo.Get(ctx, req.GitIdentityID)
-			if err != nil {
-				return nil, fmt.Errorf("get git identity: %w", err)
-			}
-			t, err := h.tokenProvider.GetToken(ctx, req.GitIdentityID)
-			if err != nil {
-				return nil, fmt.Errorf("get git token: %w", err)
-			}
-			git.Token = t
-			git.Username = identity.Username
-			git.Email = identity.Email
-		}
-
-		tfvm, err := h.taskflow.VirtualMachiner().Create(
-			ctx,
-			&taskflow.CreateVirtualMachineReq{
-				UserID:              user.ID.String(),
-				HostID:              req.HostID,
-				Git:                 git,
-				ZipUrl:              zipURL,
-				ProxyURL:            "",
-				ImageURL:            image.Name,
-				LLM:                 LLMConfig,
-				Cores:               strconv.Itoa(req.Resource.CPU),
-				Memory:              uint64(req.Resource.Memory),
-				InstallCodingAgents: req.InstallCodingAgents,
-			})
-		if err != nil {
-			h.logger.ErrorContext(ctx, "failed to create vm", "error", err)
-			return nil, err
-		}
-		if tfvm == nil {
-			return nil, fmt.Errorf("failed to create vm, vm is nil")
-		}
-
-		h.logger.InfoContext(ctx, "create vm success", "vm_id", tfvm.ID, "environment_id", tfvm.EnvironmentID)
-
-		// 手动创建的 VM 使用 expired_at 过期逻辑，任务创建的 VM 使用空闲检测逻辑
-		// 通过 Life 参数区分：Life > 0 为手动创建的 VM，使用过期时间逻辑
-		if req.Life > 0 {
-			expiredAt := req.Now.Add(time.Duration(req.Life) * time.Second)
-			if _, err := h.vmexpireQueue.Enqueue(ctx, VM_EXPIRE_QUEUE_KEY, &domain.VmExpireInfo{
-				UID:    user.ID,
-				VmID:   tfvm.ID,
-				HostID: req.HostID,
-				EnvID:  tfvm.EnvironmentID,
-			}, expiredAt, tfvm.ID); err != nil {
-				h.logger.With("error", err, "vm_id", tfvm.ID, "environment_id", tfvm.EnvironmentID).ErrorContext(ctx, "failed to enqueue countdown vm")
-			}
-		}
-
-		return &domain.VirtualMachine{
-			ID:            tfvm.ID,
-			AccessToken:   tfvm.AccessToken,
-			EnvironmentID: tfvm.EnvironmentID,
-			Name:          req.Name,
-			Host: &domain.Host{
-				ID: req.HostID,
-			},
-			LifeTimeSeconds: req.Life,
-		}, nil
-	})
+	vmID := fmt.Sprintf("agent_%s", uuid.NewString())
+	prepared, err := h.repo.PrepareCreateVirtualMachine(ctx, user, req, vmID)
 	if err != nil {
 		return nil, err
+	}
+	if prepared == nil || prepared.VirtualMachine == nil || prepared.Image == nil {
+		return nil, fmt.Errorf("failed to prepare vm")
+	}
+
+	kind := taskflow.TTLCountDown
+	if req.Life == 0 {
+		kind = taskflow.TTLForever
+	}
+
+	h.logger.InfoContext(ctx, "create vm", "req", req, "kind", kind, "seconds", req.Life, "vm_id", vmID)
+
+	model := prepared.Model
+	image := prepared.Image
+	temperature := new(float32)
+	if model != nil {
+		if keys := model.Edges.Apikeys; len(keys) > 0 {
+			model.APIKey = keys[0].APIKey
+			model.BaseURL = h.cfg.LLMProxy.BaseURL + "/v1"
+		}
+	}
+	var LLMConfig taskflow.LLMProviderReq
+	if model != nil {
+		LLMConfig = taskflow.LLMProviderReq{
+			Provider:    taskflow.LlmProviderOpenAI,
+			ApiKey:      model.APIKey,
+			Model:       model.Model,
+			Temperature: temperature,
+			BaseURL:     model.BaseURL,
+		}
+	}
+
+	repoURL := ""
+	branch := ""
+	zipURL := ""
+	if req.RepoReq != nil {
+		repoURL = req.RepoReq.RepoURL
+		branch = req.RepoReq.Branch
+		zipURL = req.RepoReq.ZipURL
+	}
+
+	git := taskflow.Git{
+		URL:    repoURL,
+		Branch: branch,
+	}
+	if req.GitIdentityID != uuid.Nil {
+		identity, err := h.girepo.Get(ctx, req.GitIdentityID)
+		if err != nil {
+			return nil, fmt.Errorf("get git identity: %w", err)
+		}
+		t, err := h.tokenProvider.GetToken(ctx, req.GitIdentityID)
+		if err != nil {
+			return nil, fmt.Errorf("get git token: %w", err)
+		}
+		git.Token = t
+		git.Username = identity.Username
+		git.Email = identity.Email
+	}
+
+	tfvm, err := h.taskflow.VirtualMachiner().Create(
+		ctx,
+		&taskflow.CreateVirtualMachineReq{
+			ID:                  vmID,
+			UserID:              user.ID.String(),
+			HostID:              req.HostID,
+			Git:                 git,
+			ZipUrl:              zipURL,
+			ProxyURL:            "",
+			ImageURL:            image.Name,
+			LLM:                 LLMConfig,
+			Cores:               strconv.Itoa(req.Resource.CPU),
+			Memory:              uint64(req.Resource.Memory),
+			InstallCodingAgents: req.InstallCodingAgents,
+		})
+	if err != nil {
+		h.logger.ErrorContext(ctx, "failed to create vm", "error", err, "vm_id", vmID)
+		return nil, err
+	}
+	if tfvm == nil {
+		return nil, fmt.Errorf("failed to create vm, vm is nil")
+	}
+	if tfvm.ID == "" {
+		tfvm.ID = vmID
+	}
+	if tfvm.ID != vmID {
+		return nil, fmt.Errorf("taskflow returned vm id %s, want %s", tfvm.ID, vmID)
+	}
+
+	h.logger.InfoContext(ctx, "create vm success", "vm_id", tfvm.ID, "environment_id", tfvm.EnvironmentID)
+
+	vm, err := h.repo.CompleteCreateVirtualMachine(ctx, vmID, tfvm)
+	if err != nil {
+		return nil, err
+	}
+
+	// 手动创建的 VM 使用 expired_at 过期逻辑，任务创建的 VM 使用空闲检测逻辑
+	// 通过 Life 参数区分：Life > 0 为手动创建的 VM，使用过期时间逻辑
+	if req.Life > 0 {
+		expiredAt := req.Now.Add(time.Duration(req.Life) * time.Second)
+		if _, err := h.vmexpireQueue.Enqueue(ctx, VM_EXPIRE_QUEUE_KEY, &domain.VmExpireInfo{
+			UID:    user.ID,
+			VmID:   tfvm.ID,
+			HostID: req.HostID,
+			EnvID:  tfvm.EnvironmentID,
+		}, expiredAt, tfvm.ID); err != nil {
+			h.logger.With("error", err, "vm_id", tfvm.ID, "environment_id", tfvm.EnvironmentID).ErrorContext(ctx, "failed to enqueue countdown vm")
+		}
 	}
 	if vm == nil {
 		return nil, fmt.Errorf("failed to create vm")

--- a/backend/biz/host/usecase/host_test.go
+++ b/backend/biz/host/usecase/host_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/url"
@@ -14,7 +15,9 @@ import (
 	"github.com/google/uuid"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/redis/go-redis/v9"
+	"github.com/samber/do"
 
+	"github.com/chaitin/MonkeyCode/backend/biz/host/repo"
 	"github.com/chaitin/MonkeyCode/backend/config"
 	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/db"
@@ -334,6 +337,79 @@ func TestHostUsecase_markRecycledTasksFinished(t *testing.T) {
 	}
 }
 
+func TestHostUsecase_CreateVMPreinsertsVirtualMachineBeforeTaskflowCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:host-usecase-create-vm-preinsert-test?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	userID := uuid.New()
+	imageID := uuid.New()
+	if _, err := client.User.Create().
+		SetID(userID).
+		SetName("tester").
+		SetRole(consts.UserRoleIndividual).
+		SetStatus(consts.UserStatusActive).
+		Save(ctx); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if _, err := client.Host.Create().
+		SetID("host-1").
+		SetUserID(userID).
+		SetHostname("host").
+		Save(ctx); err != nil {
+		t.Fatalf("create host: %v", err)
+	}
+	if _, err := client.Image.Create().
+		SetID(imageID).
+		SetUserID(userID).
+		SetName("image").
+		Save(ctx); err != nil {
+		t.Fatalf("create image: %v", err)
+	}
+
+	i := do.New()
+	do.ProvideValue(i, &config.Config{})
+	do.ProvideValue(i, client)
+	do.ProvideValue(i, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	do.ProvideValue(i, rdb)
+	hostRepo, err := repo.NewHostRepo(i)
+	if err != nil {
+		t.Fatalf("new host repo: %v", err)
+	}
+
+	vmCreate := &preinsertVMCreateStub{db: client}
+	u := &HostUsecase{
+		cfg:      &config.Config{},
+		repo:     hostRepo,
+		taskflow: &preinsertTaskflowStub{vm: vmCreate},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	vm, err := u.CreateVM(ctx, &domain.User{ID: userID}, &domain.CreateVMReq{
+		HostID:  "host-1",
+		ImageID: imageID,
+		Name:    "manual-vm",
+		Resource: &domain.Resource{
+			CPU:    2,
+			Memory: 4096,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateVM() error = %v", err)
+	}
+	if vmCreate.seenID == "" {
+		t.Fatal("expected taskflow create to receive preallocated vm id")
+	}
+	if vm.ID != vmCreate.seenID {
+		t.Fatalf("created vm id = %q, want %q", vm.ID, vmCreate.seenID)
+	}
+}
+
 type hostTaskRepoStub struct {
 	client     *db.Client
 	updatedIDs []uuid.UUID
@@ -374,6 +450,14 @@ func (s *hostTaskRepoStub) Create(context.Context, *domain.User, domain.CreateTa
 	panic("unexpected call to Create")
 }
 
+func (s *hostTaskRepoStub) PrepareCreate(context.Context, *domain.User, domain.CreateTaskReq, string, string) (*domain.PreparedProjectTask, error) {
+	panic("unexpected call to PrepareCreate")
+}
+
+func (s *hostTaskRepoStub) CompleteCreate(context.Context, string, *taskflow.VirtualMachine) error {
+	panic("unexpected call to CompleteCreate")
+}
+
 func (s *hostTaskRepoStub) Update(ctx context.Context, _ *domain.User, id uuid.UUID, fn func(up *db.TaskUpdateOne) error) error {
 	s.updatedIDs = append(s.updatedIDs, id)
 	up := s.client.Task.UpdateOneID(id)
@@ -409,4 +493,86 @@ func (s *hostTaskRepoStub) FinishModelSwitch(context.Context, uuid.UUID, bool, s
 
 func (s *hostTaskRepoStub) CompleteModelSwitch(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, bool, string, string) error {
 	panic("unexpected call to CompleteModelSwitch")
+}
+
+type preinsertTaskflowStub struct {
+	vm taskflow.VirtualMachiner
+}
+
+func (s *preinsertTaskflowStub) VirtualMachiner() taskflow.VirtualMachiner { return s.vm }
+func (s *preinsertTaskflowStub) Host() taskflow.Hoster {
+	return preinsertHosterStub{}
+}
+func (s *preinsertTaskflowStub) FileManager() taskflow.FileManager     { return nil }
+func (s *preinsertTaskflowStub) TaskManager() taskflow.TaskManager     { return nil }
+func (s *preinsertTaskflowStub) PortForwarder() taskflow.PortForwarder { return nil }
+func (s *preinsertTaskflowStub) Stats(context.Context) (*taskflow.Stats, error) {
+	return nil, nil
+}
+func (s *preinsertTaskflowStub) TaskLive(context.Context, string, bool, func(*taskflow.TaskChunk) error) error {
+	return nil
+}
+
+type preinsertHosterStub struct{}
+
+func (preinsertHosterStub) List(context.Context, string) (map[string]*taskflow.Host, error) {
+	return nil, nil
+}
+func (preinsertHosterStub) IsOnline(_ context.Context, req *taskflow.IsOnlineReq[string]) (*taskflow.IsOnlineResp, error) {
+	online := make(map[string]bool, len(req.IDs))
+	for _, id := range req.IDs {
+		online[id] = true
+	}
+	return &taskflow.IsOnlineResp{OnlineMap: online}, nil
+}
+
+type preinsertVMCreateStub struct {
+	db     *db.Client
+	seenID string
+}
+
+func (s *preinsertVMCreateStub) Create(ctx context.Context, req *taskflow.CreateVirtualMachineReq) (*taskflow.VirtualMachine, error) {
+	if req.ID == "" {
+		return nil, fmt.Errorf("taskflow create req id is empty")
+	}
+	if _, err := s.db.VirtualMachine.Get(ctx, req.ID); err != nil {
+		return nil, fmt.Errorf("virtual machine %s not visible before taskflow create: %w", req.ID, err)
+	}
+	s.seenID = req.ID
+	return &taskflow.VirtualMachine{
+		ID:            req.ID,
+		AccessToken:   "access-" + req.ID,
+		EnvironmentID: "env-" + req.ID,
+		HostID:        req.HostID,
+	}, nil
+}
+func (s *preinsertVMCreateStub) Delete(context.Context, *taskflow.DeleteVirtualMachineReq) error {
+	return nil
+}
+func (s *preinsertVMCreateStub) Hibernate(context.Context, *taskflow.HibernateVirtualMachineReq) error {
+	return nil
+}
+func (s *preinsertVMCreateStub) Resume(context.Context, *taskflow.ResumeVirtualMachineReq) error {
+	return nil
+}
+func (s *preinsertVMCreateStub) List(context.Context, string) ([]*taskflow.VirtualMachine, error) {
+	return nil, nil
+}
+func (s *preinsertVMCreateStub) Info(context.Context, taskflow.VirtualMachineInfoReq) (*taskflow.VirtualMachine, error) {
+	return nil, nil
+}
+func (s *preinsertVMCreateStub) Terminal(context.Context, *taskflow.TerminalReq) (taskflow.Sheller, error) {
+	return nil, nil
+}
+func (s *preinsertVMCreateStub) Reports(context.Context, taskflow.ReportSubscribeReq) (taskflow.Reporter, error) {
+	return nil, nil
+}
+func (s *preinsertVMCreateStub) TerminalList(context.Context, string) ([]*taskflow.Terminal, error) {
+	return nil, nil
+}
+func (s *preinsertVMCreateStub) CloseTerminal(context.Context, *taskflow.CloseTerminalReq) error {
+	return nil
+}
+func (s *preinsertVMCreateStub) IsOnline(context.Context, *taskflow.IsOnlineReq[string]) (*taskflow.IsOnlineResp, error) {
+	return nil, nil
 }

--- a/backend/biz/task/repo/task.go
+++ b/backend/biz/task/repo/task.go
@@ -505,3 +505,146 @@ func (t *TaskRepo) Create(ctx context.Context, u *domain.User, req domain.Create
 
 	return res, err
 }
+
+func (t *TaskRepo) PrepareCreate(ctx context.Context, u *domain.User, req domain.CreateTaskReq, token, vmID string) (*domain.PreparedProjectTask, error) {
+	resource := req.Resource
+
+	var res *domain.PreparedProjectTask
+	err := entx.WithTx2(ctx, t.db, func(tx *db.Tx) error {
+		h, err := tx.Host.Query().Where(host.ID(req.HostID)).First(ctx)
+		if err != nil {
+			return err
+		}
+
+		if req.UsePublicHost {
+			cnt, err := tx.VirtualMachine.Query().
+				Where(virtualmachine.UserID(u.ID)).
+				Where(virtualmachine.HasHostWith(host.HasUserWith(user.Role(consts.UserRoleAdmin)))).
+				Where(virtualmachine.ExpiredAtGT(time.Now())).
+				Count(ctx)
+			if err != nil {
+				return errcode.ErrDatabaseOperation.Wrap(err)
+			}
+			if cnt >= t.cfg.PublicHost.CountLimit {
+				return errcode.ErrPublicHostBeyondLimit.Wrap(fmt.Errorf("public host limit reached"))
+			}
+		}
+
+		mid, err := uuid.Parse(req.ModelID)
+		if err != nil {
+			return errcode.ErrModelAccessDenied.Wrap(err)
+		}
+		m, err := tx.Model.Query().
+			WithPricing().
+			WithUser().
+			Where(model.ID(mid)).
+			First(ctx)
+		if err != nil {
+			return err
+		}
+
+		apikey := uuid.NewString()
+		mak, err := tx.ModelApiKey.Create().
+			SetID(uuid.New()).
+			SetAPIKey(apikey).
+			SetUserID(u.ID).
+			SetModelID(m.ID).
+			SetVirtualmachineID(vmID).
+			Save(ctx)
+		if err != nil {
+			return err
+		}
+		m.Edges.Apikeys = append(m.Edges.Apikeys, mak)
+
+		img, err := tx.Image.Query().Where(image.ID(req.ImageID)).First(ctx)
+		if err != nil {
+			return err
+		}
+
+		id := uuid.New()
+		tk, err := tx.Task.Create().
+			SetID(id).
+			SetKind(req.Type).
+			SetSubType(req.SubType).
+			SetContent(req.Content).
+			SetUserID(u.ID).
+			SetStatus(consts.TaskStatusPending).
+			SetLogStore(consts.LogStoreClickHouse).
+			Save(ctx)
+		if err != nil {
+			return err
+		}
+
+		if tk == nil {
+			return fmt.Errorf("created task is nil")
+		}
+
+		crt := tx.ProjectTask.Create().
+			SetID(uuid.New()).
+			SetImageID(img.ID).
+			SetModelID(m.ID).
+			SetTaskID(tk.ID).
+			SetRepoURL(req.RepoReq.RepoURL).
+			SetRepoFilename(req.RepoReq.RepoFilename).
+			SetBranch(req.RepoReq.Branch).
+			SetCliName(req.CliName)
+
+		if req.GitIdentityID != uuid.Nil {
+			crt.SetGitIdentityID(req.GitIdentityID)
+		}
+		if req.Extra.ProjectID != uuid.Nil {
+			crt.SetProjectID(req.Extra.ProjectID)
+		}
+		if req.Extra.IssueID != uuid.Nil {
+			crt.SetIssueID(req.Extra.IssueID)
+		}
+		pt, err := crt.Save(ctx)
+		if err != nil {
+			return err
+		}
+		pt.Edges.Task = tk
+		pt.Edges.Model = m
+		pt.Edges.Image = img
+
+		vmCrt := tx.VirtualMachine.Create().
+			SetID(vmID).
+			SetUserID(u.ID).
+			SetName(fmt.Sprintf("task-%s", id.String())).
+			SetHostID(h.ID).
+			SetCores(resource.Core).
+			SetMemory(int64(resource.Memory)).
+			SetModelID(m.ID).
+			SetCreatedAt(req.Now).
+			SetRepoURL(req.RepoReq.RepoURL).
+			SetRepoFilename(req.RepoReq.RepoFilename).
+			SetBranch(req.RepoReq.Branch)
+		if err := vmCrt.Exec(ctx); err != nil {
+			return fmt.Errorf("failed to create virtual machine %s", err)
+		}
+
+		tvm := tx.TaskVirtualMachine.Create().
+			SetID(uuid.New()).
+			SetTaskID(tk.ID).
+			SetVirtualmachineID(vmID)
+		if err := tvm.Exec(ctx); err != nil {
+			return err
+		}
+
+		res = &domain.PreparedProjectTask{
+			ProjectTask: pt,
+			Model:       m,
+			Image:       img,
+		}
+		return nil
+	})
+	return res, err
+}
+
+func (t *TaskRepo) CompleteCreate(ctx context.Context, vmID string, vm *taskflow.VirtualMachine) error {
+	up := t.db.VirtualMachine.UpdateOneID(vmID).
+		SetEnvironmentID(vm.EnvironmentID)
+	if vm.AccessToken != "" {
+		up.SetAccessToken(vm.AccessToken)
+	}
+	return up.Exec(ctx)
+}

--- a/backend/biz/task/repo/task_create_test.go
+++ b/backend/biz/task/repo/task_create_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/db/enttest"
 	"github.com/chaitin/MonkeyCode/backend/db/modelapikey"
+	"github.com/chaitin/MonkeyCode/backend/db/taskvirtualmachine"
+	"github.com/chaitin/MonkeyCode/backend/db/virtualmachine"
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
 )
@@ -78,6 +80,78 @@ func TestTaskRepoCreateCreatesModelApiKeyWithoutPricing(t *testing.T) {
 	}
 	if keys[0].VirtualmachineID != vmID {
 		t.Fatalf("virtualmachine id = %q, want %q", keys[0].VirtualmachineID, vmID)
+	}
+}
+
+func TestTaskRepoPrepareCreatePersistsVirtualMachineBeforeTaskflowCreate(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:task-repo-prepare-create-vm-test?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	userID := uuid.New()
+	modelID := uuid.New()
+	imageID := uuid.New()
+	hostID := "host-task-prepare"
+	vmID := "agent_preallocated"
+
+	if _, err := client.User.Create().SetID(userID).SetName("user").SetRole(consts.UserRoleIndividual).SetStatus(consts.UserStatusActive).Save(ctx); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if _, err := client.Host.Create().SetID(hostID).SetUserID(userID).Save(ctx); err != nil {
+		t.Fatalf("create host: %v", err)
+	}
+	if _, err := client.Model.Create().SetID(modelID).SetUserID(userID).SetProvider("OpenAI").SetAPIKey("secret").SetBaseURL("https://api.example.com").SetModel("gpt-4o").Save(ctx); err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+	if _, err := client.Image.Create().SetID(imageID).SetUserID(userID).SetName("image").Save(ctx); err != nil {
+		t.Fatalf("create image: %v", err)
+	}
+
+	repo := &TaskRepo{
+		cfg:    &config.Config{},
+		db:     client,
+		logger: slog.Default(),
+	}
+	req := domain.CreateTaskReq{
+		Content: "content",
+		HostID:  hostID,
+		ImageID: imageID,
+		ModelID: modelID.String(),
+		Resource: &domain.VMResource{
+			Core:   1,
+			Memory: 1024,
+		},
+		Type: consts.TaskTypeDevelop,
+		Now:  time.Now(),
+	}
+
+	prepared, err := repo.PrepareCreate(ctx, &domain.User{ID: userID}, req, "", vmID)
+	if err != nil {
+		t.Fatalf("PrepareCreate() error = %v", err)
+	}
+	if prepared.ProjectTask.Edges.Task == nil {
+		t.Fatal("prepared project task missing task edge")
+	}
+
+	vm, err := client.VirtualMachine.Query().Where(virtualmachine.ID(vmID)).Only(ctx)
+	if err != nil {
+		t.Fatalf("query prepared vm: %v", err)
+	}
+	if vm.EnvironmentID != "" {
+		t.Fatalf("prepared vm environment_id = %q, want empty before taskflow create", vm.EnvironmentID)
+	}
+	if _, err := client.TaskVirtualMachine.Query().
+		Where(taskvirtualmachine.VirtualmachineIDEQ(vmID), taskvirtualmachine.TaskID(prepared.ProjectTask.TaskID)).
+		Only(ctx); err != nil {
+		t.Fatalf("query task vm relation: %v", err)
+	}
+
+	keys, err := client.ModelApiKey.Query().Where(modelapikey.ModelID(modelID), modelapikey.UserID(userID)).All(ctx)
+	if err != nil {
+		t.Fatalf("query model api keys: %v", err)
+	}
+	if len(keys) != 1 || keys[0].VirtualmachineID != vmID {
+		t.Fatalf("model api keys = %#v, want one key bound to %s", keys, vmID)
 	}
 }
 

--- a/backend/biz/task/usecase/task.go
+++ b/backend/biz/task/usecase/task.go
@@ -18,13 +18,13 @@ import (
 	"github.com/samber/do"
 
 	"github.com/chaitin/MonkeyCode/backend/biz/agentresource"
-	"github.com/chaitin/MonkeyCode/backend/db/teammember"
 	gituc "github.com/chaitin/MonkeyCode/backend/biz/git/usecase"
 	"github.com/chaitin/MonkeyCode/backend/biz/task/service"
 	vmidle "github.com/chaitin/MonkeyCode/backend/biz/vmidle/usecase"
 	"github.com/chaitin/MonkeyCode/backend/config"
 	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/db/teammember"
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/errcode"
 	"github.com/chaitin/MonkeyCode/backend/pkg/cvt"
@@ -535,112 +535,124 @@ func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.
 	}
 	ctx = entx.WithTaskConcurrencyLimit(ctx, limit)
 
-	var createdVm *taskflow.VirtualMachine
-	pt, err := a.repo.Create(ctx, user, req, token, func(pt *db.ProjectTask, m *db.Model, i *db.Image) (*taskflow.VirtualMachine, error) {
-		t := pt.Edges.Task
-		if t == nil {
-			return nil, fmt.Errorf("task edge is nil")
-		}
-		if git.URL == "" {
-			git.URL = pt.RepoURL
-		}
-		// Codeup 仓库 URL 必须带 .git 后缀才能 clone，做一次兜底归一化
-		// （覆盖用户手输仓库地址未带后缀的场景）
-		git.URL = giturl.NormalizeCloneURL(git.URL)
-
-		var token string
-		if keys := m.Edges.Apikeys; len(keys) > 0 {
-			m.APIKey = keys[0].APIKey
-			m.BaseURL = a.cfg.LLMProxy.BaseURL + "/v1"
-			token = keys[0].APIKey
-		}
-
-		coding, configs, agentRes, err := a.getCodingConfigs(ctx, req.CliName, m, req.Extra.SkillIDs, req.Extra.PluginIDs, a.userScope(ctx, user))
-		if err != nil {
-			return nil, err
-		}
-
-		vm, err := a.taskflow.VirtualMachiner().Create(ctx, &taskflow.CreateVirtualMachineReq{
-			UserID:   user.ID.String(),
-			HostID:   req.HostID,
-			HostName: t.ID.String(),
-			Git:      git,
-			ZipUrl:   req.RepoReq.ZipURL,
-			ImageURL: cmp.Or(imageName, i.Name),
-			ProxyURL: "",
-			TaskID:   t.ID,
-			LLM: taskflow.LLMProviderReq{
-				Provider: taskflow.LlmProviderOpenAI,
-				ApiKey:   m.APIKey,
-				BaseURL:  m.BaseURL,
-				Model:    m.Model,
-			},
-			Cores:    "2",
-			Memory:   8 << 30,
-			Envs:     env,
-			LogStore: normalizeTaskLogStore(t.LogStore),
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		if vm == nil {
-			return nil, fmt.Errorf("vm is nil")
-		}
-		createdVm = vm
-
-		mcps := a.buildMCPConfigs(t.ID, token)
-
-		// DEBUG: 把准备透传给 taskflow → codingmatrix 的整组 ConfigFile
-		// marshal 成一个 JSON 串、一行日志打出来。仅在 DEBUG 级别开启，
-		// 生产无噪声。
-		if a.logger.Enabled(ctx, slog.LevelDebug) {
-			if payload, err := json.Marshal(configs); err != nil {
-				a.logger.WarnContext(ctx, "tasker configs marshal failed",
-					slog.String("task_id", t.ID.String()),
-					slog.Any("err", err))
-			} else {
-				a.logger.DebugContext(ctx, "tasker configs",
-					slog.String("task_id", t.ID.String()),
-					slog.Int("count", len(configs)),
-					slog.String("configs", string(payload)),
-				)
-			}
-		}
-
-		// 存储 CreateTaskReq 到 Redis（10 分钟过期），供 Lifecycle Manager 消费
-		createTaskReq := &taskflow.CreateTaskReq{
-			ID:           t.ID,
-			VMID:         vm.ID,
-			Text:         req.Content,
-			Attachments:  taskAttachmentsToTaskflow(req.Attachments),
-			SystemPrompt: req.SystemPrompt,
-			CodingAgent:  coding,
-			LLM: taskflow.LLM{
-				ApiKey:  m.APIKey,
-				BaseURL: m.BaseURL,
-				Model:   m.Model,
-				ApiType: m.InterfaceType,
-			},
-			Configs:        configs,
-			McpConfigs:     mcps,
-			LogStore:       normalizeTaskLogStore(t.LogStore),
-			AgentResources: agentRes,
-		}
-		b, err := json.Marshal(createTaskReq)
-		if err != nil {
-			return vm, err
-		}
-		reqKey := fmt.Sprintf("task:create_req:%s", t.ID.String())
-		if err := a.redis.Set(ctx, reqKey, string(b), createReqTTL(a.cfg)).Err(); err != nil {
-			a.logger.WarnContext(ctx, "failed to store CreateTaskReq in Redis", "error", err)
-		}
-
-		return vm, nil
-	})
+	vmID := fmt.Sprintf("agent_%s", uuid.NewString())
+	prepared, err := a.repo.PrepareCreate(ctx, user, req, token, vmID)
 	if err != nil {
 		a.logger.With("error", err, "req", req).ErrorContext(ctx, "failed to create task")
 		return nil, err
+	}
+	if prepared == nil || prepared.ProjectTask == nil || prepared.Model == nil || prepared.Image == nil {
+		return nil, fmt.Errorf("failed to prepare task")
+	}
+	pt := prepared.ProjectTask
+	m := prepared.Model
+	i := prepared.Image
+	t := pt.Edges.Task
+	if t == nil {
+		return nil, fmt.Errorf("task edge is nil")
+	}
+	if git.URL == "" {
+		git.URL = pt.RepoURL
+	}
+	// Codeup 仓库 URL 必须带 .git 后缀才能 clone，做一次兜底归一化
+	// （覆盖用户手输仓库地址未带后缀的场景）
+	git.URL = giturl.NormalizeCloneURL(git.URL)
+
+	var runtimeToken string
+	if keys := m.Edges.Apikeys; len(keys) > 0 {
+		m.APIKey = keys[0].APIKey
+		m.BaseURL = a.cfg.LLMProxy.BaseURL + "/v1"
+		runtimeToken = keys[0].APIKey
+	}
+
+	coding, configs, agentRes, err := a.getCodingConfigs(ctx, req.CliName, m, req.Extra.SkillIDs, req.Extra.PluginIDs, a.userScope(ctx, user))
+	if err != nil {
+		return nil, err
+	}
+
+	createdVm, err := a.taskflow.VirtualMachiner().Create(ctx, &taskflow.CreateVirtualMachineReq{
+		ID:       vmID,
+		UserID:   user.ID.String(),
+		HostID:   req.HostID,
+		HostName: t.ID.String(),
+		Git:      git,
+		ZipUrl:   req.RepoReq.ZipURL,
+		ImageURL: cmp.Or(imageName, i.Name),
+		ProxyURL: "",
+		TaskID:   t.ID,
+		LLM: taskflow.LLMProviderReq{
+			Provider: taskflow.LlmProviderOpenAI,
+			ApiKey:   m.APIKey,
+			BaseURL:  m.BaseURL,
+			Model:    m.Model,
+		},
+		Cores:    "2",
+		Memory:   8 << 30,
+		Envs:     env,
+		LogStore: normalizeTaskLogStore(t.LogStore),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if createdVm == nil {
+		return nil, fmt.Errorf("vm is nil")
+	}
+	if createdVm.ID == "" {
+		createdVm.ID = vmID
+	}
+	if createdVm.ID != vmID {
+		return nil, fmt.Errorf("taskflow returned vm id %s, want %s", createdVm.ID, vmID)
+	}
+	if err := a.repo.CompleteCreate(ctx, vmID, createdVm); err != nil {
+		return nil, err
+	}
+
+	mcps := a.buildMCPConfigs(t.ID, runtimeToken)
+
+	// DEBUG: 把准备透传给 taskflow → codingmatrix 的整组 ConfigFile
+	// marshal 成一个 JSON 串、一行日志打出来。仅在 DEBUG 级别开启，
+	// 生产无噪声。
+	if a.logger.Enabled(ctx, slog.LevelDebug) {
+		if payload, err := json.Marshal(configs); err != nil {
+			a.logger.WarnContext(ctx, "tasker configs marshal failed",
+				slog.String("task_id", t.ID.String()),
+				slog.Any("err", err))
+		} else {
+			a.logger.DebugContext(ctx, "tasker configs",
+				slog.String("task_id", t.ID.String()),
+				slog.Int("count", len(configs)),
+				slog.String("configs", string(payload)),
+			)
+		}
+	}
+
+	// 存储 CreateTaskReq 到 Redis（10 分钟过期），供 Lifecycle Manager 消费
+	createTaskReq := &taskflow.CreateTaskReq{
+		ID:           t.ID,
+		VMID:         createdVm.ID,
+		Text:         req.Content,
+		Attachments:  taskAttachmentsToTaskflow(req.Attachments),
+		SystemPrompt: req.SystemPrompt,
+		CodingAgent:  coding,
+		LLM: taskflow.LLM{
+			ApiKey:  m.APIKey,
+			BaseURL: m.BaseURL,
+			Model:   m.Model,
+			ApiType: m.InterfaceType,
+		},
+		Configs:        configs,
+		McpConfigs:     mcps,
+		LogStore:       normalizeTaskLogStore(t.LogStore),
+		AgentResources: agentRes,
+	}
+	b, err := json.Marshal(createTaskReq)
+	if err != nil {
+		return nil, err
+	}
+	reqKey := fmt.Sprintf("task:create_req:%s", t.ID.String())
+	if err := a.redis.Set(ctx, reqKey, string(b), createReqTTL(a.cfg)).Err(); err != nil {
+		a.logger.WarnContext(ctx, "failed to store CreateTaskReq in Redis", "error", err)
 	}
 	a.logger.With("req", req).InfoContext(ctx, "task created")
 	taskMeta := lifecycle.TaskMetadata{
@@ -665,11 +677,11 @@ func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.
 	if err := a.IncrUserInputCount(ctx, user.ID, pt.Edges.Task.ID); err != nil {
 		a.logger.WarnContext(ctx, "failed to incr user input count on create", "error", err)
 	}
-	vmID := ""
+	refreshVMID := ""
 	if createdVm != nil {
-		vmID = createdVm.ID
+		refreshVMID = createdVm.ID
 	}
-	a.refreshCreatedTaskState(ctx, pt.TaskID, vmID)
+	a.refreshCreatedTaskState(ctx, pt.TaskID, refreshVMID)
 
 	result := cvt.From(pt, &domain.ProjectTask{})
 

--- a/backend/biz/task/usecase/task_create_vm_preinsert_test.go
+++ b/backend/biz/task/usecase/task_create_vm_preinsert_test.go
@@ -1,0 +1,197 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/redis/go-redis/v9"
+	"github.com/samber/do"
+
+	taskrepo "github.com/chaitin/MonkeyCode/backend/biz/task/repo"
+	vmidle "github.com/chaitin/MonkeyCode/backend/biz/vmidle/usecase"
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/db/enttest"
+	"github.com/chaitin/MonkeyCode/backend/db/taskvirtualmachine"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/pkg/lifecycle"
+	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
+)
+
+func TestTaskUsecaseCreatePreinsertsVirtualMachineBeforeTaskflowCreate(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:task-usecase-create-vm-preinsert-test?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	userID := uuid.New()
+	modelID := uuid.New()
+	imageID := uuid.New()
+	hostID := "host-task-usecase-preinsert"
+	if _, err := client.User.Create().SetID(userID).SetName("user").SetRole(consts.UserRoleIndividual).SetStatus(consts.UserStatusActive).Save(ctx); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if _, err := client.Host.Create().SetID(hostID).SetUserID(userID).Save(ctx); err != nil {
+		t.Fatalf("create host: %v", err)
+	}
+	if _, err := client.Model.Create().SetID(modelID).SetUserID(userID).SetProvider("OpenAI").SetAPIKey("secret").SetBaseURL("https://api.example.com").SetModel("gpt-4o").Save(ctx); err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+	if _, err := client.Image.Create().SetID(imageID).SetUserID(userID).SetName("image").Save(ctx); err != nil {
+		t.Fatalf("create image: %v", err)
+	}
+
+	vmCreate := &taskPreinsertVMCreateStub{db: client}
+	cfg := &config.Config{}
+	cfg.LLMProxy.BaseURL = "https://llm-proxy.example.com"
+	i := do.New()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	do.ProvideValue(i, cfg)
+	do.ProvideValue(i, client)
+	do.ProvideValue(i, logger)
+	taskRepo, err := taskrepo.NewTaskRepo(i)
+	if err != nil {
+		t.Fatalf("new task repo: %v", err)
+	}
+	uc := &TaskUsecase{
+		cfg:                   cfg,
+		repo:                  taskRepo,
+		logger:                logger,
+		taskflow:              &taskPreinsertTaskflowStub{vm: vmCreate},
+		redis:                 rdb,
+		taskLifecycle:         lifecycle.NewManager[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata](rdb, lifecycle.WithTransitions[uuid.UUID, consts.TaskStatus, lifecycle.TaskMetadata](lifecycle.TaskTransitions())),
+		vmLifecycle:           lifecycle.NewManager[string, lifecycle.VMState, lifecycle.VMMetadata](rdb, lifecycle.WithTransitions[string, lifecycle.VMState, lifecycle.VMMetadata](lifecycle.VMTransitions())),
+		taskActivityRefresher: noopTaskActivityRefresher{},
+		idleRefresher:         noopVMIdleRefresher{},
+		dbClient:              client,
+	}
+
+	_, err = uc.Create(ctx, &domain.User{ID: userID}, domain.CreateTaskReq{
+		Content: "content",
+		HostID:  hostID,
+		ImageID: imageID,
+		ModelID: modelID.String(),
+		CliName: consts.CliNameCodex,
+		Resource: &domain.VMResource{
+			Core:   1,
+			Memory: 1024,
+		},
+		Type: consts.TaskTypeDevelop,
+		RepoReq: domain.TaskRepoReq{
+			RepoURL: "https://example.com/repo.git",
+			Branch:  "main",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if vmCreate.seenID == "" {
+		t.Fatal("expected taskflow create to receive preallocated vm id")
+	}
+}
+
+type taskPreinsertTaskflowStub struct {
+	vm taskflow.VirtualMachiner
+}
+
+func (s *taskPreinsertTaskflowStub) VirtualMachiner() taskflow.VirtualMachiner { return s.vm }
+func (s *taskPreinsertTaskflowStub) Host() taskflow.Hoster                     { return taskPreinsertHosterStub{} }
+func (s *taskPreinsertTaskflowStub) FileManager() taskflow.FileManager         { return nil }
+func (s *taskPreinsertTaskflowStub) TaskManager() taskflow.TaskManager         { return nil }
+func (s *taskPreinsertTaskflowStub) PortForwarder() taskflow.PortForwarder     { return nil }
+func (s *taskPreinsertTaskflowStub) Stats(context.Context) (*taskflow.Stats, error) {
+	return nil, nil
+}
+func (s *taskPreinsertTaskflowStub) TaskLive(context.Context, string, bool, func(*taskflow.TaskChunk) error) error {
+	return nil
+}
+
+type taskPreinsertHosterStub struct{}
+
+func (taskPreinsertHosterStub) List(context.Context, string) (map[string]*taskflow.Host, error) {
+	return nil, nil
+}
+func (taskPreinsertHosterStub) IsOnline(_ context.Context, req *taskflow.IsOnlineReq[string]) (*taskflow.IsOnlineResp, error) {
+	online := make(map[string]bool, len(req.IDs))
+	for _, id := range req.IDs {
+		online[id] = true
+	}
+	return &taskflow.IsOnlineResp{OnlineMap: online}, nil
+}
+
+type taskPreinsertVMCreateStub struct {
+	db     *db.Client
+	seenID string
+}
+
+func (s *taskPreinsertVMCreateStub) Create(ctx context.Context, req *taskflow.CreateVirtualMachineReq) (*taskflow.VirtualMachine, error) {
+	if req.ID == "" {
+		return nil, fmt.Errorf("taskflow create req id is empty")
+	}
+	if _, err := s.db.VirtualMachine.Get(ctx, req.ID); err != nil {
+		return nil, fmt.Errorf("virtual machine %s not visible before taskflow create: %w", req.ID, err)
+	}
+	if _, err := s.db.TaskVirtualMachine.Query().
+		Where(taskvirtualmachine.VirtualmachineIDEQ(req.ID), taskvirtualmachine.TaskID(req.TaskID)).
+		Only(ctx); err != nil {
+		return nil, fmt.Errorf("task vm relation not visible before taskflow create: %w", err)
+	}
+	s.seenID = req.ID
+	return &taskflow.VirtualMachine{
+		ID:            req.ID,
+		AccessToken:   "access-" + req.ID,
+		EnvironmentID: "env-" + req.ID,
+		HostID:        req.HostID,
+	}, nil
+}
+func (s *taskPreinsertVMCreateStub) Delete(context.Context, *taskflow.DeleteVirtualMachineReq) error {
+	return nil
+}
+func (s *taskPreinsertVMCreateStub) Hibernate(context.Context, *taskflow.HibernateVirtualMachineReq) error {
+	return nil
+}
+func (s *taskPreinsertVMCreateStub) Resume(context.Context, *taskflow.ResumeVirtualMachineReq) error {
+	return nil
+}
+func (s *taskPreinsertVMCreateStub) List(context.Context, string) ([]*taskflow.VirtualMachine, error) {
+	return nil, nil
+}
+func (s *taskPreinsertVMCreateStub) Info(context.Context, taskflow.VirtualMachineInfoReq) (*taskflow.VirtualMachine, error) {
+	return nil, nil
+}
+func (s *taskPreinsertVMCreateStub) Terminal(context.Context, *taskflow.TerminalReq) (taskflow.Sheller, error) {
+	return nil, nil
+}
+func (s *taskPreinsertVMCreateStub) Reports(context.Context, taskflow.ReportSubscribeReq) (taskflow.Reporter, error) {
+	return nil, nil
+}
+func (s *taskPreinsertVMCreateStub) TerminalList(context.Context, string) ([]*taskflow.Terminal, error) {
+	return nil, nil
+}
+func (s *taskPreinsertVMCreateStub) CloseTerminal(context.Context, *taskflow.CloseTerminalReq) error {
+	return nil
+}
+func (s *taskPreinsertVMCreateStub) IsOnline(context.Context, *taskflow.IsOnlineReq[string]) (*taskflow.IsOnlineResp, error) {
+	return nil, nil
+}
+
+type noopTaskActivityRefresher struct{}
+
+func (noopTaskActivityRefresher) Refresh(context.Context, uuid.UUID) error      { return nil }
+func (noopTaskActivityRefresher) ForceRefresh(context.Context, uuid.UUID) error { return nil }
+
+type noopVMIdleRefresher struct{}
+
+func (noopVMIdleRefresher) Refresh(context.Context, string) error { return nil }
+
+var _ vmidle.VMIdleRefresher = noopVMIdleRefresher{}

--- a/backend/biz/task/usecase/task_switch_model_test.go
+++ b/backend/biz/task/usecase/task_switch_model_test.go
@@ -304,6 +304,12 @@ func (r *switchModelTaskRepo) List(context.Context, *domain.User, domain.TaskLis
 func (r *switchModelTaskRepo) Create(context.Context, *domain.User, domain.CreateTaskReq, string, func(*db.ProjectTask, *db.Model, *db.Image) (*taskflow.VirtualMachine, error)) (*db.ProjectTask, error) {
 	return nil, errors.New("unused")
 }
+func (r *switchModelTaskRepo) PrepareCreate(context.Context, *domain.User, domain.CreateTaskReq, string, string) (*domain.PreparedProjectTask, error) {
+	return nil, errors.New("unused")
+}
+func (r *switchModelTaskRepo) CompleteCreate(context.Context, string, *taskflow.VirtualMachine) error {
+	return errors.New("unused")
+}
 func (r *switchModelTaskRepo) Update(context.Context, *domain.User, uuid.UUID, func(*db.TaskUpdateOne) error) error {
 	return errors.New("unused")
 }

--- a/backend/biz/vmidle/usecase/policy_test.go
+++ b/backend/biz/vmidle/usecase/policy_test.go
@@ -180,6 +180,14 @@ func (s *refreshHostRepoStub) CreateVirtualMachine(context.Context, *domain.User
 	return nil, errors.New("not implemented")
 }
 
+func (s *refreshHostRepoStub) PrepareCreateVirtualMachine(context.Context, *domain.User, *domain.CreateVMReq, string) (*domain.PreparedVirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *refreshHostRepoStub) CompleteCreateVirtualMachine(context.Context, string, *taskflow.VirtualMachine) (*domain.VirtualMachine, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (s *refreshHostRepoStub) PastHourVirtualMachine(context.Context) ([]*db.VirtualMachine, error) {
 	return nil, errors.New("not implemented")
 }

--- a/backend/domain/host.go
+++ b/backend/domain/host.go
@@ -52,6 +52,8 @@ type HostRepo interface {
 	BatchGetVmIDsByEnvironmentIDs(ctx context.Context, envIDs []string) (map[string]string, error)
 	GetVirtualMachineWithUser(ctx context.Context, uid uuid.UUID, id string) (*db.VirtualMachine, error)
 	CreateVirtualMachine(ctx context.Context, user *User, req *CreateVMReq, getRepoToken func(context.Context) (string, error), fn func(*db.Model, *db.Image) (*VirtualMachine, error)) (*VirtualMachine, error)
+	PrepareCreateVirtualMachine(ctx context.Context, user *User, req *CreateVMReq, id string) (*PreparedVirtualMachine, error)
+	CompleteCreateVirtualMachine(ctx context.Context, id string, vm *taskflow.VirtualMachine) (*VirtualMachine, error)
 	PastHourVirtualMachine(ctx context.Context) ([]*db.VirtualMachine, error)
 	AllCountDownVirtualMachine(ctx context.Context) ([]*db.VirtualMachine, error)
 	DeleteVirtualMachine(ctx context.Context, uid uuid.UUID, hostID, id string, fn func(*db.VirtualMachine) error) error
@@ -71,6 +73,12 @@ type GitCredentialInfo struct {
 	GitIdentityID uuid.UUID
 	Platform      consts.GitPlatform
 	GitUsername   string
+}
+
+type PreparedVirtualMachine struct {
+	VirtualMachine *VirtualMachine
+	Model          *db.Model
+	Image          *db.Image
 }
 
 // VmIdleInfo 空闲队列 payload（任务创建的 VM）

--- a/backend/domain/task.go
+++ b/backend/domain/task.go
@@ -41,6 +41,8 @@ type TaskRepo interface {
 	Info(ctx context.Context, user *User, id uuid.UUID, isPrivileged bool) (*db.Task, error)
 	List(ctx context.Context, user *User, req TaskListReq) ([]*db.ProjectTask, *db.PageInfo, error)
 	Create(ctx context.Context, user *User, req CreateTaskReq, token string, fn func(*db.ProjectTask, *db.Model, *db.Image) (*taskflow.VirtualMachine, error)) (*db.ProjectTask, error)
+	PrepareCreate(ctx context.Context, user *User, req CreateTaskReq, token, vmID string) (*PreparedProjectTask, error)
+	CompleteCreate(ctx context.Context, vmID string, vm *taskflow.VirtualMachine) error
 	Update(ctx context.Context, user *User, id uuid.UUID, fn func(up *db.TaskUpdateOne) error) error
 	RefreshLastActiveAt(ctx context.Context, id uuid.UUID, at time.Time, minInterval time.Duration) error
 	Stop(ctx context.Context, user *User, id uuid.UUID, fn func(*db.Task) error) error
@@ -49,6 +51,12 @@ type TaskRepo interface {
 	CreateModelSwitch(ctx context.Context, item *TaskModelSwitch) error
 	FinishModelSwitch(ctx context.Context, id uuid.UUID, success bool, message, sessionID string) error
 	CompleteModelSwitch(ctx context.Context, id, taskID, modelID uuid.UUID, success bool, message, sessionID string) error
+}
+
+type PreparedProjectTask struct {
+	ProjectTask *db.ProjectTask
+	Model       *db.Model
+	Image       *db.Image
 }
 
 // repoFullName 从 repo_url 中提取 full_name

--- a/backend/pkg/lifecycle/taskhook_test.go
+++ b/backend/pkg/lifecycle/taskhook_test.go
@@ -118,6 +118,14 @@ func (s *taskHookRepoStub) Create(context.Context, *domain.User, domain.CreateTa
 	panic("unexpected call to Create")
 }
 
+func (s *taskHookRepoStub) PrepareCreate(context.Context, *domain.User, domain.CreateTaskReq, string, string) (*domain.PreparedProjectTask, error) {
+	panic("unexpected call to PrepareCreate")
+}
+
+func (s *taskHookRepoStub) CompleteCreate(context.Context, string, *taskflow.VirtualMachine) error {
+	panic("unexpected call to CompleteCreate")
+}
+
 func (s *taskHookRepoStub) Update(ctx context.Context, _ *domain.User, id uuid.UUID, fn func(up *db.TaskUpdateOne) error) error {
 	up := s.client.Task.UpdateOneID(id)
 	if err := fn(up); err != nil {

--- a/backend/pkg/taskflow/types.go
+++ b/backend/pkg/taskflow/types.go
@@ -121,6 +121,7 @@ type VirtualMachineCondition struct {
 
 // CreateVirtualMachineReq 创建虚拟机请求
 type CreateVirtualMachineReq struct {
+	ID                  string         `json:"id,omitempty"`
 	UserID              string         `json:"user_id" validate:"required"`
 	HostID              string         `json:"host_id" validate:"required"`
 	HostName            string         `json:"hostname"`

--- a/backend/pkg/taskflow/types_test.go
+++ b/backend/pkg/taskflow/types_test.go
@@ -81,6 +81,22 @@ func TestCreateVirtualMachineReqIncludesLogStore(t *testing.T) {
 	}
 }
 
+func TestCreateVirtualMachineReqIncludesID(t *testing.T) {
+	req := CreateVirtualMachineReq{
+		ID:     "agent_preallocated",
+		UserID: "u-1",
+		HostID: "h-1",
+	}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"id":"agent_preallocated"`) {
+		t.Fatalf("marshaled request missing id: %s", string(b))
+	}
+}
+
 func TestRestartTaskReqIncludesLogStore(t *testing.T) {
 	req := RestartTaskReq{
 		ID:        uuid.MustParse("22222222-2222-2222-2222-222222222222"),


### PR DESCRIPTION
## 概要
- 任务创建 VM 改为 MonkeyCode 预分配 VM ID，并先写入 tasks/project_tasks/virtualmachines/task_virtualmachines，再调用 taskflow 创建环境。
- 手动创建 VM 改为先写入 virtualmachines 占位记录，再调用 taskflow，成功后回填 environment_id/access_token。
- taskflow 客户端请求体增加 id 字段，并补充任务 VM、手动 VM 先入库回归测试。

## 验证
- cd backend && go test ./...

## 说明
- taskflow 全量 go test ./... 依赖本地 gRPC/Loki 服务，pkg/grpc 与 pkg/loki 在缺少本地服务时会失败；taskflow 受影响包已验证通过。