### PR TITLE
feat: 支持扩展包 rules 启动导入

### DIFF
--- a/backend/biz/team/repo/user.go
+++ b/backend/biz/team/repo/user.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"entgo.io/ent/dialect/sql"
@@ -295,8 +296,9 @@ func (r *TeamGroupUserRepo) GetMember(ctx context.Context, teamID, userID uuid.U
 }
 
 // InitTeam 初始化团队：创建管理员、普通成员、团队和默认资源。
-func (r *TeamGroupUserRepo) InitTeam(ctx context.Context, email string, name string, password string, imageName string) error {
-	return entx.WithTx2(ctx, r.db, func(tx *db.Tx) error {
+func (r *TeamGroupUserRepo) InitTeam(ctx context.Context, email string, name string, password string, imageName string) (*domain.InitTeamResult, error) {
+	var result *domain.InitTeamResult
+	err := entx.WithTx2(ctx, r.db, func(tx *db.Tx) error {
 		hashedPassword, err := crypto.HashPassword(password)
 		if err != nil {
 			return err
@@ -352,7 +354,7 @@ func (r *TeamGroupUserRepo) InitTeam(ctx context.Context, email string, name str
 				First(ctx)
 			if err != nil {
 				if db.IsNotFound(err) {
-					return nil
+					return fmt.Errorf("init team user %s has no team member", email)
 				}
 				return err
 			}
@@ -374,8 +376,16 @@ func (r *TeamGroupUserRepo) InitTeam(ctx context.Context, email string, name str
 		if _, _, err := agentresource.EnsureTeamBareReposTx(ctx, tx, initTeam.ID, initUser.ID); err != nil {
 			return err
 		}
-		return r.initTeamImage(ctx, tx, initTeam.ID, defaultGroup.ID, initUser.ID, imageName)
+		if err := r.initTeamImage(ctx, tx, initTeam.ID, defaultGroup.ID, initUser.ID, imageName); err != nil {
+			return err
+		}
+		result = &domain.InitTeamResult{TeamID: initTeam.ID, UserID: initUser.ID}
+		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 func (r *TeamGroupUserRepo) ensureInitTeamMember(ctx context.Context, tx *db.Tx, teamID uuid.UUID, email, name, hashedPassword string, groupID uuid.UUID) error {

--- a/backend/biz/team/repo/user_test.go
+++ b/backend/biz/team/repo/user_test.go
@@ -38,8 +38,12 @@ func TestInitTeamCreatesConfiguredImage(t *testing.T) {
 		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
-	if err := repo.InitTeam(ctx, "admin@example.com", "MonkeyCode", "password", "ghcr.io/chaitin/monkeycode-runner/devbox:latest"); err != nil {
+	result, err := repo.InitTeam(ctx, "admin@example.com", "MonkeyCode", "password", "ghcr.io/chaitin/monkeycode-runner/devbox:latest")
+	if err != nil {
 		t.Fatal(err)
+	}
+	if result.TeamID == uuid.Nil || result.UserID == uuid.Nil {
+		t.Fatalf("init team result = %#v", result)
 	}
 
 	admin, err := client.User.Query().First(ctx)
@@ -83,7 +87,7 @@ func TestInitTeamCreatesConfiguredImage(t *testing.T) {
 		t.Fatal("default group image relation was not created")
 	}
 
-	if err := repo.InitTeam(ctx, "admin@example.com", "MonkeyCode", "password", "ghcr.io/chaitin/monkeycode-runner/devbox:latest"); err != nil {
+	if _, err := repo.InitTeam(ctx, "admin@example.com", "MonkeyCode", "password", "ghcr.io/chaitin/monkeycode-runner/devbox:latest"); err != nil {
 		t.Fatal(err)
 	}
 	if count, err := client.Image.Query().Where(image.NameEQ("ghcr.io/chaitin/monkeycode-runner/devbox:latest")).Count(ctx); err != nil {
@@ -106,7 +110,7 @@ func TestInitTeamSkipsImageWhenConfigEmpty(t *testing.T) {
 		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
-	if err := repo.InitTeam(ctx, "admin@example.com", "MonkeyCode", "password", ""); err != nil {
+	if _, err := repo.InitTeam(ctx, "admin@example.com", "MonkeyCode", "password", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -125,7 +129,7 @@ func TestInitTeamCreatesMemberInDefaultGroup(t *testing.T) {
 		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
-	if err := repo.InitTeam(ctx, "admin@example.com", "MonkeyCode", "password", ""); err != nil {
+	if _, err := repo.InitTeam(ctx, "admin@example.com", "MonkeyCode", "password", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -180,7 +184,7 @@ func TestInitTeamCreatesMemberInDefaultGroup(t *testing.T) {
 		t.Fatal("member was not added to default group")
 	}
 
-	if err := repo.InitTeam(ctx, "admin@example.com", "MonkeyCode", "password", ""); err != nil {
+	if _, err := repo.InitTeam(ctx, "admin@example.com", "MonkeyCode", "password", ""); err != nil {
 		t.Fatal(err)
 	}
 	if count, err := client.User.Query().Where(user.EmailEQ("admin@example.com")).Count(ctx); err != nil {
@@ -235,7 +239,7 @@ func TestInitTeamAddsImageForExistingTeam(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := repo.InitTeam(ctx, "admin@example.com", "MonkeyCode", "password", "ghcr.io/chaitin/monkeycode-runner/devbox:latest"); err != nil {
+	if _, err := repo.InitTeam(ctx, "admin@example.com", "MonkeyCode", "password", "ghcr.io/chaitin/monkeycode-runner/devbox:latest"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/biz/team/usecase/extension_package.go
+++ b/backend/biz/team/usecase/extension_package.go
@@ -20,16 +20,23 @@ import (
 type teamExtensionPackageUsecase struct {
 	repo              domain.TeamExtensionPackageRepo
 	skillUsecase      domain.TeamSkillUsecase
+	ruleImporter      extensionPackageRuleImporter
 	staticDir         string
 	staticRoutePrefix string
 	logger            *slog.Logger
 }
 
+type extensionPackageRuleImporter interface {
+	ImportRules(ctx context.Context, userID uuid.UUID, pkg *parsedExtensionPackage) (domain.ExtensionRuleImportResult, error)
+}
+
 func NewTeamExtensionPackageUsecase(i *do.Injector) (domain.TeamExtensionPackageUsecase, error) {
 	cfg := do.MustInvoke[*config.Config](i)
+	dbClient := do.MustInvoke[*db.Client](i)
 	return &teamExtensionPackageUsecase{
 		repo:              do.MustInvoke[domain.TeamExtensionPackageRepo](i),
 		skillUsecase:      do.MustInvoke[domain.TeamSkillUsecase](i),
+		ruleImporter:      &extensionRuleImporter{db: dbClient},
 		staticDir:         cfg.StaticFiles.Dir,
 		staticRoutePrefix: cfg.StaticFiles.RoutePrefix,
 		logger:            do.MustInvoke[*slog.Logger](i),
@@ -43,6 +50,14 @@ func (u *teamExtensionPackageUsecase) Import(ctx context.Context, teamUser *doma
 	}
 
 	teamID := teamUser.GetTeamID()
+
+	var ruleResult domain.ExtensionRuleImportResult
+	if u.ruleImporter != nil {
+		ruleResult, err = u.ruleImporter.ImportRules(ctx, teamUser.User.ID, pkg)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	// Skill 导入:复用 TeamSkillUsecase.Add 走 bare repo + agent_skill 标准流程。
 	// extension_version 作为 agent_skill_version 的版本号,name 做幂等匹配。
@@ -92,11 +107,19 @@ func (u *teamExtensionPackageUsecase) Import(ctx context.Context, teamUser *doma
 	return &domain.ImportTeamExtensionPackageResp{
 		PackageID:     pkg.PackageID,
 		Version:       pkg.Version,
+		CreatedRules:  ruleResult.CreatedRules,
+		UpdatedRules:  ruleResult.UpdatedRules,
 		CreatedSkills: result.CreatedSkills,
 		UpdatedSkills: result.UpdatedSkills,
 		CreatedImages: result.CreatedImages,
 		UpdatedImages: result.UpdatedImages,
 	}, nil
+}
+
+type noopExtensionPackageRuleImporter struct{}
+
+func (noopExtensionPackageRuleImporter) ImportRules(context.Context, uuid.UUID, *parsedExtensionPackage) (domain.ExtensionRuleImportResult, error) {
+	return domain.ExtensionRuleImportResult{}, nil
 }
 
 func extensionSkillImports(pkg *parsedExtensionPackage) []domain.TeamExtensionSkillImport {

--- a/backend/biz/team/usecase/extension_package_manifest.go
+++ b/backend/biz/team/usecase/extension_package_manifest.go
@@ -18,8 +18,16 @@ import (
 type extensionPackageManifest struct {
 	PackageID string                   `json:"package_id"`
 	Version   string                   `json:"version"`
+	Rules     []extensionRuleManifest  `json:"rules"`
 	Skills    []extensionSkillManifest `json:"skills"`
 	Images    []extensionImageManifest `json:"images"`
+}
+
+type extensionRuleManifest struct {
+	RuleID      string `json:"rule_id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Path        string `json:"path"`
 }
 
 type extensionSkillManifest struct {
@@ -43,8 +51,17 @@ type extensionImageArchiveManifest struct {
 type parsedExtensionPackage struct {
 	PackageID string
 	Version   string
+	Rules     []parsedExtensionRule
 	Skills    []parsedExtensionSkill
 	Images    []parsedExtensionImage
+}
+
+type parsedExtensionRule struct {
+	RuleID      string
+	Name        string
+	Description string
+	Content     string
+	Path        string
 }
 
 type parsedExtensionSkill struct {
@@ -98,11 +115,46 @@ func parseExtensionPackage(data []byte) (*parsedExtensionPackage, error) {
 	if strings.TrimSpace(manifest.PackageID) == "" || strings.TrimSpace(manifest.Version) == "" {
 		return nil, errcode.ErrBadRequest.Wrap(fmt.Errorf("extension manifest missing package_id or version"))
 	}
+	if len(manifest.Rules) == 0 && len(manifest.Skills) == 0 && len(manifest.Images) == 0 {
+		return nil, errcode.ErrBadRequest.Wrap(fmt.Errorf("extension manifest contains no resources"))
+	}
 
 	pkg := &parsedExtensionPackage{
 		PackageID: strings.TrimSpace(manifest.PackageID),
 		Version:   strings.TrimSpace(manifest.Version),
 	}
+	seenRules := map[string]bool{}
+	for _, item := range manifest.Rules {
+		ruleID := strings.TrimSpace(item.RuleID)
+		name := strings.TrimSpace(item.Name)
+		if ruleID == "" || name == "" {
+			return nil, errcode.ErrBadRequest.Wrap(fmt.Errorf("extension rule missing rule_id or name"))
+		}
+		if seenRules[ruleID] {
+			return nil, errcode.ErrBadRequest.Wrap(fmt.Errorf("duplicate extension rule %s", ruleID))
+		}
+		seenRules[ruleID] = true
+		path, err := safeExtensionPath(item.Path)
+		if err != nil {
+			return nil, err
+		}
+		file := files[path]
+		if file == nil {
+			return nil, errcode.ErrBadRequest.Wrap(fmt.Errorf("extension rule file not found: %s", path))
+		}
+		content, err := readExtensionZipFile(file)
+		if err != nil {
+			return nil, err
+		}
+		pkg.Rules = append(pkg.Rules, parsedExtensionRule{
+			RuleID:      ruleID,
+			Name:        name,
+			Description: strings.TrimSpace(item.Description),
+			Content:     string(content),
+			Path:        path,
+		})
+	}
+
 	seenSkills := map[string]bool{}
 	for _, item := range manifest.Skills {
 		skillID := strings.TrimSpace(item.SkillID)

--- a/backend/biz/team/usecase/extension_package_manifest_test.go
+++ b/backend/biz/team/usecase/extension_package_manifest_test.go
@@ -53,6 +53,58 @@ func TestParseExtensionPackageReadsSkillAndImageArchive(t *testing.T) {
 	}
 }
 
+func TestParseExtensionPackageReadsRules(t *testing.T) {
+	data := makeExtensionZip(t, map[string]string{
+		"manifest.json": `{
+			"package_id":"pack",
+			"version":"1.0.0",
+			"rules":[{"rule_id":"codex-base","name":"codex-base","description":"base rule","path":"rules/codex-base.md"}]
+		}`,
+		"rules/codex-base.md": "# Codex Base\n",
+	})
+
+	pkg, err := parseExtensionPackage(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pkg.Rules) != 1 {
+		t.Fatalf("rules = %#v", pkg.Rules)
+	}
+	if got := pkg.Rules[0].Content; got != "# Codex Base\n" {
+		t.Fatalf("rule content = %q", got)
+	}
+	if got := pkg.Rules[0].Name; got != "codex-base" {
+		t.Fatalf("rule name = %q", got)
+	}
+}
+
+func TestParseExtensionPackageRejectsDuplicateRuleID(t *testing.T) {
+	data := makeExtensionZip(t, map[string]string{
+		"manifest.json": `{
+			"package_id":"pack",
+			"version":"1.0.0",
+			"rules":[
+				{"rule_id":"codex-base","name":"codex-base","path":"rules/a.md"},
+				{"rule_id":"codex-base","name":"codex-other","path":"rules/b.md"}
+			]
+		}`,
+		"rules/a.md": "a",
+		"rules/b.md": "b",
+	})
+	if _, err := parseExtensionPackage(data); err == nil {
+		t.Fatal("parseExtensionPackage should reject duplicate rule_id")
+	}
+}
+
+func TestParseExtensionPackageRequiresAtLeastOneResource(t *testing.T) {
+	data := makeExtensionZip(t, map[string]string{
+		"manifest.json": `{"package_id":"pack","version":"1.0.0"}`,
+	})
+	if _, err := parseExtensionPackage(data); err == nil {
+		t.Fatal("parseExtensionPackage should reject empty resources")
+	}
+}
+
 func makeExtensionZip(t *testing.T, files map[string]string) []byte {
 	t.Helper()
 	var buf bytes.Buffer

--- a/backend/biz/team/usecase/extension_package_rules.go
+++ b/backend/biz/team/usecase/extension_package_rules.go
@@ -1,0 +1,106 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/db/agentrule"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/errcode"
+)
+
+type extensionRuleImporter struct {
+	db *db.Client
+}
+
+func (i *extensionRuleImporter) ImportRules(ctx context.Context, userID uuid.UUID, pkg *parsedExtensionPackage) (domain.ExtensionRuleImportResult, error) {
+	var result domain.ExtensionRuleImportResult
+	for _, item := range pkg.Rules {
+		created, err := i.importRule(ctx, userID, pkg, item)
+		if err != nil {
+			return result, err
+		}
+		if created {
+			result.CreatedRules++
+		} else {
+			result.UpdatedRules++
+		}
+	}
+	return result, nil
+}
+
+func (i *extensionRuleImporter) importRule(ctx context.Context, userID uuid.UUID, pkg *parsedExtensionPackage, item parsedExtensionRule) (bool, error) {
+	existingBySource, err := i.db.AgentRule.Query().
+		Where(
+			agentrule.ExtensionPackageIDEQ(pkg.PackageID),
+			agentrule.ExtensionRuleIDEQ(item.RuleID),
+			agentrule.IsDeletedEQ(false),
+		).
+		Only(ctx)
+	if err != nil && !db.IsNotFound(err) {
+		return false, err
+	}
+	if existingBySource != nil {
+		version, err := i.createRuleVersion(ctx, existingBySource.ID, pkg.Version, item.Content)
+		if err != nil {
+			return false, err
+		}
+		_, err = i.db.AgentRule.UpdateOneID(existingBySource.ID).
+			SetDescription(item.Description).
+			SetExtensionVersion(pkg.Version).
+			SetActiveVersionID(version.ID).
+			Save(ctx)
+		return false, err
+	}
+
+	conflict, err := i.db.AgentRule.Query().
+		Where(
+			agentrule.NameEQ(item.Name),
+			agentrule.ScopeTypeEQ("global"),
+			agentrule.ScopeIDEQ("global"),
+			agentrule.IsDeletedEQ(false),
+		).
+		Exist(ctx)
+	if err != nil {
+		return false, err
+	}
+	if conflict {
+		return false, errcode.ErrBadRequest.Wrap(fmt.Errorf("agent rule name conflict: %s", item.Name))
+	}
+
+	rule, err := i.db.AgentRule.Create().
+		SetID(uuid.New()).
+		SetName(item.Name).
+		SetDescription(item.Description).
+		SetScopeType("global").
+		SetScopeID("global").
+		SetCreatedBy(userID).
+		SetExtensionPackageID(pkg.PackageID).
+		SetExtensionRuleID(item.RuleID).
+		SetExtensionVersion(pkg.Version).
+		Save(ctx)
+	if err != nil {
+		return false, err
+	}
+	version, err := i.createRuleVersion(ctx, rule.ID, pkg.Version, item.Content)
+	if err != nil {
+		return false, err
+	}
+	_, err = i.db.AgentRule.UpdateOneID(rule.ID).SetActiveVersionID(version.ID).Save(ctx)
+	return true, err
+}
+
+func (i *extensionRuleImporter) createRuleVersion(ctx context.Context, ruleID uuid.UUID, version, content string) (*db.AgentRuleVersion, error) {
+	if len(version) > 14 {
+		version = version[:14]
+	}
+	return i.db.AgentRuleVersion.Create().
+		SetID(uuid.New()).
+		SetRuleID(ruleID).
+		SetVersion(version).
+		SetContent(content).
+		Save(ctx)
+}

--- a/backend/biz/team/usecase/extension_package_rules_test.go
+++ b/backend/biz/team/usecase/extension_package_rules_test.go
@@ -1,0 +1,128 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/db/enttest"
+)
+
+func newRuleImportTestClient(t *testing.T) *db.Client {
+	t.Helper()
+	client := enttest.Open(t, "sqlite3", "file:extension-rule-import?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func TestExtensionRuleImporterCreatesGlobalRule(t *testing.T) {
+	ctx := context.Background()
+	client := newRuleImportTestClient(t)
+	importer := &extensionRuleImporter{db: client}
+	userID := uuid.New()
+	pkg := &parsedExtensionPackage{
+		PackageID: "pack",
+		Version:   "1.0.0",
+		Rules: []parsedExtensionRule{{
+			RuleID:      "codex-base",
+			Name:        "codex-base",
+			Description: "base",
+			Content:     "# Base\n",
+		}},
+	}
+
+	result, err := importer.ImportRules(ctx, userID, pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CreatedRules != 1 || result.UpdatedRules != 0 {
+		t.Fatalf("result = %#v", result)
+	}
+	rule, err := client.AgentRule.Query().Only(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rule.ScopeType != "global" || rule.ScopeID != "global" {
+		t.Fatalf("scope = %s/%s", rule.ScopeType, rule.ScopeID)
+	}
+	if rule.ExtensionPackageID == nil || *rule.ExtensionPackageID != "pack" {
+		t.Fatalf("extension package id = %#v", rule.ExtensionPackageID)
+	}
+	if rule.ExtensionRuleID == nil || *rule.ExtensionRuleID != "codex-base" {
+		t.Fatalf("extension rule id = %#v", rule.ExtensionRuleID)
+	}
+	if rule.ActiveVersionID == nil {
+		t.Fatal("active version id is nil")
+	}
+}
+
+func TestExtensionRuleImporterUpdatesSamePackageRule(t *testing.T) {
+	ctx := context.Background()
+	client := newRuleImportTestClient(t)
+	importer := &extensionRuleImporter{db: client}
+	userID := uuid.New()
+
+	pkg := &parsedExtensionPackage{
+		PackageID: "pack",
+		Version:   "1.0.0",
+		Rules: []parsedExtensionRule{{
+			RuleID:  "codex-base",
+			Name:    "codex-base",
+			Content: "v1",
+		}},
+	}
+	if _, err := importer.ImportRules(ctx, userID, pkg); err != nil {
+		t.Fatal(err)
+	}
+	pkg.Version = "1.0.1"
+	pkg.Rules[0].Content = "v2"
+	result, err := importer.ImportRules(ctx, userID, pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CreatedRules != 0 || result.UpdatedRules != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	count, err := client.AgentRuleVersion.Query().Count(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("version count = %d", count)
+	}
+}
+
+func TestExtensionRuleImporterRejectsNameConflict(t *testing.T) {
+	ctx := context.Background()
+	client := newRuleImportTestClient(t)
+	importer := &extensionRuleImporter{db: client}
+	userID := uuid.New()
+
+	first := &parsedExtensionPackage{
+		PackageID: "pack-a",
+		Version:   "1.0.0",
+		Rules: []parsedExtensionRule{{
+			RuleID:  "codex-base",
+			Name:    "codex-base",
+			Content: "a",
+		}},
+	}
+	if _, err := importer.ImportRules(ctx, userID, first); err != nil {
+		t.Fatal(err)
+	}
+	second := &parsedExtensionPackage{
+		PackageID: "pack-b",
+		Version:   "1.0.0",
+		Rules: []parsedExtensionRule{{
+			RuleID:  "codex-base",
+			Name:    "codex-base",
+			Content: "b",
+		}},
+	}
+	if _, err := importer.ImportRules(ctx, userID, second); err == nil {
+		t.Fatal("ImportRules should reject same rule name from different package")
+	}
+}

--- a/backend/biz/team/usecase/extension_package_test.go
+++ b/backend/biz/team/usecase/extension_package_test.go
@@ -33,6 +33,7 @@ func TestTeamExtensionPackageUsecaseImportWritesAggregatedManifest(t *testing.T)
 	}
 	u := &teamExtensionPackageUsecase{
 		repo:              repo,
+		ruleImporter:      &extensionPackageRuleImporterStub{},
 		staticDir:         staticDir,
 		staticRoutePrefix: "/static",
 		logger:            slog.Default(),
@@ -73,6 +74,35 @@ func TestTeamExtensionPackageUsecaseImportWritesAggregatedManifest(t *testing.T)
 	}
 }
 
+func TestTeamExtensionPackageUsecaseImportReturnsRuleCounts(t *testing.T) {
+	ctx := context.Background()
+	teamID := uuid.New()
+	userID := uuid.New()
+	ruleImporter := &extensionPackageRuleImporterStub{created: 1}
+	u := &teamExtensionPackageUsecase{
+		repo:              &extensionPackageRepoStub{},
+		ruleImporter:      ruleImporter,
+		staticDir:         t.TempDir(),
+		staticRoutePrefix: "/static",
+		logger:            slog.Default(),
+	}
+	data := makeExtensionZip(t, map[string]string{
+		"manifest.json":       `{"package_id":"pack","version":"1.0.0","rules":[{"rule_id":"codex-base","name":"codex-base","path":"rules/codex-base.md"}]}`,
+		"rules/codex-base.md": "# Codex Base\n",
+	})
+
+	resp, err := u.Import(ctx, &domain.TeamUser{User: &domain.User{ID: userID}, Team: &domain.Team{ID: teamID}}, &domain.ImportTeamExtensionPackageReq{
+		Filename: "pack.zip",
+		Data:     data,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.CreatedRules != 1 || resp.UpdatedRules != 0 {
+		t.Fatalf("rule counts = created %d updated %d", resp.CreatedRules, resp.UpdatedRules)
+	}
+}
+
 type extensionPackageRepoStub struct {
 	importReq *domain.TeamExtensionImport
 	archives  []*db.TeamExtensionImageArchive
@@ -88,4 +118,13 @@ func (s *extensionPackageRepoStub) ImportResources(_ context.Context, _, _ uuid.
 
 func (s *extensionPackageRepoStub) ListImageArchives(_ context.Context, _ uuid.UUID) ([]*db.TeamExtensionImageArchive, error) {
 	return s.archives, nil
+}
+
+type extensionPackageRuleImporterStub struct {
+	created int
+	updated int
+}
+
+func (s *extensionPackageRuleImporterStub) ImportRules(_ context.Context, _ uuid.UUID, _ *parsedExtensionPackage) (domain.ExtensionRuleImportResult, error) {
+	return domain.ExtensionRuleImportResult{CreatedRules: s.created, UpdatedRules: s.updated}, nil
 }

--- a/backend/biz/team/usecase/user.go
+++ b/backend/biz/team/usecase/user.go
@@ -2,8 +2,13 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
@@ -20,13 +25,14 @@ import (
 
 // TeamGroupUserUsecase 团队分组成员业务逻辑层
 type TeamGroupUserUsecase struct {
-	repo        domain.TeamGroupUserRepo
-	activeRepo  domain.UserActiveRepo
-	logger      *slog.Logger
-	config      *config.Config
-	smtpClient  domain.EmailSender
-	redisClient *redis.Client
-	teamHook    domain.TeamHook
+	repo                    domain.TeamGroupUserRepo
+	activeRepo              domain.UserActiveRepo
+	logger                  *slog.Logger
+	config                  *config.Config
+	smtpClient              domain.EmailSender
+	redisClient             *redis.Client
+	teamHook                domain.TeamHook
+	extensionPackageUsecase domain.TeamExtensionPackageUsecase
 }
 
 // NewTeamGroupUserUsecase 创建团队分组成员业务逻辑层实例
@@ -45,6 +51,9 @@ func NewTeamGroupUserUsecase(i *do.Injector) (domain.TeamGroupUserUsecase, error
 	if hook, err := do.Invoke[domain.TeamHook](i); err == nil {
 		t.teamHook = hook
 	}
+	if extensionPackageUsecase, err := do.Invoke[domain.TeamExtensionPackageUsecase](i); err == nil {
+		t.extensionPackageUsecase = extensionPackageUsecase
+	}
 
 	go t.initTeam()
 
@@ -62,11 +71,61 @@ func (u *TeamGroupUserUsecase) initTeam() {
 	}
 
 	ctx := context.Background()
-	if err := u.repo.InitTeam(ctx, u.config.InitTeam.Email, name, u.config.InitTeam.Password, u.config.InitTeam.Image); err != nil {
+	result, err := u.repo.InitTeam(ctx, u.config.InitTeam.Email, name, u.config.InitTeam.Password, u.config.InitTeam.Image)
+	if err != nil {
 		u.logger.ErrorContext(ctx, "init team failed", "error", err)
 		return
 	}
 	u.logger.InfoContext(ctx, "init team success", "email", u.config.InitTeam.Email)
+	u.importInitTeamExtensionPackages(ctx, result)
+}
+
+func (u *TeamGroupUserUsecase) importInitTeamExtensionPackages(ctx context.Context, result *domain.InitTeamResult) {
+	if u.extensionPackageUsecase == nil || result == nil {
+		return
+	}
+	dir := strings.TrimSpace(u.config.InitTeam.ExtensionPackageDir)
+	if dir == "" {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			u.logger.InfoContext(ctx, "init team extension package dir not found", "dir", dir)
+			return
+		}
+		u.logger.ErrorContext(ctx, "read init team extension package dir failed", "dir", dir, "error", err)
+		return
+	}
+	files := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".zip") {
+			continue
+		}
+		files = append(files, entry.Name())
+	}
+	sort.Strings(files)
+	teamUser := &domain.TeamUser{
+		User: &domain.User{ID: result.UserID},
+		Team: &domain.Team{ID: result.TeamID},
+	}
+	for _, name := range files {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			u.logger.ErrorContext(ctx, "read init team extension package failed", "path", path, "error", err)
+			continue
+		}
+		_, err = u.extensionPackageUsecase.Import(ctx, teamUser, &domain.ImportTeamExtensionPackageReq{
+			Filename: name,
+			Data:     data,
+		})
+		if err != nil {
+			u.logger.ErrorContext(ctx, "import init team extension package failed", "path", path, "error", err)
+			continue
+		}
+		u.logger.InfoContext(ctx, "import init team extension package success", "path", path)
+	}
 }
 
 // List 获取团队分组列表

--- a/backend/biz/team/usecase/user_init_extension_package_test.go
+++ b/backend/biz/team/usecase/user_init_extension_package_test.go
@@ -1,0 +1,53 @@
+package usecase
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+func TestImportInitTeamExtensionPackagesSortsZipFiles(t *testing.T) {
+	dir := t.TempDir()
+	for name, content := range map[string]string{
+		"002-default-skills.zip": "skills",
+		"001-default-rules.zip":  "rules",
+		"README.md":              "ignored",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	importer := &initPackageImporterStub{}
+	u := &TeamGroupUserUsecase{
+		config:                  &config.Config{},
+		logger:                  slog.Default(),
+		extensionPackageUsecase: importer,
+	}
+	u.config.InitTeam.ExtensionPackageDir = dir
+
+	u.importInitTeamExtensionPackages(context.Background(), &domain.InitTeamResult{
+		TeamID: uuid.New(),
+		UserID: uuid.New(),
+	})
+
+	if want := []string{"001-default-rules.zip", "002-default-skills.zip"}; !reflect.DeepEqual(importer.names, want) {
+		t.Fatalf("import order = %v, want %v", importer.names, want)
+	}
+}
+
+type initPackageImporterStub struct {
+	names []string
+}
+
+func (s *initPackageImporterStub) Import(_ context.Context, _ *domain.TeamUser, req *domain.ImportTeamExtensionPackageReq) (*domain.ImportTeamExtensionPackageResp, error) {
+	s.names = append(s.names, req.Filename)
+	return &domain.ImportTeamExtensionPackageResp{PackageID: req.Filename, Version: "1.0.0"}, nil
+}

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -145,10 +145,11 @@ type Doubao struct {
 }
 
 type InitTeam struct {
-	Email    string `mapstructure:"email"`
-	Password string `mapstructure:"password"`
-	Name     string `mapstructure:"name"`
-	Image    string `mapstructure:"image"`
+	Email               string `mapstructure:"email"`
+	Password            string `mapstructure:"password"`
+	Name                string `mapstructure:"name"`
+	Image               string `mapstructure:"image"`
+	ExtensionPackageDir string `mapstructure:"extension_package_dir"`
 }
 
 type TaskFlow struct {

--- a/backend/config/server/config.yaml.example
+++ b/backend/config/server/config.yaml.example
@@ -40,6 +40,7 @@ init_team:
   password: ""
   name: ""
   image: ""
+  extension_package_dir: "/app/extensions/packages"
 
 mcp_hub:
   enabled: false

--- a/backend/db/agentrule.go
+++ b/backend/db/agentrule.go
@@ -30,6 +30,12 @@ type AgentRule struct {
 	CreatedBy uuid.UUID `json:"created_by,omitempty"`
 	// ActiveVersionID holds the value of the "active_version_id" field.
 	ActiveVersionID *uuid.UUID `json:"active_version_id,omitempty"`
+	// ExtensionPackageID holds the value of the "extension_package_id" field.
+	ExtensionPackageID *string `json:"extension_package_id,omitempty"`
+	// ExtensionRuleID holds the value of the "extension_rule_id" field.
+	ExtensionRuleID *string `json:"extension_rule_id,omitempty"`
+	// ExtensionVersion holds the value of the "extension_version" field.
+	ExtensionVersion *string `json:"extension_version,omitempty"`
 	// IsDeleted holds the value of the "is_deleted" field.
 	IsDeleted bool `json:"is_deleted,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
@@ -69,7 +75,7 @@ func (*AgentRule) scanValues(columns []string) ([]any, error) {
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
 		case agentrule.FieldIsDeleted:
 			values[i] = new(sql.NullBool)
-		case agentrule.FieldName, agentrule.FieldDescription, agentrule.FieldScopeType, agentrule.FieldScopeID:
+		case agentrule.FieldName, agentrule.FieldDescription, agentrule.FieldScopeType, agentrule.FieldScopeID, agentrule.FieldExtensionPackageID, agentrule.FieldExtensionRuleID, agentrule.FieldExtensionVersion:
 			values[i] = new(sql.NullString)
 		case agentrule.FieldCreatedAt, agentrule.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -132,6 +138,27 @@ func (_m *AgentRule) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.ActiveVersionID = new(uuid.UUID)
 				*_m.ActiveVersionID = *value.S.(*uuid.UUID)
+			}
+		case agentrule.FieldExtensionPackageID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field extension_package_id", values[i])
+			} else if value.Valid {
+				_m.ExtensionPackageID = new(string)
+				*_m.ExtensionPackageID = value.String
+			}
+		case agentrule.FieldExtensionRuleID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field extension_rule_id", values[i])
+			} else if value.Valid {
+				_m.ExtensionRuleID = new(string)
+				*_m.ExtensionRuleID = value.String
+			}
+		case agentrule.FieldExtensionVersion:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field extension_version", values[i])
+			} else if value.Valid {
+				_m.ExtensionVersion = new(string)
+				*_m.ExtensionVersion = value.String
 			}
 		case agentrule.FieldIsDeleted:
 			if value, ok := values[i].(*sql.NullBool); !ok {
@@ -210,6 +237,21 @@ func (_m *AgentRule) String() string {
 	if v := _m.ActiveVersionID; v != nil {
 		builder.WriteString("active_version_id=")
 		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
+	builder.WriteString(", ")
+	if v := _m.ExtensionPackageID; v != nil {
+		builder.WriteString("extension_package_id=")
+		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
+	if v := _m.ExtensionRuleID; v != nil {
+		builder.WriteString("extension_rule_id=")
+		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
+	if v := _m.ExtensionVersion; v != nil {
+		builder.WriteString("extension_version=")
+		builder.WriteString(*v)
 	}
 	builder.WriteString(", ")
 	builder.WriteString("is_deleted=")

--- a/backend/db/agentrule/agentrule.go
+++ b/backend/db/agentrule/agentrule.go
@@ -28,6 +28,12 @@ const (
 	FieldCreatedBy = "created_by"
 	// FieldActiveVersionID holds the string denoting the active_version_id field in the database.
 	FieldActiveVersionID = "active_version_id"
+	// FieldExtensionPackageID holds the string denoting the extension_package_id field in the database.
+	FieldExtensionPackageID = "extension_package_id"
+	// FieldExtensionRuleID holds the string denoting the extension_rule_id field in the database.
+	FieldExtensionRuleID = "extension_rule_id"
+	// FieldExtensionVersion holds the string denoting the extension_version field in the database.
+	FieldExtensionVersion = "extension_version"
 	// FieldIsDeleted holds the string denoting the is_deleted field in the database.
 	FieldIsDeleted = "is_deleted"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
@@ -56,6 +62,9 @@ var Columns = []string{
 	FieldScopeID,
 	FieldCreatedBy,
 	FieldActiveVersionID,
+	FieldExtensionPackageID,
+	FieldExtensionRuleID,
+	FieldExtensionVersion,
 	FieldIsDeleted,
 	FieldCreatedAt,
 	FieldUpdatedAt,
@@ -149,6 +158,21 @@ func ByCreatedBy(opts ...sql.OrderTermOption) OrderOption {
 // ByActiveVersionID orders the results by the active_version_id field.
 func ByActiveVersionID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldActiveVersionID, opts...).ToFunc()
+}
+
+// ByExtensionPackageID orders the results by the extension_package_id field.
+func ByExtensionPackageID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldExtensionPackageID, opts...).ToFunc()
+}
+
+// ByExtensionRuleID orders the results by the extension_rule_id field.
+func ByExtensionRuleID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldExtensionRuleID, opts...).ToFunc()
+}
+
+// ByExtensionVersion orders the results by the extension_version field.
+func ByExtensionVersion(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldExtensionVersion, opts...).ToFunc()
 }
 
 // ByIsDeleted orders the results by the is_deleted field.

--- a/backend/db/agentrule/where.go
+++ b/backend/db/agentrule/where.go
@@ -81,6 +81,21 @@ func ActiveVersionID(v uuid.UUID) predicate.AgentRule {
 	return predicate.AgentRule(sql.FieldEQ(FieldActiveVersionID, v))
 }
 
+// ExtensionPackageID applies equality check predicate on the "extension_package_id" field. It's identical to ExtensionPackageIDEQ.
+func ExtensionPackageID(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldEQ(FieldExtensionPackageID, v))
+}
+
+// ExtensionRuleID applies equality check predicate on the "extension_rule_id" field. It's identical to ExtensionRuleIDEQ.
+func ExtensionRuleID(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldEQ(FieldExtensionRuleID, v))
+}
+
+// ExtensionVersion applies equality check predicate on the "extension_version" field. It's identical to ExtensionVersionEQ.
+func ExtensionVersion(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldEQ(FieldExtensionVersion, v))
+}
+
 // IsDeleted applies equality check predicate on the "is_deleted" field. It's identical to IsDeletedEQ.
 func IsDeleted(v bool) predicate.AgentRule {
 	return predicate.AgentRule(sql.FieldEQ(FieldIsDeleted, v))
@@ -409,6 +424,231 @@ func ActiveVersionIDIsNil() predicate.AgentRule {
 // ActiveVersionIDNotNil applies the NotNil predicate on the "active_version_id" field.
 func ActiveVersionIDNotNil() predicate.AgentRule {
 	return predicate.AgentRule(sql.FieldNotNull(FieldActiveVersionID))
+}
+
+// ExtensionPackageIDEQ applies the EQ predicate on the "extension_package_id" field.
+func ExtensionPackageIDEQ(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldEQ(FieldExtensionPackageID, v))
+}
+
+// ExtensionPackageIDNEQ applies the NEQ predicate on the "extension_package_id" field.
+func ExtensionPackageIDNEQ(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldNEQ(FieldExtensionPackageID, v))
+}
+
+// ExtensionPackageIDIn applies the In predicate on the "extension_package_id" field.
+func ExtensionPackageIDIn(vs ...string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldIn(FieldExtensionPackageID, vs...))
+}
+
+// ExtensionPackageIDNotIn applies the NotIn predicate on the "extension_package_id" field.
+func ExtensionPackageIDNotIn(vs ...string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldNotIn(FieldExtensionPackageID, vs...))
+}
+
+// ExtensionPackageIDGT applies the GT predicate on the "extension_package_id" field.
+func ExtensionPackageIDGT(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldGT(FieldExtensionPackageID, v))
+}
+
+// ExtensionPackageIDGTE applies the GTE predicate on the "extension_package_id" field.
+func ExtensionPackageIDGTE(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldGTE(FieldExtensionPackageID, v))
+}
+
+// ExtensionPackageIDLT applies the LT predicate on the "extension_package_id" field.
+func ExtensionPackageIDLT(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldLT(FieldExtensionPackageID, v))
+}
+
+// ExtensionPackageIDLTE applies the LTE predicate on the "extension_package_id" field.
+func ExtensionPackageIDLTE(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldLTE(FieldExtensionPackageID, v))
+}
+
+// ExtensionPackageIDContains applies the Contains predicate on the "extension_package_id" field.
+func ExtensionPackageIDContains(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldContains(FieldExtensionPackageID, v))
+}
+
+// ExtensionPackageIDHasPrefix applies the HasPrefix predicate on the "extension_package_id" field.
+func ExtensionPackageIDHasPrefix(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldHasPrefix(FieldExtensionPackageID, v))
+}
+
+// ExtensionPackageIDHasSuffix applies the HasSuffix predicate on the "extension_package_id" field.
+func ExtensionPackageIDHasSuffix(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldHasSuffix(FieldExtensionPackageID, v))
+}
+
+// ExtensionPackageIDIsNil applies the IsNil predicate on the "extension_package_id" field.
+func ExtensionPackageIDIsNil() predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldIsNull(FieldExtensionPackageID))
+}
+
+// ExtensionPackageIDNotNil applies the NotNil predicate on the "extension_package_id" field.
+func ExtensionPackageIDNotNil() predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldNotNull(FieldExtensionPackageID))
+}
+
+// ExtensionPackageIDEqualFold applies the EqualFold predicate on the "extension_package_id" field.
+func ExtensionPackageIDEqualFold(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldEqualFold(FieldExtensionPackageID, v))
+}
+
+// ExtensionPackageIDContainsFold applies the ContainsFold predicate on the "extension_package_id" field.
+func ExtensionPackageIDContainsFold(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldContainsFold(FieldExtensionPackageID, v))
+}
+
+// ExtensionRuleIDEQ applies the EQ predicate on the "extension_rule_id" field.
+func ExtensionRuleIDEQ(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldEQ(FieldExtensionRuleID, v))
+}
+
+// ExtensionRuleIDNEQ applies the NEQ predicate on the "extension_rule_id" field.
+func ExtensionRuleIDNEQ(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldNEQ(FieldExtensionRuleID, v))
+}
+
+// ExtensionRuleIDIn applies the In predicate on the "extension_rule_id" field.
+func ExtensionRuleIDIn(vs ...string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldIn(FieldExtensionRuleID, vs...))
+}
+
+// ExtensionRuleIDNotIn applies the NotIn predicate on the "extension_rule_id" field.
+func ExtensionRuleIDNotIn(vs ...string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldNotIn(FieldExtensionRuleID, vs...))
+}
+
+// ExtensionRuleIDGT applies the GT predicate on the "extension_rule_id" field.
+func ExtensionRuleIDGT(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldGT(FieldExtensionRuleID, v))
+}
+
+// ExtensionRuleIDGTE applies the GTE predicate on the "extension_rule_id" field.
+func ExtensionRuleIDGTE(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldGTE(FieldExtensionRuleID, v))
+}
+
+// ExtensionRuleIDLT applies the LT predicate on the "extension_rule_id" field.
+func ExtensionRuleIDLT(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldLT(FieldExtensionRuleID, v))
+}
+
+// ExtensionRuleIDLTE applies the LTE predicate on the "extension_rule_id" field.
+func ExtensionRuleIDLTE(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldLTE(FieldExtensionRuleID, v))
+}
+
+// ExtensionRuleIDContains applies the Contains predicate on the "extension_rule_id" field.
+func ExtensionRuleIDContains(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldContains(FieldExtensionRuleID, v))
+}
+
+// ExtensionRuleIDHasPrefix applies the HasPrefix predicate on the "extension_rule_id" field.
+func ExtensionRuleIDHasPrefix(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldHasPrefix(FieldExtensionRuleID, v))
+}
+
+// ExtensionRuleIDHasSuffix applies the HasSuffix predicate on the "extension_rule_id" field.
+func ExtensionRuleIDHasSuffix(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldHasSuffix(FieldExtensionRuleID, v))
+}
+
+// ExtensionRuleIDIsNil applies the IsNil predicate on the "extension_rule_id" field.
+func ExtensionRuleIDIsNil() predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldIsNull(FieldExtensionRuleID))
+}
+
+// ExtensionRuleIDNotNil applies the NotNil predicate on the "extension_rule_id" field.
+func ExtensionRuleIDNotNil() predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldNotNull(FieldExtensionRuleID))
+}
+
+// ExtensionRuleIDEqualFold applies the EqualFold predicate on the "extension_rule_id" field.
+func ExtensionRuleIDEqualFold(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldEqualFold(FieldExtensionRuleID, v))
+}
+
+// ExtensionRuleIDContainsFold applies the ContainsFold predicate on the "extension_rule_id" field.
+func ExtensionRuleIDContainsFold(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldContainsFold(FieldExtensionRuleID, v))
+}
+
+// ExtensionVersionEQ applies the EQ predicate on the "extension_version" field.
+func ExtensionVersionEQ(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldEQ(FieldExtensionVersion, v))
+}
+
+// ExtensionVersionNEQ applies the NEQ predicate on the "extension_version" field.
+func ExtensionVersionNEQ(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldNEQ(FieldExtensionVersion, v))
+}
+
+// ExtensionVersionIn applies the In predicate on the "extension_version" field.
+func ExtensionVersionIn(vs ...string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldIn(FieldExtensionVersion, vs...))
+}
+
+// ExtensionVersionNotIn applies the NotIn predicate on the "extension_version" field.
+func ExtensionVersionNotIn(vs ...string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldNotIn(FieldExtensionVersion, vs...))
+}
+
+// ExtensionVersionGT applies the GT predicate on the "extension_version" field.
+func ExtensionVersionGT(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldGT(FieldExtensionVersion, v))
+}
+
+// ExtensionVersionGTE applies the GTE predicate on the "extension_version" field.
+func ExtensionVersionGTE(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldGTE(FieldExtensionVersion, v))
+}
+
+// ExtensionVersionLT applies the LT predicate on the "extension_version" field.
+func ExtensionVersionLT(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldLT(FieldExtensionVersion, v))
+}
+
+// ExtensionVersionLTE applies the LTE predicate on the "extension_version" field.
+func ExtensionVersionLTE(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldLTE(FieldExtensionVersion, v))
+}
+
+// ExtensionVersionContains applies the Contains predicate on the "extension_version" field.
+func ExtensionVersionContains(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldContains(FieldExtensionVersion, v))
+}
+
+// ExtensionVersionHasPrefix applies the HasPrefix predicate on the "extension_version" field.
+func ExtensionVersionHasPrefix(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldHasPrefix(FieldExtensionVersion, v))
+}
+
+// ExtensionVersionHasSuffix applies the HasSuffix predicate on the "extension_version" field.
+func ExtensionVersionHasSuffix(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldHasSuffix(FieldExtensionVersion, v))
+}
+
+// ExtensionVersionIsNil applies the IsNil predicate on the "extension_version" field.
+func ExtensionVersionIsNil() predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldIsNull(FieldExtensionVersion))
+}
+
+// ExtensionVersionNotNil applies the NotNil predicate on the "extension_version" field.
+func ExtensionVersionNotNil() predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldNotNull(FieldExtensionVersion))
+}
+
+// ExtensionVersionEqualFold applies the EqualFold predicate on the "extension_version" field.
+func ExtensionVersionEqualFold(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldEqualFold(FieldExtensionVersion, v))
+}
+
+// ExtensionVersionContainsFold applies the ContainsFold predicate on the "extension_version" field.
+func ExtensionVersionContainsFold(v string) predicate.AgentRule {
+	return predicate.AgentRule(sql.FieldContainsFold(FieldExtensionVersion, v))
 }
 
 // IsDeletedEQ applies the EQ predicate on the "is_deleted" field.

