### PR TITLE
feat(wechat-mp): 公众号文本消息接入知识库自动问答

### DIFF
--- a/backend/biz/notify/handler/v1/wechat_callback.go
+++ b/backend/biz/notify/handler/v1/wechat_callback.go
@@ -21,7 +21,6 @@ const (
 	defaultReplySubscribe = "感谢关注！您将收到任务进度通知。"
 	defaultReplyScan      = "扫码成功"
 	defaultReplyClick     = "收到点击事件"
-	defaultReplyText      = "收到您的消息"
 )
 
 // WechatCallbackHandler 微信公众号回调处理器
@@ -200,7 +199,14 @@ func (h *WechatCallbackHandler) routeEvent(ctx context.Context, msg *msgpush.Mes
 
 	case "text":
 		h.logger.InfoContext(ctx, "wechat mp callback: text received", "openid", msg.FromUserName, "content", msg.Content)
-		replyContent = defaultReplyText
+		reply, err := h.usecase.HandleTextMessage(ctx, msg.MsgID, msg.FromUserName, msg.Content)
+		if err != nil {
+			h.logger.ErrorContext(ctx, "wechat mp callback: handle text failed", "error", err)
+		}
+		if reply == "" {
+			return []byte("success") // 已去重，无需回复
+		}
+		replyContent = reply
 
 	default:
 		h.logger.InfoContext(ctx, "wechat mp callback: unknown msg type", "type", msg.MsgType, "openid", msg.FromUserName)

--- a/backend/biz/notify/usecase/wechat_mp.go
+++ b/backend/biz/notify/usecase/wechat_mp.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
@@ -19,6 +20,7 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/db/user"
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/errcode"
+	"github.com/chaitin/MonkeyCode/backend/pkg/kbqa"
 	"github.com/chaitin/MonkeyCode/backend/pkg/msgpush"
 )
 
@@ -36,16 +38,25 @@ type WechatMPUsecaseImpl struct {
 	redis        *redis.Client
 	config       *config.Config
 	logger       *slog.Logger
+	kb           *kbqa.Client // 文本消息自动问答客户端，未配置 QA 时为 nil
 }
 
 // NewWechatMPUsecase 创建微信公众号绑定 usecase
 func NewWechatMPUsecase(i *do.Injector) (domain.WechatMPUsecase, error) {
+	cfg := do.MustInvoke[*config.Config](i)
+
+	var kb *kbqa.Client
+	if qa := cfg.Wechat.MP.QA; qa.Enabled && qa.BaseURL != "" && qa.APIKey != "" {
+		kb = kbqa.NewClient(qa.BaseURL, qa.APIKey, qa.Model)
+	}
+
 	return &WechatMPUsecaseImpl{
 		db:           do.MustInvoke[*db.Client](i),
 		wechatClient: do.MustInvoke[*msgpush.WechatClient](i),
 		redis:        do.MustInvoke[*redis.Client](i),
-		config:       do.MustInvoke[*config.Config](i),
+		config:       cfg,
 		logger:       do.MustInvoke[*slog.Logger](i).With("module", "wechat_mp.usecase"),
+		kb:           kb,
 	}, nil
 }
 
@@ -257,6 +268,104 @@ func (u *WechatMPUsecaseImpl) HandleUnsubscribe(ctx context.Context, mpOpenID st
 		}
 	}
 	return nil
