### PR TITLE
feat: 接入 Google 和 GitHub OAuth 登录后端

### DIFF
--- a/backend/biz/user/handler/v1/auth.go
+++ b/backend/biz/user/handler/v1/auth.go
@@ -23,6 +23,7 @@ type AuthHandler struct {
 	config         *config.Config
 	logger         *slog.Logger
 	usecase        domain.UserUsecase
+	oauthUsecase   domain.OAuthLoginUsecase
 	teamUsecase    domain.TeamGroupUserUsecase
 	oidcUsecase    domain.TeamOIDCLoginUsecase
 	redis          *redis.Client
@@ -41,12 +42,14 @@ func NewAuthHandler(i *do.Injector) (*AuthHandler, error) {
 	auth := do.MustInvoke[*middleware.AuthMiddleware](i)
 	targetActive := do.MustInvoke[*middleware.TargetActiveMiddleware](i)
 	captchaSvc := do.MustInvoke[*captcha.Captcha](i)
+	oauthUsecase, _ := do.Invoke[domain.OAuthLoginUsecase](i)
 	oidcUsecase, _ := do.Invoke[domain.TeamOIDCLoginUsecase](i)
 
 	h := &AuthHandler{
 		config:         cfg,
 		logger:         logger.With("module", "auth.handler"),
 		usecase:        usecase,
+		oauthUsecase:   oauthUsecase,
 		teamUsecase:    teamUsecase,
 		oidcUsecase:    oidcUsecase,
 		redis:          redisClient,
@@ -63,6 +66,8 @@ func NewAuthHandler(i *do.Injector) (*AuthHandler, error) {
 
 	// 密码登录
 	v1.POST("/password-login", web.BindHandler(h.PasswordLogin), targetActive.TargetActive())
+	v1.GET("/oauth/:provider/login", web.BindHandler(h.OAuthLogin), targetActive.TargetActive())
+	v1.GET("/oauth/:provider/callback", web.BindHandler(h.OAuthCallback), targetActive.TargetActive())
 	v1.GET("/oidc/login", web.BindHandler(h.OIDCLogin), targetActive.TargetActive())
 	v1.GET("/oidc/callback", web.BindHandler(h.OIDCCallback), targetActive.TargetActive())
 	v1.GET("/oidc/default-team", web.BaseHandler(h.OIDCDefaultPublicConfig), targetActive.TargetActive())
@@ -165,6 +170,64 @@ func (h *AuthHandler) OIDCDefaultPublicConfig(c *web.Context) error {
 		return err
 	}
 	return c.Success(resp)
+}
+
+// OAuthLogin 发起 Google/GitHub OAuth 登录
+//
+//	@Summary		发起 Google/GitHub OAuth 登录
+//	@Description	根据 provider 生成第三方授权地址。provider 仅支持 google、github。redirect_url 可选，必须是站内相对路径；登录成功后后端会跳转到该路径，空值默认 /console/。
+//	@Tags			【用户】OAuth
+//	@Accept			json
+//	@Produce		json
+//	@Param			provider		path		string	true	"登录提供方，仅支持 google、github"
+//	@Param			redirect_url	query		string	false	"登录成功后的站内跳转路径，例如 /console/tasks；只允许站内相对路径"
+//	@Success		200				{object}	web.Resp{data=domain.OAuthLoginResp}
+//	@Failure		400				{object}	web.Resp	"provider 或 redirect_url 无效"
+//	@Router			/api/v1/users/oauth/{provider}/login [get]
+func (h *AuthHandler) OAuthLogin(c *web.Context, req domain.OAuthLoginReq) error {
+	if h.oauthUsecase == nil {
+		return errcode.ErrOAuthLoginProviderDisabled
+	}
+	authURL, err := h.oauthUsecase.StartOAuthLogin(c.Request().Context(), req.Provider, req.RedirectURL)
+	if err != nil {
+		return err
+	}
+	return c.Success(domain.OAuthLoginResp{AuthURL: authURL})
+}
+
+// OAuthCallback 处理 Google/GitHub OAuth 登录回调。
+func (h *AuthHandler) OAuthCallback(c *web.Context, req domain.OAuthCallbackReq) error {
+	if h.oauthUsecase == nil {
+		return c.Redirect(http.StatusFound, "/login?oauth_error=provider_disabled")
+	}
+	resp, err := h.oauthUsecase.HandleOAuthCallback(c.Request().Context(), req.Provider, req.Code, req.State)
+	if err != nil {
+		h.logger.WarnContext(c.Request().Context(), "oauth callback failed", "provider", req.Provider, "error", err)
+		return c.Redirect(http.StatusFound, "/login?oauth_error="+oauthErrorCode(err))
+	}
+	if resp == nil || resp.User == nil {
+		return c.Redirect(http.StatusFound, "/login?oauth_error=login_failed")
+	}
+	if _, err := h.authMiddleware.Session.Save(c, consts.MonkeyCodeAISession, resp.User.ID, resp.User); err != nil {
+		h.logger.ErrorContext(c.Request().Context(), "save oauth login session failed", "error", err)
+		return errcode.ErrInternalServer
+	}
+	return c.Redirect(http.StatusFound, resp.RedirectURL)
+}
+
+func oauthErrorCode(err error) string {
+	switch err {
+	case errcode.ErrOAuthLoginProviderDisabled:
+		return "provider_disabled"
+	case errcode.ErrOAuthLoginStateInvalid:
+		return "state_invalid"
+	case errcode.ErrOAuthLoginEmailRequired:
+		return "email_required"
+	case errcode.ErrOAuthLoginEmailUnverified:
+		return "email_unverified"
+	default:
+		return "login_failed"
+	}
 }
 
 // PasswordLogin 密码登录接口

--- a/backend/biz/user/handler/v1/auth_oauth_test.go
+++ b/backend/biz/user/handler/v1/auth_oauth_test.go
@@ -1,0 +1,128 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/GoYoko/web"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/middleware"
+	"github.com/chaitin/MonkeyCode/backend/pkg/session"
+)
+
+func TestOAuthLoginRouteReturnsProviderURL(t *testing.T) {
+	w := web.New()
+	h := &AuthHandler{
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		oauthUsecase: &oauthLoginUsecaseStub{authURL: "https://auth.example.com/authorize"},
+	}
+	g := w.Group("/api/v1/users")
+	g.GET("/oauth/:provider/login", web.BindHandler(h.OAuthLogin))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/oauth/google/login?redirect_url=/console/tasks", nil)
+	rec := httptest.NewRecorder()
+
+	w.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Code int `json:"code"`
+		Data struct {
+			AuthURL string `json:"auth_url"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Code != 0 {
+		t.Fatalf("code = %d", resp.Code)
+	}
+	if got := resp.Data.AuthURL; got != "https://auth.example.com/authorize" {
+		t.Fatalf("auth_url = %q", got)
+	}
+}
+
+func TestOAuthCallbackRouteSavesSessionAndRedirects(t *testing.T) {
+	w := web.New()
+	mr := miniredis.RunT(t)
+	cfg := &config.Config{}
+	cfg.Redis.Host = "127.0.0.1"
+	port, err := strconv.Atoi(mr.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Redis.Port = port
+	cfg.Session.ExpireDay = 30
+	sess := session.New(cfg)
+	userID := uuid.New()
+	h := &AuthHandler{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		authMiddleware: middleware.NewAuthMiddleware(
+			sess,
+			nil,
+			slog.New(slog.NewTextHandler(io.Discard, nil)),
+		),
+		oauthUsecase: &oauthLoginUsecaseStub{
+			callback: &domain.OAuthLoginCallbackResp{
+				User:        &domain.User{ID: userID, Name: "Alice", Email: "alice@example.com", Role: consts.UserRoleIndividual},
+				RedirectURL: "/console/tasks",
+			},
+		},
+	}
+	g := w.Group("/api/v1/users")
+	g.GET("/oauth/:provider/callback", web.BindHandler(h.OAuthCallback))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/oauth/google/callback?code=c&state=s", nil)
+	rec := httptest.NewRecorder()
+
+	w.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Location"); got != "/console/tasks" {
+		t.Fatalf("Location = %q", got)
+	}
+	if len(rec.Result().Cookies()) == 0 {
+		t.Fatal("expected session cookie")
+	}
+}
+
+func TestOAuthCallbackSwaggerIsHidden(t *testing.T) {
+	content, err := os.ReadFile("auth.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(content), "@Router\t\t\t/api/v1/users/oauth/{provider}/callback") ||
+		strings.Contains(string(content), "@Router /api/v1/users/oauth/{provider}/callback") {
+		t.Fatal("callback route must not be exposed in swagger annotations")
+	}
+}
+
+type oauthLoginUsecaseStub struct {
+	authURL  string
+	callback *domain.OAuthLoginCallbackResp
+}
+
+func (s *oauthLoginUsecaseStub) StartOAuthLogin(context.Context, string, string) (string, error) {
+	return s.authURL, nil
+}
+
+func (s *oauthLoginUsecaseStub) HandleOAuthCallback(context.Context, string, string, string) (*domain.OAuthLoginCallbackResp, error) {
+	return s.callback, nil
+}

--- a/backend/biz/user/provider/avatar_archive.go
+++ b/backend/biz/user/provider/avatar_archive.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+)
+
+const (
+	avatarArchiveMaxSize = 2 << 20
+)
+
+var avatarFilenameRe = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+type AvatarObjectStore interface {
+	PutFile(ctx context.Context, prefix, filename string, r io.Reader) error
+	GetURL(prefix, filename string) string
+}
+
+type AvatarArchiver struct {
+	cfg        config.ObjectStorageConfig
+	httpClient *http.Client
+	store      AvatarObjectStore
+}
+
+func NewAvatarArchiver(cfg config.ObjectStorageConfig, httpClient *http.Client, store AvatarObjectStore) *AvatarArchiver {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 5 * time.Second}
+	}
+	return &AvatarArchiver{
+		cfg:        cfg,
+		httpClient: httpClient,
+		store:      store,
+	}
+}
+
+func (a *AvatarArchiver) Archive(ctx context.Context, name Name, identityID string, rawURL string) (string, error) {
+	if a == nil || a.store == nil || !a.cfg.Enabled || strings.TrimSpace(rawURL) == "" {
+		return "", nil
+	}
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return "", fmt.Errorf("invalid avatar url")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("download avatar status %d", resp.StatusCode)
+	}
+	contentType := strings.ToLower(strings.TrimSpace(strings.Split(resp.Header.Get("Content-Type"), ";")[0]))
+	if !strings.HasPrefix(contentType, "image/") {
+		return "", fmt.Errorf("avatar content type is not image: %s", contentType)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, avatarArchiveMaxSize+1))
+	if err != nil {
+		return "", err
+	}
+	if len(body) > avatarArchiveMaxSize {
+		return "", fmt.Errorf("avatar exceeds %d bytes", avatarArchiveMaxSize)
+	}
+	prefix := strings.Trim(path.Join(a.cfg.AvatarPrefix, "oauth", string(name)), "/")
+	filename := avatarArchiveFilename(identityID, u.Path, contentType)
+	if err := a.store.PutFile(ctx, prefix, filename, bytes.NewReader(body)); err != nil {
+		return "", err
+	}
+	return a.store.GetURL(prefix, filename), nil
+}
+
+func avatarArchiveFilename(identityID string, rawPath string, contentType string) string {
+	identityID = avatarFilenameRe.ReplaceAllString(strings.TrimSpace(identityID), "_")
+	identityID = strings.Trim(identityID, "._-")
+	if identityID == "" {
+		identityID = "avatar"
+	}
+	ext := strings.ToLower(path.Ext(rawPath))
+	if ext == "" {
+		if exts, _ := mime.ExtensionsByType(contentType); len(exts) > 0 {
+			ext = exts[0]
+		}
+	}
+	if ext == "" {
+		ext = ".jpg"
+	}
+	return identityID + ext
+}

--- a/backend/biz/user/provider/avatar_archive_test.go
+++ b/backend/biz/user/provider/avatar_archive_test.go
@@ -1,0 +1,96 @@
+package provider
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+)
+
+func TestAvatarArchiverUploadsImageToObjectStorage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("png-data"))
+	}))
+	defer server.Close()
+	store := &avatarObjectStoreStub{}
+	archiver := NewAvatarArchiver(config.ObjectStorageConfig{
+		Enabled:      true,
+		AvatarPrefix: "avatar",
+	}, server.Client(), store)
+
+	got, err := archiver.Archive(context.Background(), Google, "google-sub-1", server.URL+"/avatar.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "https://oss.example.com/avatar/oauth/google/google-sub-1.png" {
+		t.Fatalf("url = %q", got)
+	}
+	if store.prefix != "avatar/oauth/google" || store.filename != "google-sub-1.png" {
+		t.Fatalf("object = %s/%s", store.prefix, store.filename)
+	}
+	if string(store.body) != "png-data" {
+		t.Fatalf("body = %q", string(store.body))
+	}
+}
+
+func TestAvatarArchiverReportsInvalidOrNonImageURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("not image"))
+	}))
+	defer server.Close()
+	store := &avatarObjectStoreStub{}
+	archiver := NewAvatarArchiver(config.ObjectStorageConfig{
+		Enabled:      true,
+		AvatarPrefix: "avatar",
+	}, server.Client(), store)
+
+	tests := []struct {
+		raw     string
+		wantErr string
+	}{
+		{raw: "ftp://example.com/a.png", wantErr: "invalid avatar url"},
+		{raw: server.URL + "/avatar.txt", wantErr: "avatar content type is not image"},
+	}
+	for _, tt := range tests {
+		raw := tt.raw
+		got, err := archiver.Archive(context.Background(), Github, "123", raw)
+		if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+			t.Fatalf("Archive(%q) error = %v, want containing %q", raw, err, tt.wantErr)
+		}
+		if got != "" {
+			t.Fatalf("Archive(%q) = %q, want empty", raw, got)
+		}
+	}
+	if store.putCount != 0 {
+		t.Fatalf("put count = %d, want 0", store.putCount)
+	}
+}
+
+type avatarObjectStoreStub struct {
+	prefix   string
+	filename string
+	body     []byte
+	putCount int
+}
+
+func (s *avatarObjectStoreStub) PutFile(_ context.Context, prefix, filename string, r io.Reader) error {
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	s.prefix = prefix
+	s.filename = filename
+	s.body = body
+	s.putCount++
+	return nil
+}
+
+func (s *avatarObjectStoreStub) GetURL(prefix, filename string) string {
+	return "https://oss.example.com/" + prefix + "/" + filename
+}

--- a/backend/biz/user/provider/github.go
+++ b/backend/biz/user/provider/github.go
@@ -1,0 +1,122 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/google/go-github/v74/github"
+	"golang.org/x/oauth2"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+)
+
+type GithubProvider struct {
+	httpClient  *http.Client
+	apiBaseURL  string
+	oauthConfig *oauth2.Config
+}
+
+func NewGithub(cfg config.OAuthLoginProviderConfig, serverBaseURL string, httpClient *http.Client) *GithubProvider {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &GithubProvider{
+		httpClient: httpClient,
+		apiBaseURL: "https://api.github.com/",
+		oauthConfig: &oauth2.Config{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			RedirectURL:  oauthCallbackURL(cfg.RedirectURL, serverBaseURL, Github),
+			Scopes:       []string{"read:user", "user:email"},
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  "https://github.com/login/oauth/authorize",
+				TokenURL: "https://github.com/login/oauth/access_token",
+			},
+		},
+	}
+}
+
+func (p *GithubProvider) Name() Name {
+	return Github
+}
+
+func (p *GithubProvider) AuthCodeURL(state, _ string) string {
+	return p.oauthConfig.AuthCodeURL(state)
+}
+
+func (p *GithubProvider) Exchange(ctx context.Context, code string) (*oauth2.Token, error) {
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, p.httpClient)
+	return p.oauthConfig.Exchange(ctx, code)
+}
+
+func (p *GithubProvider) User(ctx context.Context, token *oauth2.Token, _ string) (*ExternalUser, error) {
+	if token == nil || token.AccessToken == "" {
+		return nil, errors.New("github access token is required")
+	}
+	client := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(token)))
+	if p.apiBaseURL != "" && p.apiBaseURL != "https://api.github.com/" {
+		u, err := url.Parse(p.apiBaseURL)
+		if err != nil {
+			return nil, err
+		}
+		client.BaseURL = u
+		client.UploadURL = u
+	}
+	ghUser, _, err := client.Users.Get(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	emails, _, err := client.Users.ListEmails(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	email := verifiedGithubEmail(emails)
+	if email == "" {
+		return nil, errors.New("github verified email is required")
+	}
+	name := ghUser.GetName()
+	if name == "" {
+		name = ghUser.GetLogin()
+	}
+	return &ExternalUser{
+		Provider:      Github,
+		IdentityID:    strconv.FormatInt(ghUser.GetID(), 10),
+		Email:         email,
+		EmailVerified: true,
+		Username:      ghUser.GetLogin(),
+		Name:          name,
+		AvatarURL:     ghUser.GetAvatarURL(),
+	}, nil
+}
+
+func verifiedGithubEmail(emails []*github.UserEmail) string {
+	for _, email := range emails {
+		if email.GetPrimary() && email.GetVerified() && email.GetEmail() != "" {
+			return email.GetEmail()
+		}
+	}
+	for _, email := range emails {
+		if email.GetVerified() && email.GetEmail() != "" {
+			return email.GetEmail()
+		}
+	}
+	return ""
+}
+
+func oauthCallbackURL(configured, serverBaseURL string, name Name) string {
+	if configured != "" {
+		return configured
+	}
+	return fmt.Sprintf("%s/api/v1/users/oauth/%s/callback", stringsTrimRightSlash(serverBaseURL), name)
+}
+
+func stringsTrimRightSlash(s string) string {
+	for len(s) > 0 && s[len(s)-1] == '/' {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/backend/biz/user/provider/github_test.go
+++ b/backend/biz/user/provider/github_test.go
@@ -1,0 +1,79 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestGithubProviderUsesPrimaryVerifiedEmail(t *testing.T) {
+	gp, closeServer := newGithubProviderTestServer(t, `[{"email":"primary@example.com","primary":true,"verified":true},{"email":"other@example.com","primary":false,"verified":true}]`)
+	defer closeServer()
+
+	user, err := gp.User(context.Background(), &oauth2.Token{AccessToken: "token"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if user.Email != "primary@example.com" {
+		t.Fatalf("email = %q", user.Email)
+	}
+	if !user.EmailVerified {
+		t.Fatal("email should be verified")
+	}
+}
+
+func TestGithubProviderFallsBackToAnyVerifiedEmail(t *testing.T) {
+	gp, closeServer := newGithubProviderTestServer(t, `[{"email":"primary@example.com","primary":true,"verified":false},{"email":"other@example.com","primary":false,"verified":true}]`)
+	defer closeServer()
+
+	user, err := gp.User(context.Background(), &oauth2.Token{AccessToken: "token"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if user.Email != "other@example.com" {
+		t.Fatalf("email = %q", user.Email)
+	}
+}
+
+func TestGithubProviderRejectsMissingVerifiedEmail(t *testing.T) {
+	gp, closeServer := newGithubProviderTestServer(t, `[{"email":"primary@example.com","primary":true,"verified":false}]`)
+	defer closeServer()
+
+	_, err := gp.User(context.Background(), &oauth2.Token{AccessToken: "token"}, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func newGithubProviderTestServer(t *testing.T, emailsJSON string) (*GithubProvider, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/user":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":12345,"login":"alice","name":"Alice","avatar_url":"https://example.com/avatar.png"}`))
+		case "/user/emails":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(emailsJSON))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	gp := &GithubProvider{
+		httpClient: srv.Client(),
+		apiBaseURL: srv.URL + "/",
+		oauthConfig: &oauth2.Config{
+			ClientID:     "client-id",
+			ClientSecret: "client-secret",
+			RedirectURL:  "http://localhost/callback",
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  srv.URL + "/login/oauth/authorize",
+				TokenURL: srv.URL + "/login/oauth/access_token",
+			},
+		},
+	}
+	return gp, srv.Close
+}