--- a/backend/db/agentrule_create.go
+++ b/backend/db/agentrule_create.go
@@ -93,6 +93,48 @@ func (_c *AgentRuleCreate) SetNillableActiveVersionID(v *uuid.UUID) *AgentRuleCr
 	return _c
 }
 
+// SetExtensionPackageID sets the "extension_package_id" field.
+func (_c *AgentRuleCreate) SetExtensionPackageID(v string) *AgentRuleCreate {
+	_c.mutation.SetExtensionPackageID(v)
+	return _c
+}
+
+// SetNillableExtensionPackageID sets the "extension_package_id" field if the given value is not nil.
+func (_c *AgentRuleCreate) SetNillableExtensionPackageID(v *string) *AgentRuleCreate {
+	if v != nil {
+		_c.SetExtensionPackageID(*v)
+	}
+	return _c
+}
+
+// SetExtensionRuleID sets the "extension_rule_id" field.
+func (_c *AgentRuleCreate) SetExtensionRuleID(v string) *AgentRuleCreate {
+	_c.mutation.SetExtensionRuleID(v)
+	return _c
+}
+
+// SetNillableExtensionRuleID sets the "extension_rule_id" field if the given value is not nil.
+func (_c *AgentRuleCreate) SetNillableExtensionRuleID(v *string) *AgentRuleCreate {
+	if v != nil {
+		_c.SetExtensionRuleID(*v)
+	}
+	return _c
+}
+
+// SetExtensionVersion sets the "extension_version" field.
+func (_c *AgentRuleCreate) SetExtensionVersion(v string) *AgentRuleCreate {
+	_c.mutation.SetExtensionVersion(v)
+	return _c
+}
+
+// SetNillableExtensionVersion sets the "extension_version" field if the given value is not nil.
+func (_c *AgentRuleCreate) SetNillableExtensionVersion(v *string) *AgentRuleCreate {
+	if v != nil {
+		_c.SetExtensionVersion(*v)
+	}
+	return _c
+}
+
 // SetIsDeleted sets the "is_deleted" field.
 func (_c *AgentRuleCreate) SetIsDeleted(v bool) *AgentRuleCreate {
 	_c.mutation.SetIsDeleted(v)
@@ -318,6 +360,18 @@ func (_c *AgentRuleCreate) createSpec() (*AgentRule, *sqlgraph.CreateSpec) {
 		_spec.SetField(agentrule.FieldActiveVersionID, field.TypeUUID, value)
 		_node.ActiveVersionID = &value
 	}
+	if value, ok := _c.mutation.ExtensionPackageID(); ok {
+		_spec.SetField(agentrule.FieldExtensionPackageID, field.TypeString, value)
+		_node.ExtensionPackageID = &value
+	}
+	if value, ok := _c.mutation.ExtensionRuleID(); ok {
+		_spec.SetField(agentrule.FieldExtensionRuleID, field.TypeString, value)
+		_node.ExtensionRuleID = &value
+	}
+	if value, ok := _c.mutation.ExtensionVersion(); ok {
+		_spec.SetField(agentrule.FieldExtensionVersion, field.TypeString, value)
+		_node.ExtensionVersion = &value
+	}
 	if value, ok := _c.mutation.IsDeleted(); ok {
 		_spec.SetField(agentrule.FieldIsDeleted, field.TypeBool, value)
 		_node.IsDeleted = value
@@ -479,6 +533,60 @@ func (u *AgentRuleUpsert) UpdateActiveVersionID() *AgentRuleUpsert {
 // ClearActiveVersionID clears the value of the "active_version_id" field.
 func (u *AgentRuleUpsert) ClearActiveVersionID() *AgentRuleUpsert {
 	u.SetNull(agentrule.FieldActiveVersionID)
+	return u
+}
+
+// SetExtensionPackageID sets the "extension_package_id" field.
+func (u *AgentRuleUpsert) SetExtensionPackageID(v string) *AgentRuleUpsert {
+	u.Set(agentrule.FieldExtensionPackageID, v)
+	return u
+}
+
+// UpdateExtensionPackageID sets the "extension_package_id" field to the value that was provided on create.
+func (u *AgentRuleUpsert) UpdateExtensionPackageID() *AgentRuleUpsert {
+	u.SetExcluded(agentrule.FieldExtensionPackageID)
+	return u
+}
+
+// ClearExtensionPackageID clears the value of the "extension_package_id" field.
+func (u *AgentRuleUpsert) ClearExtensionPackageID() *AgentRuleUpsert {
+	u.SetNull(agentrule.FieldExtensionPackageID)
+	return u
+}
+
+// SetExtensionRuleID sets the "extension_rule_id" field.
+func (u *AgentRuleUpsert) SetExtensionRuleID(v string) *AgentRuleUpsert {
+	u.Set(agentrule.FieldExtensionRuleID, v)
+	return u
+}
+
+// UpdateExtensionRuleID sets the "extension_rule_id" field to the value that was provided on create.
+func (u *AgentRuleUpsert) UpdateExtensionRuleID() *AgentRuleUpsert {
+	u.SetExcluded(agentrule.FieldExtensionRuleID)
+	return u
+}
+
+// ClearExtensionRuleID clears the value of the "extension_rule_id" field.
+func (u *AgentRuleUpsert) ClearExtensionRuleID() *AgentRuleUpsert {
+	u.SetNull(agentrule.FieldExtensionRuleID)
+	return u
+}
+
+// SetExtensionVersion sets the "extension_version" field.
+func (u *AgentRuleUpsert) SetExtensionVersion(v string) *AgentRuleUpsert {
+	u.Set(agentrule.FieldExtensionVersion, v)
+	return u
+}
+
+// UpdateExtensionVersion sets the "extension_version" field to the value that was provided on create.
+func (u *AgentRuleUpsert) UpdateExtensionVersion() *AgentRuleUpsert {
+	u.SetExcluded(agentrule.FieldExtensionVersion)
+	return u
+}
+
+// ClearExtensionVersion clears the value of the "extension_version" field.
+func (u *AgentRuleUpsert) ClearExtensionVersion() *AgentRuleUpsert {
+	u.SetNull(agentrule.FieldExtensionVersion)
 	return u
 }
 
@@ -661,6 +769,69 @@ func (u *AgentRuleUpsertOne) UpdateActiveVersionID() *AgentRuleUpsertOne {
 func (u *AgentRuleUpsertOne) ClearActiveVersionID() *AgentRuleUpsertOne {
 	return u.Update(func(s *AgentRuleUpsert) {
 		s.ClearActiveVersionID()
+	})
+}
+
+// SetExtensionPackageID sets the "extension_package_id" field.
+func (u *AgentRuleUpsertOne) SetExtensionPackageID(v string) *AgentRuleUpsertOne {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.SetExtensionPackageID(v)
+	})
+}
+
+// UpdateExtensionPackageID sets the "extension_package_id" field to the value that was provided on create.
+func (u *AgentRuleUpsertOne) UpdateExtensionPackageID() *AgentRuleUpsertOne {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.UpdateExtensionPackageID()
+	})
+}
+
+// ClearExtensionPackageID clears the value of the "extension_package_id" field.
+func (u *AgentRuleUpsertOne) ClearExtensionPackageID() *AgentRuleUpsertOne {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.ClearExtensionPackageID()
+	})
+}
+
+// SetExtensionRuleID sets the "extension_rule_id" field.
+func (u *AgentRuleUpsertOne) SetExtensionRuleID(v string) *AgentRuleUpsertOne {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.SetExtensionRuleID(v)
+	})
+}
+
+// UpdateExtensionRuleID sets the "extension_rule_id" field to the value that was provided on create.
+func (u *AgentRuleUpsertOne) UpdateExtensionRuleID() *AgentRuleUpsertOne {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.UpdateExtensionRuleID()
+	})
+}
+
+// ClearExtensionRuleID clears the value of the "extension_rule_id" field.
+func (u *AgentRuleUpsertOne) ClearExtensionRuleID() *AgentRuleUpsertOne {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.ClearExtensionRuleID()
+	})
+}
+
+// SetExtensionVersion sets the "extension_version" field.
+func (u *AgentRuleUpsertOne) SetExtensionVersion(v string) *AgentRuleUpsertOne {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.SetExtensionVersion(v)
+	})
+}
+
+// UpdateExtensionVersion sets the "extension_version" field to the value that was provided on create.
+func (u *AgentRuleUpsertOne) UpdateExtensionVersion() *AgentRuleUpsertOne {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.UpdateExtensionVersion()
+	})
+}
+
+// ClearExtensionVersion clears the value of the "extension_version" field.
+func (u *AgentRuleUpsertOne) ClearExtensionVersion() *AgentRuleUpsertOne {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.ClearExtensionVersion()
 	})
 }
 