+}
+
+// 文本自动问答相关常量
+const (
+	// wechatMPQAMsgDedupTTL 同一条用户消息（MsgId）只处理一次的去重 TTL
+	wechatMPQAMsgDedupTTL = 3 * time.Minute
+	// wechatMPQASyncWait 同步等待答案的最长时间，给微信 5s 被动回复超时留余量
+	wechatMPQASyncWait = 3800 * time.Millisecond
+	// wechatMPAnswerMaxRunes 答案最大字符数（微信文本上限约 2048 字节，按中文 3 字节留余量）
+	wechatMPAnswerMaxRunes = 600
+	// wechatMPQARatePerMin 单个用户每分钟最多触发的问答次数，防刷量/控成本
+	wechatMPQARatePerMin = 10
+)
+
+// HandleTextMessage 处理用户文本消息。详见 domain.WechatMPUsecase 接口注释。
+func (u *WechatMPUsecaseImpl) HandleTextMessage(ctx context.Context, msgID int64, mpOpenID, content string) (string, error) {
+	if !u.config.Wechat.MP.QA.Enabled || u.kb == nil {
+		return "收到您的消息", nil
+	}
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return "收到您的消息", nil
+	}
+
+	// 按 MsgId 去重：微信重试或用户连点时只让首次请求真正处理
+	dedupKey := fmt.Sprintf("wechat:mp:qa:msg:%d", msgID)
+	first, err := u.redis.SetNX(ctx, dedupKey, "1", wechatMPQAMsgDedupTTL).Result()
+	if err != nil {
+		u.logger.WarnContext(ctx, "wechat mp qa: dedup setnx failed, proceeding", "error", err)
+	} else if !first {
+		return "", nil // 重复，交给上层回 success
+	}
+
+	// 限流：单用户每分钟最多 wechatMPQARatePerMin 次，防刷量/控成本
+	rlKey := fmt.Sprintf("wechat:mp:qa:rl:%s", mpOpenID)
+	cnt, err := u.redis.Incr(ctx, rlKey).Result()
+	if err != nil {
+		u.logger.WarnContext(ctx, "wechat mp qa: rate limit incr failed, proceeding", "error", err)
+	} else {
+		if cnt == 1 {
+			u.redis.Expire(ctx, rlKey, time.Minute)
+		}
+		if cnt > wechatMPQARatePerMin {
+			u.logger.InfoContext(ctx, "wechat mp qa: rate limited", "openid", mpOpenID, "count", cnt)
+			return "消息太频繁啦，请稍等一会儿再问我～", nil
+		}
+	}
+
+	logger := u.logger.With("openid", mpOpenID, "msg_id", msgID)
+
+	// 后台查询：用独立 ctx（请求 ctx 在被动回复返回后会被取消），结果写入带缓冲 channel
+	resultCh := make(chan string, 1)
+	go func() {
+		bg, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		ans, err := u.kb.Ask(bg, content)
+		if err != nil {
+			logger.ErrorContext(bg, "wechat mp qa: ask failed", "error", err)
+			ans = "抱歉，我暂时没查到答案，请稍后再问我一次～"
+		}
+		resultCh <- truncateRunes(ans, wechatMPAnswerMaxRunes)
+	}()
+
+	// 同步窗口内拿到答案就直接被动回复（单气泡秒回）；超时则转客服消息补发
+	select {
+	case ans := <-resultCh:
+		return ans, nil
+	case <-time.After(wechatMPQASyncWait):
+		go func() {
+			ans := <-resultCh // 带缓冲，必到
+			bg, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			if err := u.wechatClient.SendCustomTextMessage(bg, mpOpenID, ans); err != nil {
+				logger.ErrorContext(bg, "wechat mp qa: push answer via custom message failed", "error", err)
+			}
+		}()
+		return "正在为你查询 MonkeyCode 知识库，请稍候，马上回复你 🐒", nil
+	}
+}
+
+// truncateRunes 按字符截断，超长末尾加省略号。
+// 为避免把 URL/单词截成两半（半截 URL 点不了），若截断点正处在词中间，
+// 回退到最近的空白处（最多回退 200 字，找不到则按原位截断）。
+func truncateRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	cut := max
+	if !unicode.IsSpace(r[cut]) && !unicode.IsSpace(r[cut-1]) {
+		for i := cut - 1; i > 0 && i > cut-200; i-- {
+			if unicode.IsSpace(r[i]) {
+				cut = i
+				break
+			}
+		}
+	}
+	return strings.TrimRight(string(r[:cut]), " \t\n") + "…"
 }
 
 // ExtractScene 从 EventKey 中提取 scene 值

--- a/backend/biz/notify/usecase/wechat_mp_qa_test.go
+++ b/backend/biz/notify/usecase/wechat_mp_qa_test.go
@@ -1,0 +1,24 @@
+package usecase
+
+import "testing"
+
+func TestTruncateRunes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"short", "hello", 10, "hello"},
+		{"boundary", "abc", 3, "abc"},
+		{"truncate cjk", "一二三四五", 3, "一二三…"},
+		{"empty", "", 5, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := truncateRunes(c.in, c.max); got != c.want {
+				t.Errorf("truncateRunes(%q, %d) = %q, want %q", c.in, c.max, got, c.want)
+			}
+		})
+	}
+}

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -842,4 +842,13 @@ type WechatMPConfig struct {
 	EncodingAESKey string            `mapstructure:"encoding_aes_key"`
 	Templates      map[string]string `mapstructure:"templates"`
 	MirrorMode     bool              `mapstructure:"mirror_mode"`
+	QA             WechatMPQAConfig  `mapstructure:"qa"` // 文本消息自动问答
+}
+
+// WechatMPQAConfig 公众号文本消息自动问答（接 baizhi 知识库 chat/completions）
+type WechatMPQAConfig struct {
+	Enabled bool   `mapstructure:"enabled"`
+	BaseURL string `mapstructure:"base_url"` // 形如 https://monkeycode.docs.baizhi.cloud
+	APIKey  string `mapstructure:"api_key"`  // 知识库 share token
+	Model   string `mapstructure:"model"`    // 形如 deepseek-v3.2
 }