--- a/backend/biz/user/provider/google.go
+++ b/backend/biz/user/provider/google.go
@@ -1,0 +1,99 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"golang.org/x/oauth2"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+	oidcpkg "github.com/chaitin/MonkeyCode/backend/pkg/oidc"
+)
+
+const googleIssuer = "https://accounts.google.com"
+
+type GoogleProvider struct {
+	httpClient  *http.Client
+	issuer      string
+	oidcClient  *oidcpkg.Client
+	oauthConfig *oauth2.Config
+}
+
+func NewGoogle(cfg config.OAuthLoginProviderConfig, serverBaseURL string, httpClient *http.Client) *GoogleProvider {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &GoogleProvider{
+		httpClient: httpClient,
+		issuer:     googleIssuer,
+		oidcClient: oidcpkg.NewClient(httpClient),
+		oauthConfig: &oauth2.Config{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			RedirectURL:  oauthCallbackURL(cfg.RedirectURL, serverBaseURL, Google),
+			Scopes:       []string{"openid", "email", "profile"},
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  "https://accounts.google.com/o/oauth2/v2/auth",
+				TokenURL: "https://oauth2.googleapis.com/token",
+			},
+		},
+	}
+}
+
+func (p *GoogleProvider) Name() Name {
+	return Google
+}
+
+func (p *GoogleProvider) AuthCodeURL(state, nonce string) string {
+	return p.oauthConfig.AuthCodeURL(state, oauth2.SetAuthURLParam("nonce", nonce))
+}
+
+func (p *GoogleProvider) Exchange(ctx context.Context, code string) (*oauth2.Token, error) {
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, p.httpClient)
+	return p.oauthConfig.Exchange(ctx, code)
+}
+
+func (p *GoogleProvider) User(ctx context.Context, token *oauth2.Token, nonce string) (*ExternalUser, error) {
+	if token == nil {
+		return nil, errors.New("google token is required")
+	}
+	rawIDToken, ok := token.Extra("id_token").(string)
+	if !ok || rawIDToken == "" {
+		return nil, errors.New("google id_token is required")
+	}
+	oidcClient := p.oidcClient
+	if oidcClient == nil {
+		oidcClient = oidcpkg.NewClient(p.httpClient)
+	}
+	issuer := p.issuer
+	if issuer == "" {
+		issuer = googleIssuer
+	}
+	doc, err := oidcClient.Discover(ctx, issuer)
+	if err != nil {
+		return nil, err
+	}
+	external, err := oidcClient.VerifyIDToken(ctx, doc, oidcpkg.Config{ClientID: p.oauthConfig.ClientID}, rawIDToken, nonce)
+	if err != nil {
+		return nil, err
+	}
+	if external.Email == "" || external.Name == "" || external.AvatarURL == "" {
+		enriched, infoErr := oidcClient.UserInfo(ctx, doc, p.oauthConfig.TokenSource(ctx, token), external)
+		if enriched != nil {
+			external = enriched
+		}
+		if infoErr != nil && external.Email == "" {
+			return nil, infoErr
+		}
+	}
+	return &ExternalUser{
+		Provider:      Google,
+		IdentityID:    external.Subject,
+		Email:         external.Email,
+		EmailVerified: external.EmailVerified,
+		Username:      external.Username,
+		Name:          external.Name,
+		AvatarURL:     external.AvatarURL,
+	}, nil
+}