@@ -1016,6 +1187,69 @@ func (u *AgentRuleUpsertBulk) UpdateActiveVersionID() *AgentRuleUpsertBulk {
 func (u *AgentRuleUpsertBulk) ClearActiveVersionID() *AgentRuleUpsertBulk {
 	return u.Update(func(s *AgentRuleUpsert) {
 		s.ClearActiveVersionID()
+	})
+}
+
+// SetExtensionPackageID sets the "extension_package_id" field.
+func (u *AgentRuleUpsertBulk) SetExtensionPackageID(v string) *AgentRuleUpsertBulk {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.SetExtensionPackageID(v)
+	})
+}
+
+// UpdateExtensionPackageID sets the "extension_package_id" field to the value that was provided on create.
+func (u *AgentRuleUpsertBulk) UpdateExtensionPackageID() *AgentRuleUpsertBulk {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.UpdateExtensionPackageID()
+	})
+}
+
+// ClearExtensionPackageID clears the value of the "extension_package_id" field.
+func (u *AgentRuleUpsertBulk) ClearExtensionPackageID() *AgentRuleUpsertBulk {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.ClearExtensionPackageID()
+	})
+}
+
+// SetExtensionRuleID sets the "extension_rule_id" field.
+func (u *AgentRuleUpsertBulk) SetExtensionRuleID(v string) *AgentRuleUpsertBulk {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.SetExtensionRuleID(v)
+	})
+}
+
+// UpdateExtensionRuleID sets the "extension_rule_id" field to the value that was provided on create.
+func (u *AgentRuleUpsertBulk) UpdateExtensionRuleID() *AgentRuleUpsertBulk {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.UpdateExtensionRuleID()
+	})
+}
+
+// ClearExtensionRuleID clears the value of the "extension_rule_id" field.
+func (u *AgentRuleUpsertBulk) ClearExtensionRuleID() *AgentRuleUpsertBulk {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.ClearExtensionRuleID()
+	})
+}
+
+// SetExtensionVersion sets the "extension_version" field.
+func (u *AgentRuleUpsertBulk) SetExtensionVersion(v string) *AgentRuleUpsertBulk {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.SetExtensionVersion(v)
+	})
+}
+
+// UpdateExtensionVersion sets the "extension_version" field to the value that was provided on create.
+func (u *AgentRuleUpsertBulk) UpdateExtensionVersion() *AgentRuleUpsertBulk {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.UpdateExtensionVersion()
+	})
+}
+
+// ClearExtensionVersion clears the value of the "extension_version" field.
+func (u *AgentRuleUpsertBulk) ClearExtensionVersion() *AgentRuleUpsertBulk {
+	return u.Update(func(s *AgentRuleUpsert) {
+		s.ClearExtensionVersion()
 	})
 }
 