--- a/backend/config/server/config.yaml.example
+++ b/backend/config/server/config.yaml.example
@@ -55,6 +55,40 @@ vm_idle:
   # VM 回收前，非微信公众号渠道（钉钉/飞书等）的提前预警时长（秒），<=0 视为禁用；省略则使用 3600（1h）
   recycle_warn_default_lead_seconds: 3600
 
+wechat:
+  # 微信开放平台 - 网站扫码登录（按需配置，不用可整段省略）
+  open:
+    app_id: ""
+    app_secret: ""
+    callback_url: ""
+    scope: "snsapi_login"
+    debug: false
+
+  # 微信公众号 - 消息推送 / 回调 / 文本自动问答
+  mp:
+    app_id: ""
+    app_secret: ""
+    # 服务器配置里的 Token，用于回调验签（需与公众号后台一致）
+    token: ""
+    # 安全模式的消息加解密 key，43 位；留空则为明文模式
+    encoding_aes_key: ""
+    # 按事件类型路由的模板 ID（key 为 consts.NotifyEventType 字符串）
+    templates: {}
+    # Nginx mirror 部署时置 true：绑定成功的 inline 回复会被丢弃，需主动补发模板消息。
+    # 单后端部署保持 false，否则用户会收到两次"绑定成功"。
+    mirror_mode: false
+
+    # 文本消息自动问答（接 baizhi 知识库 chat/completions）
+    qa:
+      # 总开关。false（或 base_url/api_key 缺失）时，文本消息只回固定文案，不调用知识库
+      enabled: false
+      # 知识库域名，形如 https://monkeycode.docs.baizhi.cloud
+      base_url: ""
+      # 知识库 share token。建议用环境变量注入，不要明文写进仓库
+      api_key: ""
+      # 模型名，留空默认 deepseek-v3.2
+      model: "deepseek-v3.2"
+
 task:
   create_req_ttl_seconds: 600
 

--- a/backend/domain/wechat_mp.go
+++ b/backend/domain/wechat_mp.go
@@ -12,6 +12,9 @@ type WechatMPUsecase interface {
 	Unbind(ctx context.Context, userID uuid.UUID) error
 	HandleBindEvent(ctx context.Context, scene, mpOpenID string) (string, error)
 	HandleUnsubscribe(ctx context.Context, mpOpenID string) error
+	// HandleTextMessage 处理用户文本消息：后台查知识库，同步窗口内拿到答案就返回（被动回复），
+	// 否则返回占位提示并由后台用客服消息补发。返回空串表示已去重，无需回复。
+	HandleTextMessage(ctx context.Context, msgID int64, mpOpenID, content string) (string, error)
 }
 
 // BindQRCodeResp 绑定二维码响应