--- a/backend/biz/user/provider/google_test.go
+++ b/backend/biz/user/provider/google_test.go
@@ -1,0 +1,39 @@
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestGoogleProviderAuthCodeURLIncludesStateAndNonce(t *testing.T) {
+	gp := &GoogleProvider{
+		oauthConfig: &oauth2.Config{
+			ClientID:    "client-id",
+			RedirectURL: "http://localhost/callback",
+			Scopes:      []string{"openid", "email", "profile"},
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  "https://accounts.google.com/o/oauth2/v2/auth",
+				TokenURL: "https://oauth2.googleapis.com/token",
+			},
+		},
+	}
+
+	got := gp.AuthCodeURL("state-1", "nonce-1")
+	for _, want := range []string{"state=state-1", "nonce=nonce-1", "client_id=client-id"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("AuthCodeURL %q does not contain %q", got, want)
+		}
+	}
+}
+
+func TestGoogleProviderRejectsMissingIDToken(t *testing.T) {
+	gp := &GoogleProvider{}
+
+	_, err := gp.User(context.Background(), &oauth2.Token{AccessToken: "access-token"}, "nonce-1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/backend/biz/user/provider/oauth_login.go
+++ b/backend/biz/user/provider/oauth_login.go
@@ -1,0 +1,31 @@
+package provider
+
+import (
+	"context"
+
+	"golang.org/x/oauth2"
+)
+
+type Name string
+
+const (
+	Google Name = "google"
+	Github Name = "github"
+)
+
+type ExternalUser struct {
+	Provider      Name
+	IdentityID    string
+	Email         string
+	EmailVerified bool
+	Username      string
+	Name          string
+	AvatarURL     string
+}
+
+type Provider interface {
+	Name() Name
+	AuthCodeURL(state, nonce string) string
+	Exchange(ctx context.Context, code string) (*oauth2.Token, error)
+	User(ctx context.Context, token *oauth2.Token, nonce string) (*ExternalUser, error)
+}

--- a/backend/biz/user/provider/redirect.go
+++ b/backend/biz/user/provider/redirect.go
@@ -1,0 +1,30 @@
+package provider
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+)
+
+const DefaultRedirectURL = "/console/"
+
+func CleanRedirectURL(raw string) (string, error) {
+	if strings.ContainsAny(raw, "\r\n\t") || strings.Contains(raw, `\`) {
+		return "", errors.New("redirect_url contains invalid character")
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return DefaultRedirectURL, nil
+	}
+	if strings.HasPrefix(raw, "//") || !strings.HasPrefix(raw, "/") {
+		return "", errors.New("redirect_url must be site-relative")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	if u.IsAbs() || u.Host != "" || u.Scheme != "" {
+		return "", errors.New("redirect_url must not be absolute")
+	}
+	return u.RequestURI(), nil
+}

--- a/backend/biz/user/provider/redirect_test.go
+++ b/backend/biz/user/provider/redirect_test.go
@@ -1,0 +1,35 @@
+package provider
+
+import "testing"
+
+func TestCleanRedirectURLAllowsOnlySiteRelativePath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		{name: "empty defaults", in: "", want: "/console/", ok: true},
+		{name: "console path", in: "/console/tasks", want: "/console/tasks", ok: true},
+		{name: "query kept", in: "/console/tasks?page=1", want: "/console/tasks?page=1", ok: true},
+		{name: "absolute http denied", in: "https://evil.example.com", ok: false},
+		{name: "scheme relative denied", in: "//evil.example.com", ok: false},
+		{name: "backslash denied", in: `\\evil`, ok: false},
+		{name: "relative without slash denied", in: "console/tasks", ok: false},
+		{name: "control char denied", in: "/console/\n", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CleanRedirectURL(tt.in)
+			if tt.ok && err != nil {
+				t.Fatalf("CleanRedirectURL returned error: %v", err)
+			}
+			if !tt.ok && err == nil {
+				t.Fatal("expected error")
+			}
+			if got != tt.want {
+				t.Fatalf("got = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/biz/user/register.go
+++ b/backend/biz/user/register.go
@@ -11,8 +11,10 @@ import (
 // ProvideUser 注册 user 模块的服务工厂
 func ProvideUser(i *do.Injector) {
 	do.Provide(i, repo.NewUserRepo)
+	do.Provide(i, repo.NewOAuthLoginRepo)
 	do.Provide(i, repo.NewUserActiveRepo)
 	do.Provide(i, usecase.NewUserUsecase)
+	do.Provide(i, usecase.NewOAuthLoginUsecase)
 	do.Provide(i, v1.NewAuthHandler)
 }
 

--- a/backend/biz/user/repo/oauth_login.go
+++ b/backend/biz/user/repo/oauth_login.go
@@ -1,0 +1,157 @@
+package repo
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/samber/do"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/db/user"
+	"github.com/chaitin/MonkeyCode/backend/db/useridentity"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/pkg/entx"
+)
+
+func NewOAuthLoginRepo(i *do.Injector) (domain.OAuthLoginRepo, error) {
+	return &userRepo{
+		db:     do.MustInvoke[*db.Client](i),
+		logger: do.MustInvoke[*slog.Logger](i),
+		redis:  do.MustInvoke[*redis.Client](i),
+		config: do.MustInvoke[*config.Config](i),
+	}, nil
+}
+
+func (u *userRepo) FindUserByOAuthIdentity(ctx context.Context, platform consts.UserPlatform, identityID string) (*db.User, error) {
+	identity, err := u.db.UserIdentity.Query().
+		Where(useridentity.PlatformEQ(platform), useridentity.IdentityIDEQ(identityID)).
+		WithUser().
+		First(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return identity.Edges.User, nil
+}
+
+func (u *userRepo) FindIndividualByEmail(ctx context.Context, email string) (*db.User, error) {
+	usr, err := u.db.User.Query().
+		Where(
+			user.EmailEqualFold(normalizeOAuthEmail(email)),
+			user.RoleEQ(consts.UserRoleIndividual),
+		).
+		First(ctx)
+	if db.IsNotFound(err) {
+		return nil, nil
+	}
+	return usr, err
+}
+
+func (u *userRepo) CreateIndividualWithIdentity(ctx context.Context, external *domain.OAuthLoginUser) (*db.User, error) {
+	var created *db.User
+	err := entx.WithTx2(ctx, u.db, func(tx *db.Tx) error {
+		usr, err := tx.User.Create().
+			SetID(uuid.New()).
+			SetName(oauthDisplayName(external)).
+			SetEmail(normalizeOAuthEmail(external.Email)).
+			SetAvatarURL(external.AvatarURL).
+			SetRole(consts.UserRoleIndividual).
+			SetStatus(consts.UserStatusActive).
+			Save(ctx)
+		if err != nil {
+			return err
+		}
+		if err := createOAuthIdentity(ctx, tx.Client(), usr.ID, external); err != nil {
+			return err
+		}
+		created = usr
+		return nil
+	})
+	return created, err
+}
+
+func (u *userRepo) BindOAuthIdentity(ctx context.Context, userID uuid.UUID, external *domain.OAuthLoginUser) error {
+	return entx.WithTx2(ctx, u.db, func(tx *db.Tx) error {
+		exists, err := tx.UserIdentity.Query().
+			Where(useridentity.PlatformEQ(external.Provider), useridentity.IdentityIDEQ(external.IdentityID)).
+			Exist(ctx)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			if err := createOAuthIdentity(ctx, tx.Client(), userID, external); err != nil {
+				return err
+			}
+		}
+		if external.AvatarURL != "" {
+			if _, err := tx.User.Update().
+				Where(user.IDEQ(userID), user.Or(user.AvatarURLEQ(""), user.AvatarURLIsNil())).
+				SetAvatarURL(external.AvatarURL).
+				Save(ctx); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (u *userRepo) UpdateOAuthIdentity(ctx context.Context, external *domain.OAuthLoginUser) error {
+	return entx.WithTx2(ctx, u.db, func(tx *db.Tx) error {
+		identity, err := tx.UserIdentity.Query().
+			Where(useridentity.PlatformEQ(external.Provider), useridentity.IdentityIDEQ(external.IdentityID)).
+			WithUser().
+			Only(ctx)
+		if err != nil {
+			return err
+		}
+		update := tx.UserIdentity.UpdateOneID(identity.ID).
+			SetUsername(oauthDisplayName(external)).
+			SetEmail(normalizeOAuthEmail(external.Email))
+		if external.AvatarURL != "" {
+			update = update.SetAvatarURL(external.AvatarURL)
+		}
+		if err := update.Exec(ctx); err != nil {
+			return err
+		}
+		if external.AvatarURL == "" || identity.Edges.User == nil {
+			return nil
+		}
+		usr := identity.Edges.User
+		if usr.AvatarURL == "" || usr.AvatarURL == identity.AvatarURL {
+			return tx.User.UpdateOneID(usr.ID).SetAvatarURL(external.AvatarURL).Exec(ctx)
+		}
+		return nil
+	})
+}
+
+func createOAuthIdentity(ctx context.Context, client *db.Client, userID uuid.UUID, external *domain.OAuthLoginUser) error {
+	return client.UserIdentity.Create().
+		SetID(uuid.New()).
+		SetUserID(userID).
+		SetPlatform(external.Provider).
+		SetIdentityID(external.IdentityID).
+		SetUsername(oauthDisplayName(external)).
+		SetEmail(normalizeOAuthEmail(external.Email)).
+		SetAvatarURL(external.AvatarURL).
+		Exec(ctx)
+}
+
+func normalizeOAuthEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+func oauthDisplayName(external *domain.OAuthLoginUser) string {
+	if external == nil {
+		return ""
+	}
+	for _, value := range []string{external.Name, external.Username, external.Email} {
+		if v := strings.TrimSpace(value); v != "" {
+			return v
+		}
+	}
+	return external.IdentityID
+}

--- a/backend/biz/user/repo/oauth_login_test.go
+++ b/backend/biz/user/repo/oauth_login_test.go
@@ -1,0 +1,250 @@
+package repo
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db/enttest"
+	"github.com/chaitin/MonkeyCode/backend/db/user"
+	"github.com/chaitin/MonkeyCode/backend/db/useridentity"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+func TestCreateIndividualWithIdentityCreatesUserAndIdentity(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:user_repo_oauth_create?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	repo := &userRepo{db: client, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	usr, err := repo.CreateIndividualWithIdentity(ctx, &domain.OAuthLoginUser{
+		Provider:   consts.UserPlatformGoogle,
+		IdentityID: "google-sub-1",
+		Email:      "alice@example.com",
+		Name:       "Alice",
+		AvatarURL:  "https://example.com/avatar.png",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usr.Role != consts.UserRoleIndividual {
+		t.Fatalf("role = %s, want %s", usr.Role, consts.UserRoleIndividual)
+	}
+	if usr.Email != "alice@example.com" {
+		t.Fatalf("email = %q", usr.Email)
+	}
+	count, err := client.UserIdentity.Query().Where(
+		useridentity.PlatformEQ(consts.UserPlatformGoogle),
+		useridentity.IdentityIDEQ("google-sub-1"),
+	).Count(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("identity count = %d, want 1", count)
+	}
+}
+
+func TestFindUserByOAuthIdentityReturnsBoundUser(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:user_repo_oauth_find?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	userID := uuid.New()
+	if _, err := client.User.Create().SetID(userID).SetName("Alice").SetEmail("alice@example.com").SetRole(consts.UserRoleIndividual).SetStatus(consts.UserStatusActive).Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.UserIdentity.Create().SetID(uuid.New()).SetUserID(userID).SetPlatform(consts.UserPlatformGoogle).SetIdentityID("google-sub-1").SetUsername("Alice").Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := &userRepo{db: client, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	usr, err := repo.FindUserByOAuthIdentity(ctx, consts.UserPlatformGoogle, "google-sub-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usr.ID != userID {
+		t.Fatalf("user id = %s, want %s", usr.ID, userID)
+	}
+}
+
+func TestBindOAuthIdentityIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:user_repo_oauth_bind?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	userID := uuid.New()
+	if _, err := client.User.Create().SetID(userID).SetName("Alice").SetEmail("alice@example.com").SetRole(consts.UserRoleIndividual).SetStatus(consts.UserStatusActive).Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	repo := &userRepo{db: client, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	external := &domain.OAuthLoginUser{
+		Provider:   consts.UserPlatformGoogle,
+		IdentityID: "google-sub-1",
+		Email:      "alice@example.com",
+		Name:       "Alice",
+	}
+	if err := repo.BindOAuthIdentity(ctx, userID, external); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.BindOAuthIdentity(ctx, userID, external); err != nil {
+		t.Fatal(err)
+	}
+	count, err := client.UserIdentity.Query().Where(
+		useridentity.PlatformEQ(consts.UserPlatformGoogle),
+		useridentity.IdentityIDEQ("google-sub-1"),
+	).Count(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("identity count = %d, want 1", count)
+	}
+}
+
+func TestBindOAuthIdentitySetsUserAvatarOnlyWhenEmpty(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:user_repo_oauth_bind_avatar?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	emptyAvatarUserID := uuid.New()
+	if _, err := client.User.Create().SetID(emptyAvatarUserID).SetName("Alice").SetEmail("alice@example.com").SetRole(consts.UserRoleIndividual).SetStatus(consts.UserStatusActive).Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	customAvatarUserID := uuid.New()
+	if _, err := client.User.Create().SetID(customAvatarUserID).SetName("Bob").SetEmail("bob@example.com").SetAvatarURL("https://oss.example.com/custom.png").SetRole(consts.UserRoleIndividual).SetStatus(consts.UserStatusActive).Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	repo := &userRepo{db: client, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := repo.BindOAuthIdentity(ctx, emptyAvatarUserID, &domain.OAuthLoginUser{
+		Provider:   consts.UserPlatformGoogle,
+		IdentityID: "google-sub-1",
+		Email:      "alice@example.com",
+		Name:       "Alice",
+		AvatarURL:  "https://oss.example.com/oauth-avatar.png",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.BindOAuthIdentity(ctx, customAvatarUserID, &domain.OAuthLoginUser{
+		Provider:   consts.UserPlatformGithub,
+		IdentityID: "12345",
+		Email:      "bob@example.com",
+		Name:       "Bob",
+		AvatarURL:  "https://oss.example.com/github-avatar.png",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	emptyAvatarUser, err := client.User.Get(ctx, emptyAvatarUserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if emptyAvatarUser.AvatarURL != "https://oss.example.com/oauth-avatar.png" {
+		t.Fatalf("empty avatar user avatar = %q", emptyAvatarUser.AvatarURL)
+	}
+	customAvatarUser, err := client.User.Get(ctx, customAvatarUserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if customAvatarUser.AvatarURL != "https://oss.example.com/custom.png" {
+		t.Fatalf("custom avatar user avatar = %q", customAvatarUser.AvatarURL)
+	}
+}
+
+func TestUpdateOAuthIdentityRefreshesIdentityAvatarOnly(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:user_repo_oauth_update_identity_avatar?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	userID := uuid.New()
+	if _, err := client.User.Create().SetID(userID).SetName("Alice").SetEmail("alice@example.com").SetAvatarURL("https://oss.example.com/custom.png").SetRole(consts.UserRoleIndividual).SetStatus(consts.UserStatusActive).Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.UserIdentity.Create().SetID(uuid.New()).SetUserID(userID).SetPlatform(consts.UserPlatformGoogle).SetIdentityID("google-sub-1").SetUsername("Alice").SetAvatarURL("https://oss.example.com/old.png").Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	repo := &userRepo{db: client, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	if err := repo.UpdateOAuthIdentity(ctx, &domain.OAuthLoginUser{
+		Provider:   consts.UserPlatformGoogle,
+		IdentityID: "google-sub-1",
+		Email:      "alice@example.com",
+		Name:       "Alice New",
+		AvatarURL:  "https://oss.example.com/new.png",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	identity, err := client.UserIdentity.Query().Where(useridentity.PlatformEQ(consts.UserPlatformGoogle), useridentity.IdentityIDEQ("google-sub-1")).Only(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.AvatarURL != "https://oss.example.com/new.png" {
+		t.Fatalf("identity avatar = %q", identity.AvatarURL)
+	}
+	usr, err := client.User.Query().Where(user.IDEQ(userID)).Only(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usr.AvatarURL != "https://oss.example.com/custom.png" {
+		t.Fatalf("user avatar = %q", usr.AvatarURL)
+	}
+}
+
+func TestUpdateOAuthIdentityRefreshesUserAvatarWhenStillUsingIdentityAvatar(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:user_repo_oauth_update_user_avatar?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	userID := uuid.New()
+	oldAvatar := "https://oss.example.com/old.png"
+	newAvatar := "https://oss.example.com/new.png"
+	if _, err := client.User.Create().SetID(userID).SetName("Alice").SetEmail("alice@example.com").SetAvatarURL(oldAvatar).SetRole(consts.UserRoleIndividual).SetStatus(consts.UserStatusActive).Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.UserIdentity.Create().SetID(uuid.New()).SetUserID(userID).SetPlatform(consts.UserPlatformGoogle).SetIdentityID("google-sub-1").SetUsername("Alice").SetAvatarURL(oldAvatar).Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	repo := &userRepo{db: client, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	if err := repo.UpdateOAuthIdentity(ctx, &domain.OAuthLoginUser{
+		Provider:   consts.UserPlatformGoogle,
+		IdentityID: "google-sub-1",
+		Email:      "alice@example.com",
+		Name:       "Alice",
+		AvatarURL:  newAvatar,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	usr, err := client.User.Get(ctx, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usr.AvatarURL != newAvatar {
+		t.Fatalf("user avatar = %q, want %q", usr.AvatarURL, newAvatar)
+	}
+}
+
+func TestFindIndividualByEmailIgnoresSubAccount(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:user_repo_oauth_role?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	if _, err := client.User.Create().SetID(uuid.New()).SetName("Member").SetEmail("alice@example.com").SetRole(consts.UserRoleSubAccount).SetStatus(consts.UserStatusActive).Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	repo := &userRepo{db: client, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	usr, err := repo.FindIndividualByEmail(ctx, "alice@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usr != nil {
+		t.Fatalf("expected nil user, got %s", usr.ID)
+	}
+}

--- a/backend/biz/user/usecase/oauth_login.go
+++ b/backend/biz/user/usecase/oauth_login.go
@@ -1,0 +1,285 @@
+package usecase
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/samber/do"
+
+	"github.com/chaitin/MonkeyCode/backend/biz/user/provider"
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/errcode"
+	"github.com/chaitin/MonkeyCode/backend/pkg/cvt"
+	"github.com/chaitin/MonkeyCode/backend/pkg/oss"
+)
+
+const (
+	oauthLoginStatePrefix = "oauth_login_state:"
+	oauthLoginStateTTL    = 5 * time.Minute
+)
+
+type OAuthLoginUsecase struct {
+	repo           domain.OAuthLoginRepo
+	redis          *redis.Client
+	config         *config.Config
+	logger         *slog.Logger
+	providers      map[provider.Name]provider.Provider
+	avatarArchiver oauthAvatarArchiver
+}
+
+type oauthAvatarArchiver interface {
+	Archive(ctx context.Context, name provider.Name, identityID string, rawURL string) (string, error)
+}
+
+type oauthLoginState struct {
+	Provider    string `json:"provider"`
+	RedirectURL string `json:"redirect_url"`
+	Nonce       string `json:"nonce,omitempty"`
+}
+
+func NewOAuthLoginUsecase(i *do.Injector) (domain.OAuthLoginUsecase, error) {
+	cfg := do.MustInvoke[*config.Config](i)
+	var avatarArchiver oauthAvatarArchiver
+	if cfg.ObjectStorage.Enabled {
+		client, err := oss.NewS3Compatible(context.Background(), cfg.ObjectStorage, oss.S3Option{
+			ForcePathStyle: cfg.ObjectStorage.ForcePathStyle,
+			InitBucket:     cfg.ObjectStorage.InitBucket,
+		})
+		if err != nil {
+			return nil, err
+		}
+		avatarArchiver = provider.NewAvatarArchiver(cfg.ObjectStorage, nil, client)
+	}
+	return &OAuthLoginUsecase{
+		repo:   do.MustInvoke[domain.OAuthLoginRepo](i),
+		redis:  do.MustInvoke[*redis.Client](i),
+		config: cfg,
+		logger: do.MustInvoke[*slog.Logger](i).With("module", "usecase.oauth_login"),
+		providers: map[provider.Name]provider.Provider{
+			provider.Google: provider.NewGoogle(cfg.OAuthLogin.Google, cfg.Server.BaseURL, nil),
+			provider.Github: provider.NewGithub(cfg.OAuthLogin.Github, cfg.Server.BaseURL, nil),
+		},
+		avatarArchiver: avatarArchiver,
+	}, nil
+}
+
+func (u *OAuthLoginUsecase) StartOAuthLogin(ctx context.Context, providerName string, redirectURL string) (string, error) {
+	name := provider.Name(strings.TrimSpace(providerName))
+	if !u.providerEnabled(name) {
+		return "", errcode.ErrOAuthLoginProviderDisabled
+	}
+	cleanRedirect, err := provider.CleanRedirectURL(redirectURL)
+	if err != nil {
+		return "", errcode.ErrOAuthLoginRedirectInvalid
+	}
+	p := u.providers[name]
+	if p == nil {
+		return "", errcode.ErrOAuthLoginProviderDisabled
+	}
+	state := randomOAuthToken()
+	nonce := randomOAuthToken()
+	value, err := json.Marshal(&oauthLoginState{
+		Provider:    string(name),
+		RedirectURL: cleanRedirect,
+		Nonce:       nonce,
+	})
+	if err != nil {
+		return "", err
+	}
+	if err := u.redis.Set(ctx, oauthLoginStatePrefix+state, string(value), oauthLoginStateTTL).Err(); err != nil {
+		return "", err
+	}
+	return p.AuthCodeURL(state, nonce), nil
+}
+
+func (u *OAuthLoginUsecase) HandleOAuthCallback(ctx context.Context, providerName string, code string, state string) (*domain.OAuthLoginCallbackResp, error) {
+	name := provider.Name(strings.TrimSpace(providerName))
+	if !u.providerEnabled(name) {
+		return nil, errcode.ErrOAuthLoginProviderDisabled
+	}
+	s, err := u.consumeState(ctx, state)
+	if err != nil {
+		return nil, errcode.ErrOAuthLoginStateInvalid
+	}
+	if s.Provider != string(name) {
+		return nil, errcode.ErrOAuthLoginStateInvalid
+	}
+	p := u.providers[name]
+	if p == nil {
+		return nil, errcode.ErrOAuthLoginProviderDisabled
+	}
+	token, err := p.Exchange(ctx, code)
+	if err != nil {
+		u.logger.WarnContext(ctx, "oauth token exchange failed", "provider", name, "error", err)
+		return nil, errcode.ErrOAuthLoginFailed
+	}
+	external, err := p.User(ctx, token, s.Nonce)
+	if err != nil {
+		u.logger.WarnContext(ctx, "oauth userinfo failed", "provider", name, "error", err)
+		return nil, errcode.ErrOAuthLoginFailed
+	}
+	if external == nil || strings.TrimSpace(external.Email) == "" {
+		return nil, errcode.ErrOAuthLoginEmailRequired
+	}
+	if !external.EmailVerified {
+		return nil, errcode.ErrOAuthLoginEmailUnverified
+	}
+	user, err := u.resolveUser(ctx, external)
+	if err != nil {
+		return nil, err
+	}
+	return &domain.OAuthLoginCallbackResp{
+		User:        cvt.From(user, &domain.User{}),
+		RedirectURL: s.RedirectURL,
+	}, nil
+}
+
+func (u *OAuthLoginUsecase) consumeState(ctx context.Context, state string) (*oauthLoginState, error) {
+	value, err := u.redis.GetDel(ctx, oauthLoginStatePrefix+state).Result()
+	if err != nil {
+		return nil, err
+	}
+	var s oauthLoginState
+	if err := json.Unmarshal([]byte(value), &s); err != nil {
+		return nil, err
+	}
+	if s.RedirectURL == "" {
+		s.RedirectURL = provider.DefaultRedirectURL
+	}
+	return &s, nil
+}
+
+func (u *OAuthLoginUsecase) resolveUser(ctx context.Context, external *provider.ExternalUser) (*db.User, error) {
+	platform := oauthPlatform(external.Provider)
+	avatarURL := u.archiveAvatar(ctx, external)
+	loginUser := &domain.OAuthLoginUser{
+		Provider:   platform,
+		IdentityID: external.IdentityID,
+		Email:      strings.ToLower(strings.TrimSpace(external.Email)),
+		Username:   external.Username,
+		Name:       external.Name,
+		AvatarURL:  avatarURL,
+	}
+	usr, err := u.repo.FindUserByOAuthIdentity(ctx, platform, external.IdentityID)
+	if err != nil && !db.IsNotFound(err) {
+		return nil, err
+	}
+	if err == nil && usr != nil {
+		if err := validateOAuthLoginUser(usr); err != nil {
+			return nil, err
+		}
+		if err := u.repo.UpdateOAuthIdentity(ctx, loginUser); err != nil {
+			return nil, err
+		}
+		return usr, nil
+	}
+	usr, err = u.repo.FindIndividualByEmail(ctx, loginUser.Email)
+	if err != nil {
+		return nil, err
+	}
+	if usr != nil {
+		if err := validateOAuthLoginUser(usr); err != nil {
+			return nil, err
+		}
+		if err := u.repo.BindOAuthIdentity(ctx, usr.ID, loginUser); err != nil {
+			return nil, err
+		}
+		return usr, nil
+	}
+	usr, err = u.repo.CreateIndividualWithIdentity(ctx, loginUser)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateOAuthLoginUser(usr); err != nil {
+		return nil, err
+	}
+	return usr, nil
+}
+
+func (u *OAuthLoginUsecase) archiveAvatar(ctx context.Context, external *provider.ExternalUser) string {
+	if u == nil || external == nil {
+		return ""
+	}
+	if strings.TrimSpace(external.AvatarURL) == "" {
+		u.logAvatarArchiveSkipped(ctx, external, "empty_avatar_url")
+		return ""
+	}
+	if u.avatarArchiver == nil {
+		u.logAvatarArchiveSkipped(ctx, external, "object_storage_disabled")
+		return ""
+	}
+	avatarURL, err := u.avatarArchiver.Archive(ctx, external.Provider, external.IdentityID, external.AvatarURL)
+	if err != nil {
+		u.logger.WarnContext(ctx, "archive oauth avatar failed", "provider", external.Provider, "identity_id", external.IdentityID, "error", err)
+		return ""
+	}
+	if avatarURL == "" {
+		u.logAvatarArchiveSkipped(ctx, external, "archived_avatar_url_empty")
+		return ""
+	}
+	return avatarURL
+}
+
+func (u *OAuthLoginUsecase) logAvatarArchiveSkipped(ctx context.Context, external *provider.ExternalUser, reason string) {
+	if u == nil || u.logger == nil || external == nil {
+		return
+	}
+	u.logger.WarnContext(ctx, "skip oauth avatar archive",
+		"provider", external.Provider,
+		"identity_id", external.IdentityID,
+		"reason", reason,
+		"avatar_url_present", strings.TrimSpace(external.AvatarURL) != "",
+	)
+}
+
+func validateOAuthLoginUser(usr *db.User) error {
+	if usr == nil {
+		return errcode.ErrOAuthLoginFailed
+	}
+	if usr.Role != consts.UserRoleIndividual {
+		return errcode.ErrOAuthLoginRoleDenied
+	}
+	if usr.IsBlocked {
+		return errcode.ErrUserBlocked
+	}
+	return nil
+}
+
+func (u *OAuthLoginUsecase) providerEnabled(name provider.Name) bool {
+	switch name {
+	case provider.Google:
+		return u.config.OAuthLogin.Google.Enabled && u.config.OAuthLogin.Google.ClientID != "" && u.config.OAuthLogin.Google.ClientSecret != ""
+	case provider.Github:
+		return u.config.OAuthLogin.Github.Enabled && u.config.OAuthLogin.Github.ClientID != "" && u.config.OAuthLogin.Github.ClientSecret != ""
+	default:
+		return false
+	}
+}
+
+func oauthPlatform(name provider.Name) consts.UserPlatform {
+	switch name {
+	case provider.Google:
+		return consts.UserPlatformGoogle
+	case provider.Github:
+		return consts.UserPlatformGithub
+	default:
+		return consts.UserPlatform(name)
+	}
+}
+
+func randomOAuthToken() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return base64.RawURLEncoding.EncodeToString([]byte(time.Now().Format(time.RFC3339Nano)))
+	}
+	return base64.RawURLEncoding.EncodeToString(b)
+}

--- a/backend/biz/user/usecase/oauth_login_test.go
+++ b/backend/biz/user/usecase/oauth_login_test.go
@@ -1,0 +1,332 @@
+package usecase
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"golang.org/x/oauth2"
+
+	"github.com/chaitin/MonkeyCode/backend/biz/user/provider"
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/consts"
+	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/errcode"
+)
+
+func TestOAuthLoginStartRejectsDisabledProvider(t *testing.T) {
+	uc, _ := newOAuthLoginUsecaseForTest(t, nil, nil)
+
+	_, err := uc.StartOAuthLogin(context.Background(), "google", "/console/tasks")
+	if err != errcode.ErrOAuthLoginProviderDisabled {
+		t.Fatalf("error = %v, want provider disabled", err)
+	}
+}
+
+func TestOAuthLoginStartRejectsInvalidRedirect(t *testing.T) {
+	cfg := oauthLoginTestConfig()
+	uc, _ := newOAuthLoginUsecaseForTest(t, cfg, nil)
+
+	_, err := uc.StartOAuthLogin(context.Background(), "google", "https://evil.example.com")
+	if err != errcode.ErrOAuthLoginRedirectInvalid {
+		t.Fatalf("error = %v, want redirect invalid", err)
+	}
+}
+
+func TestOAuthLoginCallbackCreatesIndividualAndReturnsRedirect(t *testing.T) {
+	cfg := oauthLoginTestConfig()
+	repo := &oauthLoginRepoStub{}
+	uc, _ := newOAuthLoginUsecaseForTest(t, cfg, repo)
+	uc.avatarArchiver = &oauthAvatarArchiverStub{url: "https://oss.example.com/avatar/oauth/google/google-id.png"}
+
+	authURL, err := uc.StartOAuthLogin(context.Background(), "google", "/console/tasks")
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := stateFromAuthURL(t, authURL)
+	resp, err := uc.HandleOAuthCallback(context.Background(), "google", "code", state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.RedirectURL != "/console/tasks" {
+		t.Fatalf("redirect = %q", resp.RedirectURL)
+	}
+	if resp.User == nil || resp.User.Email != "alice@example.com" {
+		t.Fatalf("user = %#v", resp.User)
+	}
+	if repo.created == nil {
+		t.Fatal("expected created user")
+	}
+	if repo.created.AvatarURL != "https://oss.example.com/avatar/oauth/google/google-id.png" {
+		t.Fatalf("created avatar = %q", repo.created.AvatarURL)
+	}
+}
+
+func TestOAuthLoginCallbackRejectsProviderMismatch(t *testing.T) {
+	cfg := oauthLoginTestConfig()
+	uc, _ := newOAuthLoginUsecaseForTest(t, cfg, nil)
+
+	authURL, err := uc.StartOAuthLogin(context.Background(), "google", "/console/tasks")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = uc.HandleOAuthCallback(context.Background(), "github", "code", stateFromAuthURL(t, authURL))
+	if err != errcode.ErrOAuthLoginStateInvalid {
+		t.Fatalf("error = %v, want state invalid", err)
+	}
+}
+
+func TestOAuthLoginCallbackBindsExistingIndividual(t *testing.T) {
+	cfg := oauthLoginTestConfig()
+	existing := &db.User{ID: uuid.New(), Name: "Alice", Email: "alice@example.com", Role: consts.UserRoleIndividual, Status: consts.UserStatusActive}
+	repo := &oauthLoginRepoStub{individual: existing}
+	uc, _ := newOAuthLoginUsecaseForTest(t, cfg, repo)
+	uc.avatarArchiver = &oauthAvatarArchiverStub{url: "https://oss.example.com/avatar/oauth/google/google-id.png"}
+
+	authURL, err := uc.StartOAuthLogin(context.Background(), "google", "/console/tasks")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := uc.HandleOAuthCallback(context.Background(), "google", "code", stateFromAuthURL(t, authURL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.User.ID != existing.ID {
+		t.Fatalf("user id = %s, want %s", resp.User.ID, existing.ID)
+	}
+	if !repo.bound {
+		t.Fatal("expected identity bind")
+	}
+	if repo.boundUser == nil || repo.boundUser.AvatarURL != "https://oss.example.com/avatar/oauth/google/google-id.png" {
+		t.Fatalf("bound user = %#v", repo.boundUser)
+	}
+}
+
+func TestOAuthLoginCallbackRefreshesBoundIdentityAvatar(t *testing.T) {
+	cfg := oauthLoginTestConfig()
+	existing := &db.User{ID: uuid.New(), Name: "Alice", Email: "alice@example.com", Role: consts.UserRoleIndividual, Status: consts.UserStatusActive}
+	repo := &oauthLoginRepoStub{identityUser: existing}
+	uc, _ := newOAuthLoginUsecaseForTest(t, cfg, repo)
+	uc.avatarArchiver = &oauthAvatarArchiverStub{url: "https://oss.example.com/avatar/oauth/google/google-id-new.png"}
+
+	authURL, err := uc.StartOAuthLogin(context.Background(), "google", "/console/tasks")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := uc.HandleOAuthCallback(context.Background(), "google", "code", stateFromAuthURL(t, authURL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.User.ID != existing.ID {
+		t.Fatalf("user id = %s, want %s", resp.User.ID, existing.ID)
+	}
+	if repo.updatedIdentity == nil || repo.updatedIdentity.AvatarURL != "https://oss.example.com/avatar/oauth/google/google-id-new.png" {
+		t.Fatalf("updated identity = %#v", repo.updatedIdentity)
+	}
+}
+
+func TestOAuthLoginCallbackDoesNotPersistThirdPartyAvatarWhenArchiveFails(t *testing.T) {
+	cfg := oauthLoginTestConfig()
+	repo := &oauthLoginRepoStub{}
+	uc, _ := newOAuthLoginUsecaseForTest(t, cfg, repo)
+	uc.avatarArchiver = &oauthAvatarArchiverStub{err: errors.New("upload failed")}
+
+	authURL, err := uc.StartOAuthLogin(context.Background(), "google", "/console/tasks")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = uc.HandleOAuthCallback(context.Background(), "google", "code", stateFromAuthURL(t, authURL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repo.created == nil {
+		t.Fatal("expected created user")
+	}
+	if repo.created.AvatarURL != "" {
+		t.Fatalf("created avatar = %q, want empty", repo.created.AvatarURL)
+	}
+}
+
+func TestOAuthLoginArchiveAvatarLogsSkippedReasons(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	uc := &OAuthLoginUsecase{logger: logger}
+
+	got := uc.archiveAvatar(context.Background(), &provider.ExternalUser{
+		Provider:   provider.Google,
+		IdentityID: "google-id",
+		AvatarURL:  "https://example.com/avatar.png",
+	})
+	if got != "" {
+		t.Fatalf("avatar url = %q, want empty", got)
+	}
+	if !strings.Contains(buf.String(), "skip oauth avatar archive") || !strings.Contains(buf.String(), "object_storage_disabled") {
+		t.Fatalf("log = %s", buf.String())
+	}
+
+	buf.Reset()
+	uc.avatarArchiver = &oauthAvatarArchiverStub{}
+	got = uc.archiveAvatar(context.Background(), &provider.ExternalUser{
+		Provider:   provider.Github,
+		IdentityID: "12345",
+	})
+	if got != "" {
+		t.Fatalf("avatar url = %q, want empty", got)
+	}
+	if !strings.Contains(buf.String(), "skip oauth avatar archive") || !strings.Contains(buf.String(), "empty_avatar_url") {
+		t.Fatalf("log = %s", buf.String())
+	}
+}
+
+func TestOAuthLoginCallbackRejectsNonIndividualBoundUser(t *testing.T) {
+	cfg := oauthLoginTestConfig()
+	repo := &oauthLoginRepoStub{identityUser: &db.User{ID: uuid.New(), Role: consts.UserRoleSubAccount, Status: consts.UserStatusActive}}
+	uc, _ := newOAuthLoginUsecaseForTest(t, cfg, repo)
+
+	authURL, err := uc.StartOAuthLogin(context.Background(), "google", "/console/tasks")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = uc.HandleOAuthCallback(context.Background(), "google", "code", stateFromAuthURL(t, authURL))
+	if err != errcode.ErrOAuthLoginRoleDenied {
+		t.Fatalf("error = %v, want role denied", err)
+	}
+}
+
+func newOAuthLoginUsecaseForTest(t *testing.T, cfg *config.Config, repo *oauthLoginRepoStub) (*OAuthLoginUsecase, func()) {
+	t.Helper()
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	if repo == nil {
+		repo = &oauthLoginRepoStub{}
+	}
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	uc := &OAuthLoginUsecase{
+		repo:   repo,
+		redis:  rdb,
+		config: cfg,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		providers: map[provider.Name]provider.Provider{
+			provider.Google: &oauthProviderStub{name: provider.Google},
+			provider.Github: &oauthProviderStub{name: provider.Github},
+		},
+	}
+	return uc, func() {
+		_ = rdb.Close()
+		mr.Close()
+	}
+}
+
+func oauthLoginTestConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.OAuthLogin.Google.Enabled = true
+	cfg.OAuthLogin.Google.ClientID = "google-client"
+	cfg.OAuthLogin.Google.ClientSecret = "google-secret"
+	cfg.OAuthLogin.Github.Enabled = true
+	cfg.OAuthLogin.Github.ClientID = "github-client"
+	cfg.OAuthLogin.Github.ClientSecret = "github-secret"
+	return cfg
+}
+
+func stateFromAuthURL(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := u.Query().Get("state")
+	if state == "" {
+		t.Fatalf("missing state in %q", raw)
+	}
+	return state
+}
+
+type oauthProviderStub struct {
+	name provider.Name
+}
+
+func (p *oauthProviderStub) Name() provider.Name {
+	return p.name
+}
+
+func (p *oauthProviderStub) AuthCodeURL(state, nonce string) string {
+	v := url.Values{}
+	v.Set("state", state)
+	v.Set("nonce", nonce)
+	return "https://auth.example.com/authorize?" + v.Encode()
+}
+
+func (p *oauthProviderStub) Exchange(context.Context, string) (*oauth2.Token, error) {
+	return &oauth2.Token{AccessToken: "token"}, nil
+}
+
+func (p *oauthProviderStub) User(context.Context, *oauth2.Token, string) (*provider.ExternalUser, error) {
+	return &provider.ExternalUser{
+		Provider:      p.name,
+		IdentityID:    string(p.name) + "-id",
+		Email:         "alice@example.com",
+		EmailVerified: true,
+		Username:      "alice",
+		Name:          "Alice",
+		AvatarURL:     "https://example.com/avatar.png",
+	}, nil
+}
+
+type oauthLoginRepoStub struct {
+	identityUser    *db.User
+	individual      *db.User
+	created         *domain.OAuthLoginUser
+	boundUser       *domain.OAuthLoginUser
+	updatedIdentity *domain.OAuthLoginUser
+	bound           bool
+}
+
+func (r *oauthLoginRepoStub) FindUserByOAuthIdentity(context.Context, consts.UserPlatform, string) (*db.User, error) {
+	if r.identityUser == nil {
+		return nil, &db.NotFoundError{}
+	}
+	return r.identityUser, nil
+}
+
+func (r *oauthLoginRepoStub) FindIndividualByEmail(context.Context, string) (*db.User, error) {
+	return r.individual, nil
+}
+
+func (r *oauthLoginRepoStub) CreateIndividualWithIdentity(_ context.Context, external *domain.OAuthLoginUser) (*db.User, error) {
+	if strings.TrimSpace(external.Email) == "" {
+		return nil, errors.New("email required")
+	}
+	r.created = external
+	return &db.User{ID: uuid.New(), Name: external.Name, Email: external.Email, Role: consts.UserRoleIndividual, Status: consts.UserStatusActive}, nil
+}
+
+func (r *oauthLoginRepoStub) BindOAuthIdentity(_ context.Context, _ uuid.UUID, external *domain.OAuthLoginUser) error {
+	r.bound = true
+	r.boundUser = external
+	return nil
+}
+
+func (r *oauthLoginRepoStub) UpdateOAuthIdentity(_ context.Context, external *domain.OAuthLoginUser) error {
+	r.updatedIdentity = external
+	return nil
+}
+
+type oauthAvatarArchiverStub struct {
+	url string
+	err error
+}
+
+func (a *oauthAvatarArchiverStub) Archive(context.Context, provider.Name, string, string) (string, error) {
+	return a.url, a.err
+}

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -80,6 +80,8 @@ type Config struct {
 	// 微信配置（开放平台 OAuth 登录 + 公众号消息推送）
 	Wechat WechatConfig `mapstructure:"wechat"`
 
+	OAuthLogin OAuthLoginConfig `mapstructure:"oauth_login"`
+
 	InitTeam InitTeam `mapstructure:"init_team"`
 
 	// 语音识别配置（阿里云 NLS，用于一段录音 POST 接口）
@@ -94,6 +96,18 @@ type Config struct {
 type ReviewAgent struct {
 	ModelID string `mapstructure:"model_id"`
 	Image   string `mapstructure:"image"`
+}
+
+type OAuthLoginConfig struct {
+	Google OAuthLoginProviderConfig `mapstructure:"google"`
+	Github OAuthLoginProviderConfig `mapstructure:"github"`
+}
+
+type OAuthLoginProviderConfig struct {
+	Enabled      bool   `mapstructure:"enabled"`
+	ClientID     string `mapstructure:"client_id"`
+	ClientSecret string `mapstructure:"client_secret"`
+	RedirectURL  string `mapstructure:"redirect_url"`
 }
 
 // AliyunOSSConfig is structurally identical to mcai-backend's config.OSSConfig
@@ -393,6 +407,14 @@ func Init(dir string) (*Config, error) {
 	v.SetDefault("wechat.mp.qa.base_url", "")
 	v.SetDefault("wechat.mp.qa.api_key", "")
 	v.SetDefault("wechat.mp.qa.model", "deepseek-v3.2")
+	v.SetDefault("oauth_login.google.enabled", false)
+	v.SetDefault("oauth_login.google.client_id", "")
+	v.SetDefault("oauth_login.google.client_secret", "")
+	v.SetDefault("oauth_login.google.redirect_url", "")
+	v.SetDefault("oauth_login.github.enabled", false)
+	v.SetDefault("oauth_login.github.client_id", "")
+	v.SetDefault("oauth_login.github.client_secret", "")
+	v.SetDefault("oauth_login.github.redirect_url", "")
 
 	v.SetConfigType("yaml")
 	v.AddConfigPath(dir)

--- a/backend/config/oss_config_test.go
+++ b/backend/config/oss_config_test.go
@@ -65,6 +65,18 @@ func TestObjectStorageDefaults(t *testing.T) {
 	if cfg.HostInstaller.BundlePath != "installer/{{.arch}}/host.tgz" {
 		t.Fatalf("host_installer.bundle_path = %q", cfg.HostInstaller.BundlePath)
 	}
+	if cfg.OAuthLogin.Google.Enabled {
+		t.Fatal("oauth_login.google.enabled default = true, want false")
+	}
+	if cfg.OAuthLogin.Google.ClientID != "" {
+		t.Fatalf("oauth_login.google.client_id = %q, want empty", cfg.OAuthLogin.Google.ClientID)
+	}
+	if cfg.OAuthLogin.Github.Enabled {
+		t.Fatal("oauth_login.github.enabled default = true, want false")
+	}
+	if cfg.OAuthLogin.Github.ClientID != "" {
+		t.Fatalf("oauth_login.github.client_id = %q, want empty", cfg.OAuthLogin.Github.ClientID)
+	}
 }
 
 func TestTaskCreateReqTTLCanBeConfiguredByEnv(t *testing.T) {

--- a/backend/config/server/config.yaml.example
+++ b/backend/config/server/config.yaml.example
@@ -90,6 +90,20 @@ wechat:
       # 模型名，留空默认 deepseek-v3.2
       model: "deepseek-v3.2"
 
+oauth_login:
+  google:
+    enabled: false
+    client_id: ""
+    client_secret: ""
+    # 留空时默认使用 server.base_url + /api/v1/users/oauth/google/callback
+    redirect_url: ""
+  github:
+    enabled: false
+    client_id: ""
+    client_secret: ""
+    # 留空时默认使用 server.base_url + /api/v1/users/oauth/github/callback
+    redirect_url: ""
+
 task:
   create_req_ttl_seconds: 600
 

--- a/backend/consts/user.go
+++ b/backend/consts/user.go
@@ -4,6 +4,7 @@ type UserPlatform string
 
 const (
 	UserPlatformBaizhi UserPlatform = "baizhi" // 百智云平台
+	UserPlatformGoogle UserPlatform = "google"
 	UserPlatformGithub UserPlatform = "github"
 	UserPlatformGitLab UserPlatform = "gitlab"
 	UserPlatformGitea  UserPlatform = "gitea"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -110,6 +110,47 @@
                 }
             }
         },
+        "/api/v1/server/config": {
+            "get": {
+                "description": "返回当前服务的产品形态、SaaS 区域和版本信息，用于前端区分部署形态和升级状态。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "【服务】配置信息"
+                ],
+                "summary": "获取服务配置",
+                "responses": {
+                    "200": {
+                        "description": "获取成功",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/web.Resp"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/domain.ServerConfig"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "服务器内部错误",
+                        "schema": {
+                            "$ref": "#/definitions/web.Resp"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/skills": {
             "get": {
                 "security": [
@@ -7274,6 +7315,62 @@
                 }
             }
         },
+        "/api/v1/users/oauth/{provider}/login": {
+            "get": {
+                "description": "根据 provider 生成第三方授权地址。provider 仅支持 google、github。redirect_url 可选，必须是站内相对路径；登录成功后后端会跳转到该路径，空值默认 /console/。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "【用户】第三方登录"
+                ],
+                "summary": "发起 Google/GitHub OAuth 登录",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "登录提供方，仅支持 google、github",
+                        "name": "provider",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "登录成功后的站内跳转路径，例如 /console/tasks；只允许站内相对路径",
+                        "name": "redirect_url",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/web.Resp"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/domain.OAuthLoginResp"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "provider 或 redirect_url 无效",
+                        "schema": {
+                            "$ref": "#/definitions/web.Resp"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/users/oidc/callback": {
             "get": {
                 "description": "处理身份源回调并创建 MonkeyCode 登录会话",
@@ -9869,6 +9966,7 @@
             "type": "string",
             "enum": [
                 "baizhi",
+                "google",
                 "github",
                 "gitlab",
                 "gitea",
@@ -9880,6 +9978,7 @@
             },
             "x-enum-varnames": [
                 "UserPlatformBaizhi",
+                "UserPlatformGoogle",
                 "UserPlatformGithub",
                 "UserPlatformGitLab",
                 "UserPlatformGitea",
@@ -11094,6 +11193,9 @@
                 "created_images": {
                     "type": "integer"
                 },
+                "created_rules": {
+                    "type": "integer"
+                },
                 "created_skills": {
                     "type": "integer"
                 },
@@ -11101,6 +11203,9 @@
                     "type": "string"
                 },
                 "updated_images": {
+                    "type": "integer"
+                },
+                "updated_rules": {
                     "type": "integer"
                 },
                 "updated_skills": {
@@ -11642,6 +11747,14 @@
                 }
             }
         },
+        "domain.OAuthLoginResp": {
+            "type": "object",
+            "properties": {
+                "auth_url": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.OpenAIError": {
             "type": "object",
             "properties": {
@@ -11695,6 +11808,28 @@
                     "$ref": "#/definitions/domain.SkillScope"
                 }
             }
+        },
+        "domain.ProductEdition": {
+            "type": "string",
+            "enum": [
+                "saas",
+                "private"
+            ],
+            "x-enum-varnames": [
+                "ProductEditionSaaS",
+                "ProductEditionPrivate"
+            ]
+        },
+        "domain.ProductRegion": {
+            "type": "string",
+            "enum": [
+                "cn",
+                "global"
+            ],
+            "x-enum-varnames": [
+                "ProductRegionCN",
+                "ProductRegionGlobal"
+            ]
         },
         "domain.Project": {
             "type": "object",
@@ -12133,6 +12268,47 @@
                 "email": {
                     "description": "要绑定的邮箱地址",
                     "type": "string"
+                }
+            }
+        },
+        "domain.ServerConfig": {
+            "type": "object",
+            "properties": {
+                "current_version": {
+                    "description": "CurrentVersion 当前服务版本。",
+                    "type": "string",
+                    "example": "v1.2.3"
+                },
+                "edition": {
+                    "description": "Edition 当前产品形态：SaaS 或私有化版本。",
+                    "enum": [
+                        "saas",
+                        "private"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/domain.ProductEdition"
+                        }
+                    ],
+                    "example": "saas"
+                },
+                "latest_version": {
+                    "description": "LatestVersion 最新可用版本。",
+                    "type": "string",
+                    "example": "v1.2.4"
+                },
+                "region": {
+                    "description": "Region SaaS 区域，国内 SaaS 返回 cn，海外 SaaS 返回 global。",
+                    "enum": [
+                        "cn",
+                        "global"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/domain.ProductRegion"
+                        }
+                    ],
+                    "example": "cn"
                 }
             }
         },

--- a/backend/domain/user.go
+++ b/backend/domain/user.go
@@ -36,6 +36,48 @@ type UserRepo interface {
 	SetEmail(ctx context.Context, userID uuid.UUID, email string) error
 }
 
+type OAuthLoginUser struct {
+	Provider   consts.UserPlatform
+	IdentityID string
+	Email      string
+	Username   string
+	Name       string
+	AvatarURL  string
+}
+
+type OAuthLoginRepo interface {
+	FindUserByOAuthIdentity(ctx context.Context, platform consts.UserPlatform, identityID string) (*db.User, error)
+	FindIndividualByEmail(ctx context.Context, email string) (*db.User, error)
+	CreateIndividualWithIdentity(ctx context.Context, external *OAuthLoginUser) (*db.User, error)
+	BindOAuthIdentity(ctx context.Context, userID uuid.UUID, external *OAuthLoginUser) error
+	UpdateOAuthIdentity(ctx context.Context, external *OAuthLoginUser) error
+}
+
+type OAuthLoginUsecase interface {
+	StartOAuthLogin(ctx context.Context, provider string, redirectURL string) (string, error)
+	HandleOAuthCallback(ctx context.Context, provider string, code string, state string) (*OAuthLoginCallbackResp, error)
+}
+
+type OAuthLoginCallbackResp struct {
+	User        *User
+	RedirectURL string
+}
+
+type OAuthLoginResp struct {
+	AuthURL string `json:"auth_url"`
+}
+
+type OAuthLoginReq struct {
+	Provider    string `param:"provider" validate:"required" swaggerignore:"true"`
+	RedirectURL string `query:"redirect_url"`
+}
+
+type OAuthCallbackReq struct {
+	Provider string `param:"provider" validate:"required" swaggerignore:"true"`
+	Code     string `query:"code" validate:"required"`
+	State    string `query:"state" validate:"required"`
+}
+
 // UserActiveRepo 用户活跃记录仓储接口
 type UserActiveRepo interface {
 	RecordActiveIP(ctx context.Context, key string, ip string) error

--- a/backend/errcode/errcode.go
+++ b/backend/errcode/errcode.go
@@ -108,6 +108,13 @@ var (
 	ErrOIDCEmailDomainDenied         = web.NewErr(http.StatusOK, 10623, "err-oidc-email-domain-denied")
 	ErrOIDCTeamMemberRequired        = web.NewErr(http.StatusOK, 10624, "err-oidc-team-member-required")
 	ErrPasswordLoginDisabled         = web.NewErr(http.StatusOK, 10625, "err-password-login-disabled")
+	ErrOAuthLoginProviderDisabled    = web.NewErr(http.StatusOK, 10626, "err-oauth-login-provider-disabled")
+	ErrOAuthLoginStateInvalid        = web.NewErr(http.StatusOK, 10627, "err-oauth-login-state-invalid")
+	ErrOAuthLoginEmailRequired       = web.NewErr(http.StatusOK, 10628, "err-oauth-login-email-required")
+	ErrOAuthLoginEmailUnverified     = web.NewErr(http.StatusOK, 10629, "err-oauth-login-email-unverified")
+	ErrOAuthLoginRoleDenied          = web.NewErr(http.StatusOK, 10630, "err-oauth-login-role-denied")
+	ErrOAuthLoginFailed              = web.NewErr(http.StatusOK, 10631, "err-oauth-login-failed")
+	ErrOAuthLoginRedirectInvalid     = web.NewErr(http.StatusOK, 10632, "err-oauth-login-redirect-invalid")
 
 	// captcha 模块
 	ErrCreateCaptchaFailed = web.NewErr(http.StatusOK, 10700, "err-create-captcha-failed")

--- a/backend/errcode/locale.en.toml
+++ b/backend/errcode/locale.en.toml
@@ -237,6 +237,27 @@ other = "Account is not a member of this team"
 [err-password-login-disabled]
 other = "Password login is disabled for this team"
 
+[err-oauth-login-provider-disabled]
+other = "This login method is not enabled"
+
+[err-oauth-login-state-invalid]
+other = "Login state has expired, please try again"
+
+[err-oauth-login-email-required]
+other = "The third-party account did not return a usable email"
+
+[err-oauth-login-email-unverified]
+other = "The third-party account email is not verified"
+
+[err-oauth-login-role-denied]
+other = "This account is not allowed to use third-party login"
+
+[err-oauth-login-failed]
+other = "Third-party login failed"
+
+[err-oauth-login-redirect-invalid]
+other = "Login redirect URL is invalid"
+
 [err-has-invalid-entry]
 other = "Invalid entry exists"
 

--- a/backend/errcode/locale.zh.toml
+++ b/backend/errcode/locale.zh.toml
@@ -244,6 +244,27 @@ other = "账号未加入该团队"
 [err-password-login-disabled]
 other = "该团队已关闭账号密码登录"
 
+[err-oauth-login-provider-disabled]
+other = "该登录方式暂未启用"
+
+[err-oauth-login-state-invalid]
+other = "登录状态已失效，请重新登录"
+
+[err-oauth-login-email-required]
+other = "第三方账号未返回可用邮箱"
+
+[err-oauth-login-email-unverified]
+other = "第三方账号邮箱未验证"
+
+[err-oauth-login-role-denied]
+other = "该账号不允许使用第三方登录"
+
+[err-oauth-login-failed]
+other = "第三方登录失败"
+
+[err-oauth-login-redirect-invalid]
+other = "登录跳转地址无效"
+
 [err-has-invalid-entry]
 other = "存在无效条目"
 

--- a/backend/pkg/oss/oss.go
+++ b/backend/pkg/oss/oss.go
@@ -350,11 +350,26 @@ func objectAccessBase(cfg config.ObjectStorageConfig) string {
 	if err != nil {
 		return strings.TrimRight(base, "/") + "/" + bucket
 	}
+	if endpointHostHasBucket(u, bucket) {
+		return u.String()
+	}
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 	if len(parts) == 0 || parts[len(parts)-1] != bucket {
 		u.Path = strings.TrimRight(u.Path, "/") + "/" + bucket
 	}
 	return u.String()
+}
+
+func endpointHostHasBucket(u *url.URL, bucket string) bool {
+	if u == nil {
+		return false
+	}
+	bucket = strings.ToLower(strings.Trim(bucket, "/"))
+	if bucket == "" {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return strings.HasPrefix(host, bucket+".")
 }
 
 func presignSigningEndpoint(cfg config.ObjectStorageConfig) string {

--- a/backend/pkg/oss/oss_test.go
+++ b/backend/pkg/oss/oss_test.go
@@ -61,6 +61,20 @@ func TestPublicURLAddsBucketWhenAccessEndpointHasNoPath(t *testing.T) {
 	}
 }
 
+func TestPublicURLDoesNotAddBucketWhenAccessEndpointHostHasBucket(t *testing.T) {
+	client := &Client{
+		cfg: config.ObjectStorageConfig{
+			AccessEndpoint: "https://monkeycode-global.oss-accelerate.aliyuncs.com",
+			Bucket:         "monkeycode-global",
+		},
+	}
+	url := client.GetURL("dev/avatar/oauth/google", "108176778654195666956.png")
+	want := "https://monkeycode-global.oss-accelerate.aliyuncs.com/dev/avatar/oauth/google/108176778654195666956.png"
+	if url != want {
+		t.Fatalf("url = %q, want %q", url, want)
+	}
+}
+
 func TestPublicURLEscapesPath(t *testing.T) {
 	client := &Client{
 		cfg: config.ObjectStorageConfig{


### PR DESCRIPTION
## Summary
- 新增 Google/GitHub OAuth 登录后端链路，包含 provider、usecase、repo 和 HTTP login/callback 接口
- 支持登录发起时传入站内 redirect_url，回调成功后写入现有 session 并回跳
- 补充 OAuth 登录配置、错误码、Swagger 注释和单元测试；复用现有 user_identities 唯一索引，未新增 migration

## Test Plan
- [x] cd backend && GOWORK=off make swag
- [x] cd backend && GOWORK=off go test ./... -count=1