### PR TITLE
fix: 规则扩展包导入使用时间版本号

### DIFF
--- a/backend/biz/team/usecase/extension_package_rules.go
+++ b/backend/biz/team/usecase/extension_package_rules.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -15,6 +16,9 @@ import (
 type extensionRuleImporter struct {
 	db *db.Client
 }
+
+// VersionFormat is the time layout for rule version identifiers: yyyymmddhhmmss.
+const VersionFormat = "20060102150405"
 
 func (i *extensionRuleImporter) ImportRules(ctx context.Context, userID uuid.UUID, pkg *parsedExtensionPackage) (domain.ExtensionRuleImportResult, error) {
 	var result domain.ExtensionRuleImportResult
@@ -44,7 +48,7 @@ func (i *extensionRuleImporter) importRule(ctx context.Context, userID uuid.UUID
 		return false, err
 	}
 	if existingBySource != nil {
-		version, err := i.createRuleVersion(ctx, existingBySource.ID, pkg.Version, item.Content)
+		version, err := i.createRuleVersion(ctx, existingBySource.ID, item.Content)
 		if err != nil {
 			return false, err
 		}
@@ -85,7 +89,7 @@ func (i *extensionRuleImporter) importRule(ctx context.Context, userID uuid.UUID
 	if err != nil {
 		return false, err
 	}
-	version, err := i.createRuleVersion(ctx, rule.ID, pkg.Version, item.Content)
+	version, err := i.createRuleVersion(ctx, rule.ID, item.Content)
 	if err != nil {
 		return false, err
 	}
@@ -93,14 +97,14 @@ func (i *extensionRuleImporter) importRule(ctx context.Context, userID uuid.UUID
 	return true, err
 }
 
-func (i *extensionRuleImporter) createRuleVersion(ctx context.Context, ruleID uuid.UUID, version, content string) (*db.AgentRuleVersion, error) {
-	if len(version) > 14 {
-		version = version[:14]
-	}
+func (i *extensionRuleImporter) createRuleVersion(ctx context.Context, ruleID uuid.UUID, content string) (*db.AgentRuleVersion, error) {
+	now := time.Now()
+	version := now.UTC().Format(VersionFormat)
 	return i.db.AgentRuleVersion.Create().
 		SetID(uuid.New()).
 		SetRuleID(ruleID).
 		SetVersion(version).
 		SetContent(content).
+		SetCreatedAt(now).
 		Save(ctx)
 }

--- a/backend/biz/team/usecase/extension_package_rules_test.go
+++ b/backend/biz/team/usecase/extension_package_rules_test.go
@@ -2,7 +2,9 @@ package usecase
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	_ "github.com/mattn/go-sqlite3"
@@ -57,6 +59,14 @@ func TestExtensionRuleImporterCreatesGlobalRule(t *testing.T) {
 	if rule.ActiveVersionID == nil {
 		t.Fatal("active version id is nil")
 	}
+	version, err := client.AgentRuleVersion.Get(ctx, *rule.ActiveVersionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRuleVersionFormat(t, version.Version)
+	if version.Version == pkg.Version {
+		t.Fatalf("rule version should not use package version %q", pkg.Version)
+	}
 }
 
 func TestExtensionRuleImporterUpdatesSamePackageRule(t *testing.T) {
@@ -93,6 +103,28 @@ func TestExtensionRuleImporterUpdatesSamePackageRule(t *testing.T) {
 	if count != 2 {
 		t.Fatalf("version count = %d", count)
 	}
+	versions, err := client.AgentRuleVersion.Query().All(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, version := range versions {
+		assertRuleVersionFormat(t, version.Version)
+		if strings.HasPrefix(version.Version, "1.0.") {
+			t.Fatalf("rule version should not use package version %q", version.Version)
+		}
+	}
+	rule, err := client.AgentRule.Query().Only(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	active, err := client.AgentRuleVersion.Get(ctx, *rule.ActiveVersionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRuleVersionFormat(t, active.Version)
+	if active.Content != "v2" {
+		t.Fatalf("active content = %q, want v2", active.Content)
+	}
 }
 
 func TestExtensionRuleImporterRejectsNameConflict(t *testing.T) {
@@ -124,5 +156,15 @@ func TestExtensionRuleImporterRejectsNameConflict(t *testing.T) {
 	}
 	if _, err := importer.ImportRules(ctx, userID, second); err == nil {
 		t.Fatal("ImportRules should reject same rule name from different package")
+	}
+}
+
+func assertRuleVersionFormat(t *testing.T, version string) {
+	t.Helper()
+	if len(version) != 14 {
+		t.Fatalf("rule version = %q, want 14-char timestamp", version)
+	}
+	if _, err := time.Parse(VersionFormat, version); err != nil {
+		t.Fatalf("rule version = %q does not match %s: %v", version, VersionFormat, err)
 	}
 }


### PR DESCRIPTION
## Summary
- 扩展包导入 rules 时，agent_rule_versions.version 改为当前 UTC 时间戳版本
- 保留 agent_rules.extension_version 记录扩展包版本
- 增加测试覆盖不再使用 manifest.version 作为 rule version

## Test Plan
- GOWORK=off go test ./biz/team/usecase -run 'TestExtensionRuleImporter|TestTeamExtensionPackageUsecase' -count=1\n- GOWORK=off go test ./biz/team/... -count=1\n- GOWORK=off go test ./biz/agentresource -count=1