### PR TITLE
feat: 新增产品版本查询接口

### DIFF
--- a/backend/biz/product/handler/v1/version.go
+++ b/backend/biz/product/handler/v1/version.go
@@ -1,0 +1,49 @@
+package v1
+
+import (
+	"log/slog"
+
+	"github.com/GoYoko/web"
+	"github.com/samber/do"
+
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+type VersionHandler struct {
+	provider domain.ProductVersionProvider
+	logger   *slog.Logger
+}
+
+func NewVersionHandler(i *do.Injector) (*VersionHandler, error) {
+	w := do.MustInvoke[*web.Web](i)
+	provider, err := do.Invoke[domain.ProductVersionProvider](i)
+	h := &VersionHandler{
+		provider: provider,
+		logger:   do.MustInvoke[*slog.Logger](i).With("handler", "product.version"),
+	}
+	if err != nil {
+		return h, nil
+	}
+
+	w.Group("/api/v1/product").GET("/version", web.BaseHandler(h.Get))
+	return h, nil
+}
+
+// Get 获取产品版本信息
+//
+//	@Summary		获取产品版本信息
+//	@Description	返回当前服务的产品形态，用于前端区分国内 SaaS、海外 SaaS 和私有化版本。
+//	@Tags			【产品】版本信息
+//	@Accept			json
+//	@Produce		json
+//	@Success		200	{object}	web.Resp{data=domain.ProductVersion}	"获取成功"
+//	@Failure		500	{object}	web.Resp								"服务器内部错误"
+//	@Router			/api/v1/product/version [get]
+func (h *VersionHandler) Get(c *web.Context) error {
+	info, err := h.provider.GetProductVersion(c.Request().Context())
+	if err != nil {
+		h.logger.ErrorContext(c.Request().Context(), "get product version failed", "error", err)
+		return err
+	}
+	return c.Success(info)
+}

--- a/backend/biz/product/register.go
+++ b/backend/biz/product/register.go
@@ -1,0 +1,15 @@
+package product
+
+import (
+	"github.com/samber/do"
+
+	v1 "github.com/chaitin/MonkeyCode/backend/biz/product/handler/v1"
+)
+
+func ProvideProduct(i *do.Injector) {
+	do.Provide(i, v1.NewVersionHandler)
+}
+
+func InvokeProduct(i *do.Injector) {
+	do.MustInvoke[*v1.VersionHandler](i)
+}

--- a/backend/biz/product/register_test.go
+++ b/backend/biz/product/register_test.go
@@ -1,0 +1,100 @@
+package product
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoYoko/web"
+	"github.com/samber/do"
+
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+type productVersionProviderStub struct {
+	info domain.ProductVersion
+}
+
+func (s productVersionProviderStub) GetProductVersion(context.Context) (domain.ProductVersion, error) {
+	return s.info, nil
+}
+
+func TestProductRegistersVersionRoute(t *testing.T) {
+	injector := do.New()
+	w := web.New()
+	do.ProvideValue(injector, w)
+	do.ProvideValue(injector, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	do.ProvideValue[domain.ProductVersionProvider](injector, productVersionProviderStub{})
+
+	ProvideProduct(injector)
+	InvokeProduct(injector)
+
+	if !hasRoute(w, http.MethodGet, "/api/v1/product/version") {
+		t.Fatal("GET /api/v1/product/version route is not registered")
+	}
+}
+
+func TestProductSkipsVersionRouteWithoutProvider(t *testing.T) {
+	injector := do.New()
+	w := web.New()
+	do.ProvideValue(injector, w)
+	do.ProvideValue(injector, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ProvideProduct(injector)
+	InvokeProduct(injector)
+
+	if hasRoute(w, http.MethodGet, "/api/v1/product/version") {
+		t.Fatal("GET /api/v1/product/version should not be registered without provider")
+	}
+}
+
+func TestProductVersionReturnsInjectedProviderInfo(t *testing.T) {
+	injector := do.New()
+	w := web.New()
+	do.ProvideValue(injector, w)
+	do.ProvideValue(injector, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	do.ProvideValue[domain.ProductVersionProvider](injector, productVersionProviderStub{
+		info: domain.ProductVersion{
+			Edition: domain.ProductEditionSaaSCN,
+		},
+	})
+
+	ProvideProduct(injector)
+	InvokeProduct(injector)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/product/version", nil)
+	rec := httptest.NewRecorder()
+	w.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Code    int                   `json:"code"`
+		Message string                `json:"message"`
+		Data    domain.ProductVersion `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Code != 0 || resp.Message != "success" {
+		t.Fatalf("response meta = (%d, %q), want (0, success)", resp.Code, resp.Message)
+	}
+	if resp.Data.Edition != domain.ProductEditionSaaSCN {
+		t.Fatalf("data = %+v", resp.Data)
+	}
+}
+
+func hasRoute(w *web.Web, method, path string) bool {
+	for _, route := range w.Routes() {
+		if route.Method == method && route.Path == path {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/biz/register.go
+++ b/backend/biz/register.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/biz/mcphub"
 	"github.com/chaitin/MonkeyCode/backend/biz/notify"
 	"github.com/chaitin/MonkeyCode/backend/biz/plugin"
+	"github.com/chaitin/MonkeyCode/backend/biz/product"
 	"github.com/chaitin/MonkeyCode/backend/biz/project"
 	"github.com/chaitin/MonkeyCode/backend/biz/public"
 	"github.com/chaitin/MonkeyCode/backend/biz/setting"
@@ -46,6 +47,7 @@ func RegisterAll(i *do.Injector) error {
 	vmidle.ProvideVMIdle(i)
 	skill.ProvideSkill(i)
 	plugin.ProvidePlugin(i)
+	product.ProvideProduct(i)
 	return nil
 }
 
@@ -63,6 +65,7 @@ func InvokeAll(i *do.Injector) {
 	vmidle.InvokeVMIdle(i)
 	skill.InvokeSkill(i)
 	plugin.InvokePlugin(i)
+	product.InvokeProduct(i)
 }
 
 // RegisterOpenSource 注册仅在开源项目中使用的模块

--- a/backend/bridge.go
+++ b/backend/bridge.go
@@ -104,6 +104,12 @@ func WithMemberManager(mm domain.MemberManager) BridgeOption {
 	}
 }
 
+func WithProductVersionProvider(provider domain.ProductVersionProvider) BridgeOption {
+	return func(i *do.Injector) {
+		do.ProvideValue(i, provider)
+	}
+}
+
 func Register(e *echo.Echo, dir string, opts ...BridgeOption) error {
 	cfg, err := config.Init(dir)
 	if err != nil {

--- a/backend/bridge_test.go
+++ b/backend/bridge_test.go
@@ -1,0 +1,32 @@
+package backend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samber/do"
+
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+type bridgeProductVersionProviderStub struct{}
+
+func (bridgeProductVersionProviderStub) GetProductVersion(context.Context) (domain.ProductVersion, error) {
+	return domain.ProductVersion{Edition: domain.ProductEditionPrivate}, nil
+}
+
+func TestWithProductVersionProviderRegistersProvider(t *testing.T) {
+	injector := do.New()
+	provider := bridgeProductVersionProviderStub{}
+
+	WithProductVersionProvider(provider)(injector)
+
+	got := do.MustInvoke[domain.ProductVersionProvider](injector)
+	info, err := got.GetProductVersion(context.Background())
+	if err != nil {
+		t.Fatalf("GetProductVersion: %v", err)
+	}
+	if info.Edition != domain.ProductEditionPrivate {
+		t.Fatalf("edition = %q, want %q", info.Edition, domain.ProductEditionPrivate)
+	}
+}

--- a/backend/domain/product_version.go
+++ b/backend/domain/product_version.go
@@ -1,0 +1,24 @@
+package domain
+
+import "context"
+
+// ProductEdition 表示当前服务的产品形态。
+type ProductEdition string
+
+const (
+	// ProductEditionSaaSCN 国内 SaaS 版本。
+	ProductEditionSaaSCN ProductEdition = "saas_cn"
+	// ProductEditionSaaSGlobal 海外 SaaS 版本。
+	ProductEditionSaaSGlobal ProductEdition = "saas_global"
+	// ProductEditionPrivate 私有化版本。
+	ProductEditionPrivate ProductEdition = "private"
+)
+
+type ProductVersion struct {
+	// Edition 当前产品形态：国内 SaaS、海外 SaaS 或私有化版本。
+	Edition ProductEdition `json:"edition" example:"saas_cn"`
+}
+
+type ProductVersionProvider interface {
+	GetProductVersion(ctx context.Context) (ProductVersion, error)
+}


### PR DESCRIPTION
## 变更内容
- 在 MonkeyCode 后端新增 `ProductVersionProvider` 接口与产品版本响应结构
- `ProductVersion.edition` 定义为 enum：`saas_cn` / `saas_global` / `private`，响应只返回 `edition`
- 新增 `GET /api/v1/product/version`，由外部仓库注入版本信息提供方
- 新增 `WithProductVersionProvider` bridge option，未注入时不注册该路由

## 验证
- `go test . ./domain ./biz/product`