--- a/backend/pkg/kbqa/client.go
+++ b/backend/pkg/kbqa/client.go
@@ -1,0 +1,135 @@
+// Package kbqa 封装 baizhi 知识库的 OpenAI 兼容问答接口（/share/v1/chat/completions），
+// 供微信公众号文本消息自动问答使用。单轮问答，stream=false 直接取完整答案。
+package kbqa
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Client 知识库问答客户端
+type Client struct {
+	http    *http.Client
+	baseURL string
+	apiKey  string
+	model   string
+}
+
+// defaultModel 未配置 model 时的兜底模型
+const defaultModel = "deepseek-v3.2"
+
+// NewClient 创建客户端。baseURL 形如 https://monkeycode.docs.baizhi.cloud
+func NewClient(baseURL, apiKey, model string) *Client {
+	if model == "" {
+		model = defaultModel
+	}
+	return &Client{
+		http:    &http.Client{Timeout: 30 * time.Second},
+		baseURL: strings.TrimRight(baseURL, "/"),
+		apiKey:  apiKey,
+		model:   model,
+	}
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatReq struct {
+	Model    string        `json:"model"`
+	Stream   bool          `json:"stream"`
+	Messages []chatMessage `json:"messages"`
+}
+
+type chatResp struct {
+	Choices []struct {
+		Message chatMessage `json:"message"`
+	} `json:"choices"`
+}
+
+// 微信公众号文本消息是纯文本、不渲染 markdown，但会把裸 http(s) URL 自动变成可点链接。
+// 故清洗策略：图片/链接一律转成裸 URL，去掉引用角标和加粗/标题等渲染不出来的标记。
+var (
+	citationRe   = regexp.MustCompile(`\[\[\d+\]\([^)]*\)\]`)    // [[1](url)] 引用角标
+	codeFenceRe  = regexp.MustCompile("(?m)^[ \\t]*```.*\\n?")  // ```lang 代码块围栏行（连同换行）
+	inlineCodeRe = regexp.MustCompile("`([^`]+)`")              // `行内代码`
+	imageRe      = regexp.MustCompile(`!\[[^\]]*\]\(([^)]+)\)`)  // ![alt](url) 图片 → 裸 URL
+	linkRe       = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`) // [text](url) 链接 → 文字：URL
+	boldRe       = regexp.MustCompile(`\*\*([^*]+)\*\*`)         // **加粗**
+	italicRe     = regexp.MustCompile(`\*([^*]+)\*`)            // *斜体*
+	headingRe    = regexp.MustCompile(`(?m)^\s*#{1,6}\s*`)       // # 标题
+	blankLinesRe = regexp.MustCompile(`\n{3,}`)                 // 多余空行
+)
+
+// cleanForWeChat 把 markdown 答案转成微信纯文本友好的形式。
+// 顺序有依赖：代码围栏先于行内代码；图片先于链接（![..](..) 内含 [..](..)）；
+// 加粗(**)先于斜体(*)。注意这是 best-effort 正则清洗，非完整 markdown 解析，
+// 代码块内若恰好含 markdown 标记可能被一并处理。
+func cleanForWeChat(s string) string {
+	s = citationRe.ReplaceAllString(s, "")       // 去引用角标
+	s = codeFenceRe.ReplaceAllString(s, "")      // 去代码块围栏行，保留代码内容
+	s = inlineCodeRe.ReplaceAllString(s, "$1")   // 去行内代码反引号
+	s = imageRe.ReplaceAllString(s, "\n$1\n")    // 图片 → 独占一行的裸 URL（可点）
+	s = linkRe.ReplaceAllString(s, "$1：$2")      // 链接 → 文字：URL
+	s = boldRe.ReplaceAllString(s, "$1")         // 去 **加粗**
+	s = italicRe.ReplaceAllString(s, "$1")       // 去 *斜体*
+	s = headingRe.ReplaceAllString(s, "")        // 去 # 标题
+	s = blankLinesRe.ReplaceAllString(s, "\n\n") // 收敛连续空行
+	return strings.TrimSpace(s)
+}
+
+// Ask 单轮问答，返回清洗后的完整答案。
+func (c *Client) Ask(ctx context.Context, question string) (string, error) {
+	payload, err := json.Marshal(&chatReq{
+		Model:    c.model,
+		Stream:   false,
+		Messages: []chatMessage{{Role: "user", Content: question}},
+	})
+	if err != nil {
+		return "", fmt.Errorf("kbqa: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/share/v1/chat/completions", bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("kbqa: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("kbqa: do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("kbqa: read body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("kbqa: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var r chatResp
+	if err := json.Unmarshal(body, &r); err != nil {
+		return "", fmt.Errorf("kbqa: unmarshal body: %w", err)
+	}
+	if len(r.Choices) == 0 {
+		return "", fmt.Errorf("kbqa: empty choices")
+	}
+
+	answer := cleanForWeChat(r.Choices[0].Message.Content)
+	if answer == "" {
+		return "", fmt.Errorf("kbqa: empty answer")
+	}
+	return answer, nil
+}

--- a/backend/pkg/kbqa/client_test.go
+++ b/backend/pkg/kbqa/client_test.go
@@ -1,0 +1,96 @@
+package kbqa
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAsk_Success_StripsCitation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/share/v1/chat/completions" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("unexpected auth header: %s", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"MonkeyCode 是开源 AI 开发平台[[1](https://x.com/a)]。"}}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-key", "deepseek-v3.2")
+	got, err := c.Ask(context.Background(), "什么是 MonkeyCode")
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	want := "MonkeyCode 是开源 AI 开发平台。"
+	if got != want {
+		t.Errorf("got %q, want %q (citation should be stripped)", got, want)
+	}
+}
+
+func TestAsk_NonOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "bad", "")
+	_, err := c.Ask(context.Background(), "q")
+	if err == nil {
+		t.Fatal("expected error on non-200")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error should mention status code: %v", err)
+	}
+}
+
+func TestAsk_EmptyChoices(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "k", "")
+	if _, err := c.Ask(context.Background(), "q"); err == nil {
+		t.Fatal("expected error on empty choices")
+	}
+}
+
+func TestNewClient_DefaultModel(t *testing.T) {
+	if c := NewClient("https://x", "k", ""); c.model != defaultModel {
+		t.Errorf("model = %q, want default %q", c.model, defaultModel)
+	}
+	if c := NewClient("https://x", "k", "custom"); c.model != "custom" {
+		t.Errorf("model = %q, want custom", c.model)
+	}
+}
+
+func TestCleanForWeChat(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"citation stripped", "答案[[1](https://x/n/abc)]。", "答案。"},
+		{"image to bare url", "见下图：![架构图](https://img.cdn/a.png)", "见下图：\nhttps://img.cdn/a.png"},
+		{"link to text-colon-url", "详见[文档](https://docs/x)", "详见文档：https://docs/x"},
+		{"bold removed", "这是**重点**内容", "这是重点内容"},
+		{"italic removed", "这是*斜体*内容", "这是斜体内容"},
+		{"heading removed", "## 功能列表\n内容", "功能列表\n内容"},
+		{"inline code unwrapped", "执行 `go build` 命令", "执行 go build 命令"},
+		{"code fence stripped", "示例：\n```go\nfmt.Println(1)\n```\n完毕", "示例：\nfmt.Println(1)\n完毕"},
+		{"plain unchanged", "普通文本 https://a.com 直接可点", "普通文本 https://a.com 直接可点"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := cleanForWeChat(c.in); got != c.want {
+				t.Errorf("cleanForWeChat(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/backend/pkg/msgpush/wechat.go
+++ b/backend/pkg/msgpush/wechat.go
@@ -471,6 +471,50 @@ func (c *WechatClient) SendTemplateMessage(ctx context.Context, msg *TemplateMes
 	return nil
 }
 
+// ========== 客服消息 ==========
+
+// customMessageText 客服文本消息正文
+type customMessageText struct {
+	Content string `json:"content"`
+}
+
+// customMessageReq 客服消息请求体
+type customMessageReq struct {
+	ToUser  string            `json:"touser"`
+	MsgType string            `json:"msgtype"`
+	Text    customMessageText `json:"text"`
+}
+
+// customMessageResp 客服消息发送响应
+type customMessageResp struct {
+	ErrCode int    `json:"errcode"`
+	ErrMsg  string `json:"errmsg"`
+}
+
+func (r customMessageResp) wechatErr() (int, string) { return r.ErrCode, r.ErrMsg }
+
+// SendCustomTextMessage 发送客服文本消息。
+// 仅在用户最近一次互动后的额度有效期内可用（用户发消息：48h 内 5 条）。
+func (c *WechatClient) SendCustomTextMessage(ctx context.Context, openID, content string) error {
+	req := &customMessageReq{
+		ToUser:  openID,
+		MsgType: "text",
+		Text:    customMessageText{Content: content},
+	}
+	_, err := withTokenRetry(ctx, c, func(token string) (*customMessageResp, error) {
+		return request.Post[customMessageResp](c.wechatClient, ctx, "/cgi-bin/message/custom/send",
+			req,
+			request.WithQuery(request.Query{"access_token": token}),
+		)
+	})
+	if err != nil {
+		c.logger.ErrorContext(ctx, "failed to send custom message", "error", err, "touser", openID)
+		return fmt.Errorf("failed to send custom message: %w", err)
+	}
+	c.logger.InfoContext(ctx, "custom message sent", "touser", openID)
+	return nil
+}
+
 // ========== HTTP Handler 辅助方法 ==========
 //
 // 微信回调的 HTTP 接收/路由/回复全部在 biz/notify/handler/v1/wechat_callback.go。


### PR DESCRIPTION
用户给公众号发文本时，调用 baizhi 知识库（OpenAI 兼容 /share/v1/chat/completions） 自动回复。被动回复 5s 限制下：同步窗口（3.8s）内拿到答案就直接回，超时则回
"正在思考"并由后台用客服消息异步补发。

- pkg/kbqa: 知识库问答客户端（stream=false）；cleanForWeChat 把 markdown （图片/链接/代码块/行内代码/加粗/斜体/标题/引用角标）清洗成微信纯文本友好格式， 图片/链接转成裸 URL（微信自动可点）
- pkg/msgpush: 新增 SendCustomTextMessage 客服消息接口（复用 token 刷新重试）
- biz/notify: HandleTextMessage 同步等 3.8s + 超时转客服；MsgId 去重； 单用户 10 条/分钟限流；答案按 600 字截断且避免切断 URL
- config: WechatMPConfig 增加 qa 段（enabled/base_url/api_key/model）