### PR TITLE
fix: 设置初始化扩展包目录默认值

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -347,6 +347,7 @@ func Init(dir string) (*Config, error) {
 	v.SetDefault("init_team.name", "")
 	v.SetDefault("init_team.password", "")
 	v.SetDefault("init_team.image", "")
+	v.SetDefault("init_team.extension_package_dir", "/app/extensions/packages")
 	v.SetDefault("taskflow.grpc_url", "")
 	v.SetDefault("task.at_keyword", "")
 	v.SetDefault("task.host_ids", []string{})

--- a/backend/config/oss_config_test.go
+++ b/backend/config/oss_config_test.go
@@ -11,6 +11,7 @@ func TestObjectStorageDefaults(t *testing.T) {
 	t.Setenv("MCAI_OBJECT_STORAGE_TEMP_PREFIX", "")
 	t.Setenv("MCAI_TASKFLOW_GRPC_URL", "")
 	t.Setenv("MCAI_TASK_CREATE_REQ_TTL_SECONDS", "")
+	t.Setenv("MCAI_INIT_TEAM_EXTENSION_PACKAGE_DIR", "")
 
 	cfg, err := Init(t.TempDir())
 	if err != nil {
@@ -45,6 +46,9 @@ func TestObjectStorageDefaults(t *testing.T) {
 	}
 	if cfg.Task.CreateReqTTLSeconds != 600 {
 		t.Fatalf("task.create_req_ttl_seconds = %d, want 600", cfg.Task.CreateReqTTLSeconds)
+	}
+	if cfg.InitTeam.ExtensionPackageDir != "/app/extensions/packages" {
+		t.Fatalf("init_team.extension_package_dir = %q", cfg.InitTeam.ExtensionPackageDir)
 	}
 	if !cfg.StaticFiles.Enabled {
 		t.Fatal("static_files.enabled default = false, want true")


### PR DESCRIPTION
## 变更内容
- 为 `init_team.extension_package_dir` 设置默认值 `/app/extensions/packages`
- 补充配置默认值测试，避免初始化扩展包目录为空

## 验证
- `GOWORK=off go test ./config -count=1`