--- a/backend/db/agentrule_update.go
+++ b/backend/db/agentrule_update.go
@@ -127,6 +127,66 @@ func (_u *AgentRuleUpdate) ClearActiveVersionID() *AgentRuleUpdate {
 	return _u
 }
 
+// SetExtensionPackageID sets the "extension_package_id" field.
+func (_u *AgentRuleUpdate) SetExtensionPackageID(v string) *AgentRuleUpdate {
+	_u.mutation.SetExtensionPackageID(v)
+	return _u
+}
+
+// SetNillableExtensionPackageID sets the "extension_package_id" field if the given value is not nil.
+func (_u *AgentRuleUpdate) SetNillableExtensionPackageID(v *string) *AgentRuleUpdate {
+	if v != nil {
+		_u.SetExtensionPackageID(*v)
+	}
+	return _u
+}
+
+// ClearExtensionPackageID clears the value of the "extension_package_id" field.
+func (_u *AgentRuleUpdate) ClearExtensionPackageID() *AgentRuleUpdate {
+	_u.mutation.ClearExtensionPackageID()
+	return _u
+}
+
+// SetExtensionRuleID sets the "extension_rule_id" field.
+func (_u *AgentRuleUpdate) SetExtensionRuleID(v string) *AgentRuleUpdate {
+	_u.mutation.SetExtensionRuleID(v)
+	return _u
+}
+
+// SetNillableExtensionRuleID sets the "extension_rule_id" field if the given value is not nil.
+func (_u *AgentRuleUpdate) SetNillableExtensionRuleID(v *string) *AgentRuleUpdate {
+	if v != nil {
+		_u.SetExtensionRuleID(*v)
+	}
+	return _u
+}
+
+// ClearExtensionRuleID clears the value of the "extension_rule_id" field.
+func (_u *AgentRuleUpdate) ClearExtensionRuleID() *AgentRuleUpdate {
+	_u.mutation.ClearExtensionRuleID()
+	return _u
+}
+
+// SetExtensionVersion sets the "extension_version" field.
+func (_u *AgentRuleUpdate) SetExtensionVersion(v string) *AgentRuleUpdate {
+	_u.mutation.SetExtensionVersion(v)
+	return _u
+}
+
+// SetNillableExtensionVersion sets the "extension_version" field if the given value is not nil.
+func (_u *AgentRuleUpdate) SetNillableExtensionVersion(v *string) *AgentRuleUpdate {
+	if v != nil {
+		_u.SetExtensionVersion(*v)
+	}
+	return _u
+}
+
+// ClearExtensionVersion clears the value of the "extension_version" field.
+func (_u *AgentRuleUpdate) ClearExtensionVersion() *AgentRuleUpdate {
+	_u.mutation.ClearExtensionVersion()
+	return _u
+}
+
 // SetIsDeleted sets the "is_deleted" field.
 func (_u *AgentRuleUpdate) SetIsDeleted(v bool) *AgentRuleUpdate {
 	_u.mutation.SetIsDeleted(v)
@@ -294,6 +354,24 @@ func (_u *AgentRuleUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if _u.mutation.ActiveVersionIDCleared() {
 		_spec.ClearField(agentrule.FieldActiveVersionID, field.TypeUUID)
+	}
+	if value, ok := _u.mutation.ExtensionPackageID(); ok {
+		_spec.SetField(agentrule.FieldExtensionPackageID, field.TypeString, value)
+	}
+	if _u.mutation.ExtensionPackageIDCleared() {
+		_spec.ClearField(agentrule.FieldExtensionPackageID, field.TypeString)
+	}
+	if value, ok := _u.mutation.ExtensionRuleID(); ok {
+		_spec.SetField(agentrule.FieldExtensionRuleID, field.TypeString, value)
+	}
+	if _u.mutation.ExtensionRuleIDCleared() {
+		_spec.ClearField(agentrule.FieldExtensionRuleID, field.TypeString)
+	}
+	if value, ok := _u.mutation.ExtensionVersion(); ok {
+		_spec.SetField(agentrule.FieldExtensionVersion, field.TypeString, value)
+	}
+	if _u.mutation.ExtensionVersionCleared() {
+		_spec.ClearField(agentrule.FieldExtensionVersion, field.TypeString)
 	}
 	if value, ok := _u.mutation.IsDeleted(); ok {
 		_spec.SetField(agentrule.FieldIsDeleted, field.TypeBool, value)
@@ -464,6 +542,66 @@ func (_u *AgentRuleUpdateOne) SetNillableActiveVersionID(v *uuid.UUID) *AgentRul
 // ClearActiveVersionID clears the value of the "active_version_id" field.
 func (_u *AgentRuleUpdateOne) ClearActiveVersionID() *AgentRuleUpdateOne {
 	_u.mutation.ClearActiveVersionID()
+	return _u
+}
+
+// SetExtensionPackageID sets the "extension_package_id" field.
+func (_u *AgentRuleUpdateOne) SetExtensionPackageID(v string) *AgentRuleUpdateOne {
+	_u.mutation.SetExtensionPackageID(v)
+	return _u
+}
+
+// SetNillableExtensionPackageID sets the "extension_package_id" field if the given value is not nil.
+func (_u *AgentRuleUpdateOne) SetNillableExtensionPackageID(v *string) *AgentRuleUpdateOne {
+	if v != nil {
+		_u.SetExtensionPackageID(*v)
+	}
+	return _u
+}
+
+// ClearExtensionPackageID clears the value of the "extension_package_id" field.
+func (_u *AgentRuleUpdateOne) ClearExtensionPackageID() *AgentRuleUpdateOne {
+	_u.mutation.ClearExtensionPackageID()
+	return _u
+}
+
+// SetExtensionRuleID sets the "extension_rule_id" field.
+func (_u *AgentRuleUpdateOne) SetExtensionRuleID(v string) *AgentRuleUpdateOne {
+	_u.mutation.SetExtensionRuleID(v)
+	return _u
+}
+
+// SetNillableExtensionRuleID sets the "extension_rule_id" field if the given value is not nil.
+func (_u *AgentRuleUpdateOne) SetNillableExtensionRuleID(v *string) *AgentRuleUpdateOne {
+	if v != nil {
+		_u.SetExtensionRuleID(*v)
+	}
+	return _u
+}
+
+// ClearExtensionRuleID clears the value of the "extension_rule_id" field.
+func (_u *AgentRuleUpdateOne) ClearExtensionRuleID() *AgentRuleUpdateOne {
+	_u.mutation.ClearExtensionRuleID()
+	return _u
+}
+
+// SetExtensionVersion sets the "extension_version" field.
+func (_u *AgentRuleUpdateOne) SetExtensionVersion(v string) *AgentRuleUpdateOne {
+	_u.mutation.SetExtensionVersion(v)
+	return _u
+}
+
+// SetNillableExtensionVersion sets the "extension_version" field if the given value is not nil.
+func (_u *AgentRuleUpdateOne) SetNillableExtensionVersion(v *string) *AgentRuleUpdateOne {
+	if v != nil {
+		_u.SetExtensionVersion(*v)
+	}
+	return _u
+}
+
+// ClearExtensionVersion clears the value of the "extension_version" field.
+func (_u *AgentRuleUpdateOne) ClearExtensionVersion() *AgentRuleUpdateOne {
+	_u.mutation.ClearExtensionVersion()
 	return _u
 }
 
@@ -664,6 +802,24 @@ func (_u *AgentRuleUpdateOne) sqlSave(ctx context.Context) (_node *AgentRule, er
 	}
 	if _u.mutation.ActiveVersionIDCleared() {
 		_spec.ClearField(agentrule.FieldActiveVersionID, field.TypeUUID)
+	}
+	if value, ok := _u.mutation.ExtensionPackageID(); ok {
+		_spec.SetField(agentrule.FieldExtensionPackageID, field.TypeString, value)
+	}
+	if _u.mutation.ExtensionPackageIDCleared() {
+		_spec.ClearField(agentrule.FieldExtensionPackageID, field.TypeString)
+	}
+	if value, ok := _u.mutation.ExtensionRuleID(); ok {
+		_spec.SetField(agentrule.FieldExtensionRuleID, field.TypeString, value)
+	}
+	if _u.mutation.ExtensionRuleIDCleared() {
+		_spec.ClearField(agentrule.FieldExtensionRuleID, field.TypeString)
+	}
+	if value, ok := _u.mutation.ExtensionVersion(); ok {
+		_spec.SetField(agentrule.FieldExtensionVersion, field.TypeString, value)
+	}
+	if _u.mutation.ExtensionVersionCleared() {
+		_spec.ClearField(agentrule.FieldExtensionVersion, field.TypeString)
 	}
 	if value, ok := _u.mutation.IsDeleted(); ok {
 		_spec.SetField(agentrule.FieldIsDeleted, field.TypeBool, value)

--- a/backend/db/migrate/schema.go
+++ b/backend/db/migrate/schema.go
@@ -131,6 +131,9 @@ var (
 		{Name: "scope_id", Type: field.TypeString, Default: "global"},
 		{Name: "created_by", Type: field.TypeUUID},
 		{Name: "active_version_id", Type: field.TypeUUID, Nullable: true},
+		{Name: "extension_package_id", Type: field.TypeString, Nullable: true},
+		{Name: "extension_rule_id", Type: field.TypeString, Nullable: true},
+		{Name: "extension_version", Type: field.TypeString, Nullable: true},
 		{Name: "is_deleted", Type: field.TypeBool, Default: false},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
@@ -150,6 +153,11 @@ var (
 				Name:    "agentrule_active_version_id",
 				Unique:  false,
 				Columns: []*schema.Column{AgentRulesColumns[6]},
+			},
+			{
+				Name:    "agentrule_extension_package_id_extension_rule_id",
+				Unique:  false,
+				Columns: []*schema.Column{AgentRulesColumns[7], AgentRulesColumns[8]},
 			},
 		},
 	}

--- a/backend/db/mutation.go
+++ b/backend/db/mutation.go
@@ -3470,25 +3470,28 @@ func (m *AgentPluginVersionMutation) ResetEdge(name string) error {
 // AgentRuleMutation represents an operation that mutates the AgentRule nodes in the graph.
 type AgentRuleMutation struct {
 	config
-	op                Op
-	typ               string
-	id                *uuid.UUID
-	name              *string
-	description       *string
-	scope_type        *agentrule.ScopeType
-	scope_id          *string
-	created_by        *uuid.UUID
-	active_version_id *uuid.UUID
-	is_deleted        *bool
-	created_at        *time.Time
-	updated_at        *time.Time
-	clearedFields     map[string]struct{}
-	versions          map[uuid.UUID]struct{}
-	removedversions   map[uuid.UUID]struct{}
-	clearedversions   bool
-	done              bool
-	oldValue          func(context.Context) (*AgentRule, error)
-	predicates        []predicate.AgentRule
+	op                   Op
+	typ                  string
+	id                   *uuid.UUID
+	name                 *string
+	description          *string
+	scope_type           *agentrule.ScopeType
+	scope_id             *string
+	created_by           *uuid.UUID
+	active_version_id    *uuid.UUID
+	extension_package_id *string
+	extension_rule_id    *string
+	extension_version    *string
+	is_deleted           *bool
+	created_at           *time.Time
+	updated_at           *time.Time
+	clearedFields        map[string]struct{}
+	versions             map[uuid.UUID]struct{}
+	removedversions      map[uuid.UUID]struct{}
+	clearedversions      bool
+	done                 bool
+	oldValue             func(context.Context) (*AgentRule, error)
+	predicates           []predicate.AgentRule
 }
 
 var _ ent.Mutation = (*AgentRuleMutation)(nil)
@@ -3837,6 +3840,153 @@ func (m *AgentRuleMutation) ResetActiveVersionID() {
 	delete(m.clearedFields, agentrule.FieldActiveVersionID)
 }
 
+// SetExtensionPackageID sets the "extension_package_id" field.
+func (m *AgentRuleMutation) SetExtensionPackageID(s string) {
+	m.extension_package_id = &s
+}
+
+// ExtensionPackageID returns the value of the "extension_package_id" field in the mutation.
+func (m *AgentRuleMutation) ExtensionPackageID() (r string, exists bool) {
+	v := m.extension_package_id
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldExtensionPackageID returns the old "extension_package_id" field's value of the AgentRule entity.
+// If the AgentRule object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AgentRuleMutation) OldExtensionPackageID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExtensionPackageID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExtensionPackageID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExtensionPackageID: %w", err)
+	}
+	return oldValue.ExtensionPackageID, nil
+}
+
+// ClearExtensionPackageID clears the value of the "extension_package_id" field.
+func (m *AgentRuleMutation) ClearExtensionPackageID() {
+	m.extension_package_id = nil
+	m.clearedFields[agentrule.FieldExtensionPackageID] = struct{}{}
+}
+
+// ExtensionPackageIDCleared returns if the "extension_package_id" field was cleared in this mutation.
+func (m *AgentRuleMutation) ExtensionPackageIDCleared() bool {
+	_, ok := m.clearedFields[agentrule.FieldExtensionPackageID]
+	return ok
+}
+
+// ResetExtensionPackageID resets all changes to the "extension_package_id" field.
+func (m *AgentRuleMutation) ResetExtensionPackageID() {
+	m.extension_package_id = nil
+	delete(m.clearedFields, agentrule.FieldExtensionPackageID)
+}
+
+// SetExtensionRuleID sets the "extension_rule_id" field.
+func (m *AgentRuleMutation) SetExtensionRuleID(s string) {
+	m.extension_rule_id = &s
+}
+
+// ExtensionRuleID returns the value of the "extension_rule_id" field in the mutation.
+func (m *AgentRuleMutation) ExtensionRuleID() (r string, exists bool) {
+	v := m.extension_rule_id
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldExtensionRuleID returns the old "extension_rule_id" field's value of the AgentRule entity.
+// If the AgentRule object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AgentRuleMutation) OldExtensionRuleID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExtensionRuleID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExtensionRuleID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExtensionRuleID: %w", err)
+	}
+	return oldValue.ExtensionRuleID, nil
+}
+
+// ClearExtensionRuleID clears the value of the "extension_rule_id" field.
+func (m *AgentRuleMutation) ClearExtensionRuleID() {
+	m.extension_rule_id = nil
+	m.clearedFields[agentrule.FieldExtensionRuleID] = struct{}{}
+}
+
+// ExtensionRuleIDCleared returns if the "extension_rule_id" field was cleared in this mutation.
+func (m *AgentRuleMutation) ExtensionRuleIDCleared() bool {
+	_, ok := m.clearedFields[agentrule.FieldExtensionRuleID]
+	return ok
+}
+
+// ResetExtensionRuleID resets all changes to the "extension_rule_id" field.
+func (m *AgentRuleMutation) ResetExtensionRuleID() {
+	m.extension_rule_id = nil
+	delete(m.clearedFields, agentrule.FieldExtensionRuleID)
+}
+
+// SetExtensionVersion sets the "extension_version" field.
+func (m *AgentRuleMutation) SetExtensionVersion(s string) {
+	m.extension_version = &s
+}
+
+// ExtensionVersion returns the value of the "extension_version" field in the mutation.
+func (m *AgentRuleMutation) ExtensionVersion() (r string, exists bool) {
+	v := m.extension_version
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldExtensionVersion returns the old "extension_version" field's value of the AgentRule entity.
+// If the AgentRule object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AgentRuleMutation) OldExtensionVersion(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExtensionVersion is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExtensionVersion requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExtensionVersion: %w", err)
+	}
+	return oldValue.ExtensionVersion, nil
+}
+
+// ClearExtensionVersion clears the value of the "extension_version" field.
+func (m *AgentRuleMutation) ClearExtensionVersion() {
+	m.extension_version = nil
+	m.clearedFields[agentrule.FieldExtensionVersion] = struct{}{}
+}
+
+// ExtensionVersionCleared returns if the "extension_version" field was cleared in this mutation.
+func (m *AgentRuleMutation) ExtensionVersionCleared() bool {
+	_, ok := m.clearedFields[agentrule.FieldExtensionVersion]
+	return ok
+}
+
+// ResetExtensionVersion resets all changes to the "extension_version" field.
+func (m *AgentRuleMutation) ResetExtensionVersion() {
+	m.extension_version = nil
+	delete(m.clearedFields, agentrule.FieldExtensionVersion)
+}
+
 // SetIsDeleted sets the "is_deleted" field.
 func (m *AgentRuleMutation) SetIsDeleted(b bool) {
 	m.is_deleted = &b
@@ -4033,7 +4183,7 @@ func (m *AgentRuleMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *AgentRuleMutation) Fields() []string {
-	fields := make([]string, 0, 9)
+	fields := make([]string, 0, 12)
 	if m.name != nil {
 		fields = append(fields, agentrule.FieldName)
 	}
@@ -4051,6 +4201,15 @@ func (m *AgentRuleMutation) Fields() []string {
 	}
 	if m.active_version_id != nil {
 		fields = append(fields, agentrule.FieldActiveVersionID)
+	}
+	if m.extension_package_id != nil {
+		fields = append(fields, agentrule.FieldExtensionPackageID)
+	}
+	if m.extension_rule_id != nil {
+		fields = append(fields, agentrule.FieldExtensionRuleID)
+	}
+	if m.extension_version != nil {
+		fields = append(fields, agentrule.FieldExtensionVersion)
 	}
 	if m.is_deleted != nil {
 		fields = append(fields, agentrule.FieldIsDeleted)
@@ -4081,6 +4240,12 @@ func (m *AgentRuleMutation) Field(name string) (ent.Value, bool) {
 		return m.CreatedBy()
 	case agentrule.FieldActiveVersionID:
 		return m.ActiveVersionID()
+	case agentrule.FieldExtensionPackageID:
+		return m.ExtensionPackageID()
+	case agentrule.FieldExtensionRuleID:
+		return m.ExtensionRuleID()
+	case agentrule.FieldExtensionVersion:
+		return m.ExtensionVersion()
 	case agentrule.FieldIsDeleted:
 		return m.IsDeleted()
 	case agentrule.FieldCreatedAt:
@@ -4108,6 +4273,12 @@ func (m *AgentRuleMutation) OldField(ctx context.Context, name string) (ent.Valu
 		return m.OldCreatedBy(ctx)
 	case agentrule.FieldActiveVersionID:
 		return m.OldActiveVersionID(ctx)
+	case agentrule.FieldExtensionPackageID:
+		return m.OldExtensionPackageID(ctx)
+	case agentrule.FieldExtensionRuleID:
+		return m.OldExtensionRuleID(ctx)
+	case agentrule.FieldExtensionVersion:
+		return m.OldExtensionVersion(ctx)
 	case agentrule.FieldIsDeleted:
 		return m.OldIsDeleted(ctx)
 	case agentrule.FieldCreatedAt:
@@ -4164,6 +4335,27 @@ func (m *AgentRuleMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetActiveVersionID(v)
+		return nil
+	case agentrule.FieldExtensionPackageID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExtensionPackageID(v)
+		return nil
+	case agentrule.FieldExtensionRuleID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExtensionRuleID(v)
+		return nil
+	case agentrule.FieldExtensionVersion:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExtensionVersion(v)
 		return nil
 	case agentrule.FieldIsDeleted:
 		v, ok := value.(bool)
@@ -4222,6 +4414,15 @@ func (m *AgentRuleMutation) ClearedFields() []string {
 	if m.FieldCleared(agentrule.FieldActiveVersionID) {
 		fields = append(fields, agentrule.FieldActiveVersionID)
 	}
+	if m.FieldCleared(agentrule.FieldExtensionPackageID) {
+		fields = append(fields, agentrule.FieldExtensionPackageID)
+	}
+	if m.FieldCleared(agentrule.FieldExtensionRuleID) {
+		fields = append(fields, agentrule.FieldExtensionRuleID)
+	}
+	if m.FieldCleared(agentrule.FieldExtensionVersion) {
+		fields = append(fields, agentrule.FieldExtensionVersion)
+	}
 	return fields
 }
 
@@ -4241,6 +4442,15 @@ func (m *AgentRuleMutation) ClearField(name string) error {
 		return nil
 	case agentrule.FieldActiveVersionID:
 		m.ClearActiveVersionID()
+		return nil
+	case agentrule.FieldExtensionPackageID:
+		m.ClearExtensionPackageID()
+		return nil
+	case agentrule.FieldExtensionRuleID:
+		m.ClearExtensionRuleID()
+		return nil
+	case agentrule.FieldExtensionVersion:
+		m.ClearExtensionVersion()
 		return nil
 	}
 	return fmt.Errorf("unknown AgentRule nullable field %s", name)
@@ -4267,6 +4477,15 @@ func (m *AgentRuleMutation) ResetField(name string) error {
 		return nil
 	case agentrule.FieldActiveVersionID:
 		m.ResetActiveVersionID()
+		return nil
+	case agentrule.FieldExtensionPackageID:
+		m.ResetExtensionPackageID()
+		return nil
+	case agentrule.FieldExtensionRuleID:
+		m.ResetExtensionRuleID()
+		return nil
+	case agentrule.FieldExtensionVersion:
+		m.ResetExtensionVersion()
 		return nil
 	case agentrule.FieldIsDeleted:
 		m.ResetIsDeleted()

--- a/backend/db/runtime/runtime.go
+++ b/backend/db/runtime/runtime.go
@@ -169,15 +169,15 @@ func init() {
 	// agentrule.DefaultScopeID holds the default value on creation for the scope_id field.
 	agentrule.DefaultScopeID = agentruleDescScopeID.Default.(string)
 	// agentruleDescIsDeleted is the schema descriptor for is_deleted field.
-	agentruleDescIsDeleted := agentruleFields[7].Descriptor()
+	agentruleDescIsDeleted := agentruleFields[10].Descriptor()
 	// agentrule.DefaultIsDeleted holds the default value on creation for the is_deleted field.
 	agentrule.DefaultIsDeleted = agentruleDescIsDeleted.Default.(bool)
 	// agentruleDescCreatedAt is the schema descriptor for created_at field.
-	agentruleDescCreatedAt := agentruleFields[8].Descriptor()
+	agentruleDescCreatedAt := agentruleFields[11].Descriptor()
 	// agentrule.DefaultCreatedAt holds the default value on creation for the created_at field.
 	agentrule.DefaultCreatedAt = agentruleDescCreatedAt.Default.(func() time.Time)
 	// agentruleDescUpdatedAt is the schema descriptor for updated_at field.
-	agentruleDescUpdatedAt := agentruleFields[9].Descriptor()
+	agentruleDescUpdatedAt := agentruleFields[12].Descriptor()
 	// agentrule.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	agentrule.DefaultUpdatedAt = agentruleDescUpdatedAt.Default.(func() time.Time)
 	// agentrule.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.

--- a/backend/domain/team.go
+++ b/backend/domain/team.go
@@ -60,7 +60,12 @@ type TeamGroupUserRepo interface {
 	DeleteUser(ctx context.Context, teamID, userID uuid.UUID) error
 	GetMembersByIDs(ctx context.Context, teamID uuid.UUID, userIDs []uuid.UUID) ([]*db.TeamMember, error)
 	GetMember(ctx context.Context, teamID, userID uuid.UUID) (*db.TeamMember, error)
-	InitTeam(ctx context.Context, email, name, password, image string) error
+	InitTeam(ctx context.Context, email, name, password, image string) (*InitTeamResult, error)
+}
+
+type InitTeamResult struct {
+	TeamID uuid.UUID
+	UserID uuid.UUID
 }
 
 type TeamPolicyRepo interface {

--- a/backend/domain/team_extension_package.go
+++ b/backend/domain/team_extension_package.go
@@ -25,6 +25,8 @@ type ImportTeamExtensionPackageReq struct {
 type ImportTeamExtensionPackageResp struct {
 	PackageID     string `json:"package_id"`
 	Version       string `json:"version"`
+	CreatedRules  int    `json:"created_rules"`
+	UpdatedRules  int    `json:"updated_rules"`
 	CreatedSkills int    `json:"created_skills"`
 	UpdatedSkills int    `json:"updated_skills"`
 	CreatedImages int    `json:"created_images"`
@@ -68,4 +70,9 @@ type TeamExtensionImportResult struct {
 	UpdatedSkills int
 	CreatedImages int
 	UpdatedImages int
+}
+
+type ExtensionRuleImportResult struct {
+	CreatedRules int
+	UpdatedRules int
 }

--- a/backend/ent/schema/agent_rule.go
+++ b/backend/ent/schema/agent_rule.go
@@ -33,6 +33,9 @@ func (AgentRule) Fields() []ent.Field {
 		field.String("scope_id").Default("global"),
 		field.UUID("created_by", uuid.UUID{}),
 		field.UUID("active_version_id", uuid.UUID{}).Optional().Nillable(),
+		field.String("extension_package_id").Optional().Nillable(),
+		field.String("extension_rule_id").Optional().Nillable(),
+		field.String("extension_version").Optional().Nillable(),
 		field.Bool("is_deleted").Default(false),
 		field.Time("created_at").Default(time.Now),
 		field.Time("updated_at").Default(time.Now).UpdateDefault(time.Now),
@@ -51,6 +54,7 @@ func (AgentRule) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("scope_type", "scope_id"),
 		index.Fields("active_version_id"),
+		index.Fields("extension_package_id", "extension_rule_id"),
 	}
 }
 

--- a/backend/migration/000021_agent_rules_extension_source.down.sql
+++ b/backend/migration/000021_agent_rules_extension_source.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+DROP INDEX IF EXISTS idx_agent_rules_extension_source;
+
+ALTER TABLE agent_rules
+  DROP COLUMN IF EXISTS extension_version,
+  DROP COLUMN IF EXISTS extension_rule_id,
+  DROP COLUMN IF EXISTS extension_package_id;
+
+COMMIT;

--- a/backend/migration/000021_agent_rules_extension_source.up.sql
+++ b/backend/migration/000021_agent_rules_extension_source.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TABLE agent_rules
+  ADD COLUMN IF NOT EXISTS extension_package_id VARCHAR(255),
+  ADD COLUMN IF NOT EXISTS extension_rule_id VARCHAR(255),
+  ADD COLUMN IF NOT EXISTS extension_version VARCHAR(64);
+
+CREATE INDEX IF NOT EXISTS idx_agent_rules_extension_source
+  ON agent_rules (extension_package_id, extension_rule_id)
+  WHERE extension_package_id IS NOT NULL AND extension_rule_id IS NOT NULL;
+
+COMMIT;

--- a/backend/migration/migration_test.go
+++ b/backend/migration/migration_test.go
@@ -74,3 +74,28 @@ func TestTeamMCPHubMigrationAddsTeamScopeAndCalls(t *testing.T) {
 		}
 	}
 }
+
+func TestAgentRulesExtensionSourceMigrationExists(t *testing.T) {
+	up, err := os.ReadFile("000021_agent_rules_extension_source.up.sql")
+	if err != nil {
+		t.Fatalf("read up migration: %v", err)
+	}
+	for _, want := range []string{
+		"extension_package_id",
+		"extension_rule_id",
+		"extension_version",
+		"idx_agent_rules_extension_source",
+	} {
+		if !strings.Contains(string(up), want) {
+			t.Fatalf("up migration missing %q", want)
+		}
+	}
+
+	down, err := os.ReadFile("000021_agent_rules_extension_source.down.sql")
+	if err != nil {
+		t.Fatalf("read down migration: %v", err)
+	}
+	if !strings.Contains(string(down), "DROP COLUMN IF EXISTS extension_package_id") {
+		t.Fatalf("down migration does not drop extension source columns")
+	}
+}


### PR DESCRIPTION
## Summary
- 为 agent_rules 增加扩展包来源字段和迁移
- 扩展包 manifest 支持 rules，并导入为全局规则
- init_team 支持扫描本地扩展包目录并按文件名顺序导入

## Test Plan
- go test ./biz/team/... ./biz/agentresource ./migration -count=1
- go test ./... -count=1