### PR TITLE
fix: 修复私有化对象资源访问地址

### DIFF
--- a/backend/biz/task/usecase/attachment.go
+++ b/backend/biz/task/usecase/attachment.go
@@ -33,6 +33,9 @@ func validateAttachments(userID uuid.UUID, attachments []domain.TaskAttachment, 
 			return errcode.ErrBadRequest.Wrap(fmt.Errorf("attachment filename is empty"))
 		}
 		if key, ok := asseturl.Parse(raw); ok {
+			if !objectCfg.Enabled {
+				return errcode.ErrBadRequest.Wrap(fmt.Errorf("object storage is disabled"))
+			}
 			if !asseturl.AllowedForUser(key, userID, objectCfg) {
 				return errcode.ErrBadRequest.Wrap(fmt.Errorf("attachment asset is not allowed"))
 			}
@@ -70,7 +73,7 @@ func (a *TaskUsecase) taskAttachmentsToTaskflow(ctx context.Context, attachments
 	for _, attachment := range attachments {
 		raw := strings.TrimSpace(attachment.URL)
 		if key, ok := asseturl.Parse(raw); ok {
-			if a == nil || a.attachmentSigner == nil {
+			if a == nil || a.cfg == nil || !a.cfg.ObjectStorage.Enabled || a.attachmentSigner == nil {
 				return nil, errcode.ErrBadRequest.Wrap(fmt.Errorf("object storage is disabled"))
 			}
 			u, err := a.attachmentSigner.PresignGet(ctx, key, attachmentPresignExpires(a.cfg))

--- a/backend/biz/task/usecase/attachment.go
+++ b/backend/biz/task/usecase/attachment.go
@@ -1,19 +1,23 @@
 package usecase
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/chaitin/MonkeyCode/backend/config"
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/errcode"
+	"github.com/chaitin/MonkeyCode/backend/pkg/asseturl"
 	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
+	"github.com/google/uuid"
 )
 
 const maxAttachments = 10
 
-func validateAttachments(attachments []domain.TaskAttachment, cfg config.Attachment) error {
+func validateAttachments(userID uuid.UUID, attachments []domain.TaskAttachment, cfg config.Attachment, objectCfg config.ObjectStorageConfig) error {
 	if len(attachments) == 0 {
 		return nil
 	}
@@ -27,6 +31,12 @@ func validateAttachments(attachments []domain.TaskAttachment, cfg config.Attachm
 		}
 		if strings.TrimSpace(attachment.Filename) == "" {
 			return errcode.ErrBadRequest.Wrap(fmt.Errorf("attachment filename is empty"))
+		}
+		if key, ok := asseturl.Parse(raw); ok {
+			if !asseturl.AllowedForUser(key, userID, objectCfg) {
+				return errcode.ErrBadRequest.Wrap(fmt.Errorf("attachment asset is not allowed"))
+			}
+			continue
 		}
 		u, err := url.Parse(raw)
 		if err != nil || u.Host == "" {
@@ -52,16 +62,41 @@ func matchAllowedAttachmentPrefix(raw string, prefixes []string) bool {
 	return false
 }
 
-func taskAttachmentsToTaskflow(attachments []domain.TaskAttachment) []taskflow.Attachment {
+func (a *TaskUsecase) taskAttachmentsToTaskflow(ctx context.Context, attachments []domain.TaskAttachment) ([]taskflow.Attachment, error) {
 	if len(attachments) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]taskflow.Attachment, 0, len(attachments))
 	for _, attachment := range attachments {
+		raw := strings.TrimSpace(attachment.URL)
+		if key, ok := asseturl.Parse(raw); ok {
+			if a == nil || a.attachmentSigner == nil {
+				return nil, errcode.ErrBadRequest.Wrap(fmt.Errorf("object storage is disabled"))
+			}
+			u, err := a.attachmentSigner.PresignGet(ctx, key, attachmentPresignExpires(a.cfg))
+			if err != nil {
+				return nil, err
+			}
+			raw = u
+		}
 		out = append(out, taskflow.Attachment{
-			URL:      attachment.URL,
+			URL:      raw,
 			Filename: attachment.Filename,
 		})
 	}
-	return out
+	return out, nil
+}
+
+func attachmentPresignExpires(cfg *config.Config) time.Duration {
+	if cfg == nil {
+		return 7 * 24 * time.Hour
+	}
+	expires, err := time.ParseDuration(strings.TrimSpace(cfg.ObjectStorage.PresignExpires))
+	if err != nil || expires <= 0 {
+		return 7 * 24 * time.Hour
+	}
+	if expires > 7*24*time.Hour {
+		return 7 * 24 * time.Hour
+	}
+	return expires
 }

--- a/backend/biz/task/usecase/attachment_test.go
+++ b/backend/biz/task/usecase/attachment_test.go
@@ -1,27 +1,54 @@
 package usecase
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/chaitin/MonkeyCode/backend/config"
 	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/pkg/asseturl"
+	"github.com/google/uuid"
 )
 
 func TestValidateAttachmentsAllowsEmpty(t *testing.T) {
 	cfg := config.Attachment{AllowedURLPrefixes: []string{"https://oss.example.com/temp/"}}
-	if err := validateAttachments(nil, cfg); err != nil {
+	if err := validateAttachments(uuid.Nil, nil, cfg, config.ObjectStorageConfig{}); err != nil {
 		t.Fatalf("validateAttachments(nil) error = %v", err)
 	}
-	if err := validateAttachments([]domain.TaskAttachment{}, cfg); err != nil {
+	if err := validateAttachments(uuid.Nil, []domain.TaskAttachment{}, cfg, config.ObjectStorageConfig{}); err != nil {
 		t.Fatalf("validateAttachments(empty) error = %v", err)
 	}
 }
 
 func TestValidateAttachmentsAllowsConfiguredPrefix(t *testing.T) {
 	cfg := config.Attachment{AllowedURLPrefixes: []string{"https://oss.example.com/temp/"}}
-	err := validateAttachments([]domain.TaskAttachment{{URL: "https://oss.example.com/temp/a.txt", Filename: "a.txt"}}, cfg)
+	err := validateAttachments(uuid.Nil, []domain.TaskAttachment{{URL: "https://oss.example.com/temp/a.txt", Filename: "a.txt"}}, cfg, config.ObjectStorageConfig{})
 	if err != nil {
 		t.Fatalf("validateAttachments() error = %v", err)
+	}
+}
+
+func TestValidateAttachmentsAllowsOwnedAssetURL(t *testing.T) {
+	userID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	cfg := config.ObjectStorageConfig{TempPrefix: "tmp/task-attachments"}
+	key := "tmp/task-attachments/11111111-1111-1111-1111-111111111111_hash.png"
+
+	err := validateAttachments(userID, []domain.TaskAttachment{{URL: asseturl.Build(key), Filename: "a.png"}}, config.Attachment{}, cfg)
+	if err != nil {
+		t.Fatalf("validateAttachments() error = %v", err)
+	}
+}
+
+func TestValidateAttachmentsRejectsOtherUserAssetURL(t *testing.T) {
+	userID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	cfg := config.ObjectStorageConfig{TempPrefix: "tmp/task-attachments"}
+	key := "tmp/task-attachments/22222222-2222-2222-2222-222222222222_hash.png"
+
+	err := validateAttachments(userID, []domain.TaskAttachment{{URL: asseturl.Build(key), Filename: "a.png"}}, config.Attachment{}, cfg)
+	if err == nil {
+		t.Fatal("validateAttachments() error = nil, want error")
 	}
 }
 
@@ -48,8 +75,53 @@ func TestValidateAttachmentsRejectsBadInputs(t *testing.T) {
 	}
 
 	for _, attachments := range cases {
-		if err := validateAttachments(attachments, cfg); err == nil {
+		if err := validateAttachments(uuid.Nil, attachments, cfg, config.ObjectStorageConfig{}); err == nil {
 			t.Fatalf("validateAttachments(%#v) error = nil, want error", attachments)
 		}
 	}
+}
+
+func TestTaskAttachmentsToTaskflowConvertsAssetURLToHTTPPresignURL(t *testing.T) {
+	signer := &fakeAttachmentSigner{}
+	u := &TaskUsecase{attachmentSigner: signer}
+	got, err := u.taskAttachmentsToTaskflow(context.Background(), []domain.TaskAttachment{
+		{URL: asseturl.Build("tmp/task-attachments/11111111-1111-1111-1111-111111111111_hash.png"), Filename: "a.png"},
+	})
+	if err != nil {
+		t.Fatalf("taskAttachmentsToTaskflow() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d", len(got))
+	}
+	wantURL := "http://agent.local/tmp/task-attachments/11111111-1111-1111-1111-111111111111_hash.png"
+	if got[0].URL != wantURL {
+		t.Fatalf("url = %q, want %q", got[0].URL, wantURL)
+	}
+	if signer.key != "tmp/task-attachments/11111111-1111-1111-1111-111111111111_hash.png" {
+		t.Fatalf("key = %q", signer.key)
+	}
+}
+
+func TestTaskAttachmentsToTaskflowKeepsExternalURL(t *testing.T) {
+	u := &TaskUsecase{}
+	got, err := u.taskAttachmentsToTaskflow(context.Background(), []domain.TaskAttachment{
+		{URL: "https://oss.example.com/temp/a.txt", Filename: "a.txt"},
+	})
+	if err != nil {
+		t.Fatalf("taskAttachmentsToTaskflow() error = %v", err)
+	}
+	if got[0].URL != "https://oss.example.com/temp/a.txt" {
+		t.Fatalf("url = %q", got[0].URL)
+	}
+}
+
+type fakeAttachmentSigner struct {
+	key     string
+	expires time.Duration
+}
+
+func (f *fakeAttachmentSigner) PresignGet(_ context.Context, key string, expires time.Duration) (string, error) {
+	f.key = key
+	f.expires = expires
+	return fmt.Sprintf("http://agent.local/%s", key), nil
 }

--- a/backend/biz/task/usecase/attachment_test.go
+++ b/backend/biz/task/usecase/attachment_test.go
@@ -32,7 +32,7 @@ func TestValidateAttachmentsAllowsConfiguredPrefix(t *testing.T) {
 
 func TestValidateAttachmentsAllowsOwnedAssetURL(t *testing.T) {
 	userID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
-	cfg := config.ObjectStorageConfig{TempPrefix: "tmp/task-attachments"}
+	cfg := config.ObjectStorageConfig{Enabled: true, TempPrefix: "tmp/task-attachments"}
 	key := "tmp/task-attachments/11111111-1111-1111-1111-111111111111_hash.png"
 
 	err := validateAttachments(userID, []domain.TaskAttachment{{URL: asseturl.Build(key), Filename: "a.png"}}, config.Attachment{}, cfg)
@@ -43,10 +43,20 @@ func TestValidateAttachmentsAllowsOwnedAssetURL(t *testing.T) {
 
 func TestValidateAttachmentsRejectsOtherUserAssetURL(t *testing.T) {
 	userID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
-	cfg := config.ObjectStorageConfig{TempPrefix: "tmp/task-attachments"}
+	cfg := config.ObjectStorageConfig{Enabled: true, TempPrefix: "tmp/task-attachments"}
 	key := "tmp/task-attachments/22222222-2222-2222-2222-222222222222_hash.png"
 
 	err := validateAttachments(userID, []domain.TaskAttachment{{URL: asseturl.Build(key), Filename: "a.png"}}, config.Attachment{}, cfg)
+	if err == nil {
+		t.Fatal("validateAttachments() error = nil, want error")
+	}
+}
+
+func TestValidateAttachmentsRejectsAssetURLWhenObjectStorageDisabled(t *testing.T) {
+	userID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	key := "tmp/task-attachments/11111111-1111-1111-1111-111111111111_hash.png"
+
+	err := validateAttachments(userID, []domain.TaskAttachment{{URL: asseturl.Build(key), Filename: "a.png"}}, config.Attachment{}, config.ObjectStorageConfig{TempPrefix: "tmp/task-attachments"})
 	if err == nil {
 		t.Fatal("validateAttachments() error = nil, want error")
 	}
@@ -83,7 +93,11 @@ func TestValidateAttachmentsRejectsBadInputs(t *testing.T) {
 
 func TestTaskAttachmentsToTaskflowConvertsAssetURLToHTTPPresignURL(t *testing.T) {
 	signer := &fakeAttachmentSigner{}
-	u := &TaskUsecase{attachmentSigner: signer}
+	u := &TaskUsecase{
+		cfg:              &config.Config{},
+		attachmentSigner: signer,
+	}
+	u.cfg.ObjectStorage.Enabled = true
 	got, err := u.taskAttachmentsToTaskflow(context.Background(), []domain.TaskAttachment{
 		{URL: asseturl.Build("tmp/task-attachments/11111111-1111-1111-1111-111111111111_hash.png"), Filename: "a.png"},
 	})
@@ -103,7 +117,8 @@ func TestTaskAttachmentsToTaskflowConvertsAssetURLToHTTPPresignURL(t *testing.T)
 }
 
 func TestTaskAttachmentsToTaskflowKeepsExternalURL(t *testing.T) {
-	u := &TaskUsecase{}
+	signer := &fakeAttachmentSigner{}
+	u := &TaskUsecase{attachmentSigner: signer}
 	got, err := u.taskAttachmentsToTaskflow(context.Background(), []domain.TaskAttachment{
 		{URL: "https://oss.example.com/temp/a.txt", Filename: "a.txt"},
 	})
@@ -112,6 +127,19 @@ func TestTaskAttachmentsToTaskflowKeepsExternalURL(t *testing.T) {
 	}
 	if got[0].URL != "https://oss.example.com/temp/a.txt" {
 		t.Fatalf("url = %q", got[0].URL)
+	}
+	if signer.key != "" {
+		t.Fatalf("signer called for http url: %q", signer.key)
+	}
+}
+
+func TestTaskAttachmentsToTaskflowRejectsAssetURLWhenObjectStorageDisabled(t *testing.T) {
+	u := &TaskUsecase{attachmentSigner: &fakeAttachmentSigner{}}
+	_, err := u.taskAttachmentsToTaskflow(context.Background(), []domain.TaskAttachment{
+		{URL: asseturl.Build("tmp/task-attachments/11111111-1111-1111-1111-111111111111_hash.png"), Filename: "a.png"},
+	})
+	if err == nil {
+		t.Fatal("taskAttachmentsToTaskflow() error = nil, want error")
 	}
 }
 

--- a/backend/biz/task/usecase/task.go
+++ b/backend/biz/task/usecase/task.go
@@ -63,6 +63,7 @@ type TaskUsecase struct {
 	idleRefresher         vmidle.VMIdleRefresher
 	dbClient              *db.Client
 	resolver              agentresource.ResolverInterface
+	attachmentSigner      domain.AttachmentURLSigner
 }
 
 // NewTaskUsecase 创建任务业务逻辑实例
@@ -85,11 +86,16 @@ func NewTaskUsecase(i *do.Injector) (domain.TaskUsecase, error) {
 		idleRefresher:         do.MustInvoke[vmidle.VMIdleRefresher](i),
 		dbClient:              do.MustInvoke[*db.Client](i),
 	}
-
 	// agentresource.ResolverInterface 注入失败时降级为 nil — getCodingConfigs
 	// 内部 nil-check，跳过 rule/skill/plugin 注入，并打 warn 日志。
 	if r, err := do.Invoke[agentresource.ResolverInterface](i); err == nil {
 		u.resolver = r
+	}
+
+	if signer, err := do.Invoke[domain.AttachmentURLSigner](i); err == nil {
+		u.attachmentSigner = signer
+	} else if store, err := do.Invoke[agentresource.ObjectStore](i); err == nil {
+		u.attachmentSigner = store
 	}
 
 	// 可选注入 TaskHook
@@ -401,7 +407,11 @@ func (a *TaskUsecase) Continue(ctx context.Context, user *domain.User, id uuid.U
 	if strings.TrimSpace(string(req.Content)) == "" {
 		return errcode.ErrBadRequest
 	}
-	if err := validateAttachments(req.Attachments, a.cfg.Attachment); err != nil {
+	if err := validateAttachments(user.ID, req.Attachments, a.cfg.Attachment, a.cfg.ObjectStorage); err != nil {
+		return err
+	}
+	attachments, err := a.taskAttachmentsToTaskflow(ctx, req.Attachments)
+	if err != nil {
 		return err
 	}
 	t, err := a.repo.Info(ctx, user, id, false)
@@ -418,7 +428,7 @@ func (a *TaskUsecase) Continue(ctx context.Context, user *domain.User, id uuid.U
 		Task: &taskflow.Task{
 			ID:          id,
 			Text:        string(req.Content),
-			Attachments: taskAttachmentsToTaskflow(req.Attachments),
+			Attachments: attachments,
 			LogStore:    string(tk.LogStore),
 		},
 	}); err != nil {
@@ -450,7 +460,11 @@ func (a *TaskUsecase) IncrUserInputCount(ctx context.Context, userID, taskID uui
 
 // Create implements domain.TaskUsecase.
 func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.CreateTaskReq) (*domain.ProjectTask, error) {
-	if err := validateAttachments(req.Attachments, a.cfg.Attachment); err != nil {
+	if err := validateAttachments(user.ID, req.Attachments, a.cfg.Attachment, a.cfg.ObjectStorage); err != nil {
+		return nil, err
+	}
+	attachments, err := a.taskAttachmentsToTaskflow(ctx, req.Attachments)
+	if err != nil {
 		return nil, err
 	}
 
@@ -632,7 +646,7 @@ func (a *TaskUsecase) Create(ctx context.Context, user *domain.User, req domain.
 		ID:           t.ID,
 		VMID:         createdVm.ID,
 		Text:         req.Content,
-		Attachments:  taskAttachmentsToTaskflow(req.Attachments),
+		Attachments:  attachments,
 		SystemPrompt: req.SystemPrompt,
 		CodingAgent:  coding,
 		LLM: taskflow.LLM{

--- a/backend/biz/uploader/handler/http/v1/uploader.go
+++ b/backend/biz/uploader/handler/http/v1/uploader.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"net/http"
+	"net/url"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -22,6 +25,7 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/errcode"
 	"github.com/chaitin/MonkeyCode/backend/middleware"
+	"github.com/chaitin/MonkeyCode/backend/pkg/asseturl"
 	"github.com/chaitin/MonkeyCode/backend/pkg/oss"
 )
 
@@ -60,6 +64,7 @@ func NewUploaderHandler(i *do.Injector) (*UploaderHandler, error) {
 	g.Use(auth.Auth(), targetActive.TargetActive())
 	g.POST("", web.BindHandler(h.Upload))
 	g.POST("/presign", web.BindHandler(h.Presign))
+	w.Group(asseturl.Path).GET("", web.BaseHandler(h.Asset), auth.Auth(), targetActive.TargetActive())
 	return h, nil
 }
 
@@ -107,7 +112,7 @@ func (h *UploaderHandler) Upload(c *web.Context, req domain.UploadReq) error {
 		h.logger.With("error", err).ErrorContext(c.Request().Context(), "upload object failed")
 		return err
 	}
-	return c.Success(client.GetURL(prefix, filename))
+	return c.Success(assetAccessURL(prefix, filename))
 }
 
 func (h *UploaderHandler) Presign(c *web.Context, req domain.PresignReq) error {
@@ -127,11 +132,107 @@ func (h *UploaderHandler) Presign(c *web.Context, req domain.PresignReq) error {
 		h.logger.With("error", err).ErrorContext(c.Request().Context(), "presign object failed")
 		return err
 	}
+	presign.UploadURL = uploadURLForRequest(presign.UploadURL, c.Request())
+	presign.AccessURL = assetAccessURL(h.cfg.ObjectStorage.TempPrefix, filename)
 	return c.Success(domain.PresignResp{UploadURL: presign.UploadURL, AccessURL: presign.AccessURL})
+}
+
+func (h *UploaderHandler) Asset(c *web.Context) error {
+	if h == nil || h.client == nil {
+		return errcode.ErrBadRequest.Wrap(fmt.Errorf("object storage is disabled"))
+	}
+	user := middleware.GetUser(c)
+	if user == nil {
+		return errcode.ErrUnauthorized
+	}
+	key, ok := asseturl.Parse(c.Request().URL.String())
+	if !ok {
+		return errcode.ErrBadRequest.Wrap(fmt.Errorf("invalid asset key"))
+	}
+	if !asseturl.AllowedForUser(key, user.ID, h.cfg.ObjectStorage) {
+		return errcode.ErrUnauthorized
+	}
+	rc, err := h.client.GetObject(c.Request().Context(), key)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	contentType := mime.TypeByExtension(path.Ext(key))
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	c.Response().Header().Set("Content-Type", contentType)
+	c.Response().Header().Set("Cache-Control", "private, max-age=3600")
+	_, err = io.Copy(c.Response().Writer, rc)
+	return err
 }
 
 func (h *UploaderHandler) requestClient(r *http.Request) *oss.Client {
 	return h.client.WithAccessEndpoint(h.cfg.ObjectStorage.AccessEndpoint)
+}
+
+func assetAccessURL(prefix, filename string) string {
+	return asseturl.Build(assetObjectKey(prefix, filename))
+}
+
+func assetObjectKey(prefix, filename string) string {
+	cleanPrefix, _ := asseturl.CleanKey(prefix)
+	name := path.Base(strings.Trim(filename, "/"))
+	if name == "." || name == ".." || name == "/" {
+		name = ""
+	}
+	key, _ := asseturl.CleanKey(path.Join(cleanPrefix, name))
+	return key
+}
+
+func uploadURLForRequest(raw string, r *http.Request) string {
+	if requestScheme(r) != "https" {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil || !strings.EqualFold(u.Scheme, "http") {
+		return raw
+	}
+	u.Scheme = "https"
+	return u.String()
+}
+
+func requestScheme(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if proto := firstHeaderValue(r.Header.Get("X-Forwarded-Proto")); proto != "" {
+		return strings.ToLower(proto)
+	}
+	if proto := forwardedProto(r.Header.Get("Forwarded")); proto != "" {
+		return strings.ToLower(proto)
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	if r.URL != nil {
+		return strings.ToLower(r.URL.Scheme)
+	}
+	return ""
+}
+
+func firstHeaderValue(v string) string {
+	if i := strings.Index(v, ","); i >= 0 {
+		v = v[:i]
+	}
+	return strings.TrimSpace(v)
+}
+
+func forwardedProto(v string) string {
+	v = firstHeaderValue(v)
+	for _, part := range strings.Split(v, ";") {
+		key, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+		if !ok || !strings.EqualFold(key, "proto") {
+			continue
+		}
+		return strings.Trim(strings.TrimSpace(value), `"`)
+	}
+	return ""
 }
 
 func (h *UploaderHandler) uploadPrefix(usage consts.UploadUsage) (string, error) {

--- a/backend/biz/uploader/handler/http/v1/uploader_test.go
+++ b/backend/biz/uploader/handler/http/v1/uploader_test.go
@@ -83,3 +83,45 @@ func TestRequestObjectStorageClientUsesConfiguredAccessEndpoint(t *testing.T) {
 		t.Fatalf("url = %q", got)
 	}
 }
+
+func TestRequestObjectStorageClientKeepsConfiguredHTTPAccessEndpoint(t *testing.T) {
+	h := &UploaderHandler{cfg: &config.Config{}}
+	h.cfg.ObjectStorage.AccessEndpoint = "http://monkeycode.example.com/oss"
+	h.cfg.ObjectStorage.Bucket = "monkeycode-private"
+	client, err := oss.NewS3Compatible(context.Background(), config.ObjectStorageConfig{
+		Endpoint:        "http://internal:9000",
+		AccessKey:       "ak",
+		AccessKeySecret: "sk",
+		Bucket:          "monkeycode-private",
+	}, oss.S3Option{ForcePathStyle: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.client = client
+	req := httptest.NewRequest("POST", "http://internal:8888/api/v1/uploader/presign", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	got := h.requestClient(req).GetURL("tmp", "a.txt")
+	if got != "http://monkeycode.example.com/oss/monkeycode-private/tmp/a.txt" {
+		t.Fatalf("url = %q", got)
+	}
+}
+
+func TestUploadURLForRequestUpgradesOnlyBrowserUploadURL(t *testing.T) {
+	req := httptest.NewRequest("POST", "http://internal:8888/api/v1/uploader/presign", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	got := uploadURLForRequest("http://monkeycode.example.com/oss/monkeycode-private/tmp/a.txt?X-Amz-Signature=abc", req)
+	want := "https://monkeycode.example.com/oss/monkeycode-private/tmp/a.txt?X-Amz-Signature=abc"
+	if got != want {
+		t.Fatalf("url = %q", got)
+	}
+}
+
+func TestAssetAccessURLReturnsRelativePath(t *testing.T) {
+	got := assetAccessURL("tmp/task-attachments", "11111111-1111-1111-1111-111111111111_hash.png")
+	want := "/api/v1/assets?key=tmp%2Ftask-attachments%2F11111111-1111-1111-1111-111111111111_hash.png"
+	if got != want {
+		t.Fatalf("url = %q, want %q", got, want)
+	}
+}

--- a/backend/domain/task.go
+++ b/backend/domain/task.go
@@ -117,6 +117,10 @@ type TaskAttachment struct {
 	Filename string `json:"filename"`
 }
 
+type AttachmentURLSigner interface {
+	PresignGet(ctx context.Context, key string, expires time.Duration) (string, error)
+}
+
 // Validate 验证请求参数
 func (r *CreateTaskReq) Validate() error {
 	if r.Resource == nil {

--- a/backend/pkg/asseturl/asseturl.go
+++ b/backend/pkg/asseturl/asseturl.go
@@ -1,0 +1,62 @@
+package asseturl
+
+import (
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/config"
+)
+
+const Path = "/api/v1/assets"
+
+func Build(key string) string {
+	key, ok := CleanKey(key)
+	if !ok {
+		return Path
+	}
+	return Path + "?key=" + url.QueryEscape(key)
+}
+
+func Parse(raw string) (string, bool) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Path != Path {
+		return "", false
+	}
+	return CleanKey(u.Query().Get("key"))
+}
+
+func CleanKey(raw string) (string, bool) {
+	key := strings.Trim(path.Clean(strings.TrimSpace(raw)), "/")
+	if key == "" || key == "." || key == ".." || strings.HasPrefix(key, "../") {
+		return "", false
+	}
+	return key, true
+}
+
+func AllowedForUser(key string, userID uuid.UUID, cfg config.ObjectStorageConfig) bool {
+	key, ok := CleanKey(key)
+	if !ok {
+		return false
+	}
+	if hasPrefix(key, cfg.AvatarPrefix) || hasPrefix(key, cfg.SpecPrefix) || hasPrefix(key, cfg.RepoPrefix) {
+		return true
+	}
+	if !hasPrefix(key, cfg.TempPrefix) {
+		return false
+	}
+	if userID == uuid.Nil {
+		return false
+	}
+	return strings.HasPrefix(path.Base(key), userID.String()+"_")
+}
+
+func hasPrefix(key, prefix string) bool {
+	prefix, ok := CleanKey(prefix)
+	if !ok {
+		return false
+	}
+	return key == prefix || strings.HasPrefix(key, prefix+"/")
+}

--- a/backend/pkg/asseturl/asseturl_test.go
+++ b/backend/pkg/asseturl/asseturl_test.go
@@ -1,0 +1,27 @@
+package asseturl
+
+import "testing"
+
+func TestBuildReturnsRelativeAssetPath(t *testing.T) {
+	got := Build("temp/user_id/a #?.png")
+	want := "/api/v1/assets?key=temp%2Fuser_id%2Fa+%23%3F.png"
+	if got != want {
+		t.Fatalf("Build() = %q, want %q", got, want)
+	}
+}
+
+func TestParseAcceptsRelativeAssetPath(t *testing.T) {
+	got, ok := Parse("/api/v1/assets?key=temp%2Fuser_id%2Fa.png")
+	if !ok {
+		t.Fatal("Parse() ok = false")
+	}
+	if got != "temp/user_id/a.png" {
+		t.Fatalf("key = %q", got)
+	}
+}
+
+func TestParseRejectsUnsafeKey(t *testing.T) {
+	if _, ok := Parse("/api/v1/assets?key=../secret"); ok {
+		t.Fatal("Parse() ok = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary
- 上传预签名响应保留浏览器 PUT 的 HTTPS 升级，避免 HTTPS 页面触发 Mixed Content。
- 将前端展示用 `access_url` 改为相对资产路径，并新增后端资产代理接口从对象存储读取资源。
- 任务附件下发 agent 前会把资产路径转换为 HTTP 预签名 URL，避免自签 HTTPS 证书影响 agent 下载。

## Test Plan
- [x] `GOWORK=off go test ./pkg/asseturl ./pkg/oss ./biz/uploader/handler/http/v1 ./biz/task/usecase`
- [x] `GOWORK=off go test ./...`
