### PR TITLE
refactor: OIDC 自动创建成员委托成员管理

### DIFF
--- a/backend/biz/team/repo/oidc.go
+++ b/backend/biz/team/repo/oidc.go
@@ -11,14 +11,11 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/db/team"
-	"github.com/chaitin/MonkeyCode/backend/db/teamgroupmember"
 	"github.com/chaitin/MonkeyCode/backend/db/teammember"
 	"github.com/chaitin/MonkeyCode/backend/db/teamoidcconfig"
 	"github.com/chaitin/MonkeyCode/backend/db/user"
 	"github.com/chaitin/MonkeyCode/backend/db/useridentity"
 	"github.com/chaitin/MonkeyCode/backend/domain"
-	"github.com/chaitin/MonkeyCode/backend/errcode"
-	"github.com/chaitin/MonkeyCode/backend/pkg/entx"
 	"github.com/chaitin/MonkeyCode/backend/pkg/oidc"
 )
 
@@ -141,73 +138,6 @@ func (r *TeamOIDCRepo) BindOIDCIdentity(ctx context.Context, userID uuid.UUID, e
 		SetEmail(external.Email).
 		SetAvatarURL(external.AvatarURL).
 		Exec(ctx)
-}
-
-func (r *TeamOIDCRepo) AutoCreateMember(ctx context.Context, teamID uuid.UUID, external *domain.OIDCExternalUser) (*db.User, error) {
-	var created *db.User
-	err := entx.WithTx2(ctx, r.db, func(tx *db.Tx) error {
-		tm, err := tx.Team.Get(ctx, teamID)
-		if err != nil {
-			return err
-		}
-		count, err := tx.TeamMember.Query().Where(teammember.TeamIDEQ(teamID)).Count(ctx)
-		if err != nil {
-			return err
-		}
-		if count >= tm.MemberLimit {
-			return errcode.ErrTeamMemberLimitExceeded
-		}
-		email := normalizeEmail(external.Email)
-		u, err := tx.User.Query().Where(user.EmailEQ(email), user.RoleEQ(consts.UserRoleSubAccount)).First(ctx)
-		if err != nil {
-			if !db.IsNotFound(err) {
-				return err
-			}
-			name := external.Name
-			if name == "" {
-				name = external.Username
-			}
-			if name == "" {
-				name = email
-			}
-			u, err = tx.User.Create().
-				SetID(uuid.New()).
-				SetName(name).
-				SetEmail(email).
-				SetAvatarURL(external.AvatarURL).
-				SetRole(consts.UserRoleSubAccount).
-				SetStatus(consts.UserStatusActive).
-				Save(ctx)
-			if err != nil {
-				return err
-			}
-		}
-		exists, err := tx.TeamMember.Query().Where(teammember.TeamIDEQ(teamID), teammember.UserIDEQ(u.ID)).Exist(ctx)
-		if err != nil {
-			return err
-		}
-		if !exists {
-			if _, err := tx.TeamMember.Create().SetID(uuid.New()).SetTeamID(teamID).SetUserID(u.ID).SetRole(consts.TeamMemberRoleUser).Save(ctx); err != nil {
-				return err
-			}
-		}
-		group, err := ensureDefaultTeamGroupTx(ctx, tx, teamID)
-		if err != nil {
-			return err
-		}
-		exists, err = tx.TeamGroupMember.Query().Where(teamgroupmember.GroupIDEQ(group.ID), teamgroupmember.UserIDEQ(u.ID)).Exist(ctx)
-		if err != nil {
-			return err
-		}
-		if !exists {
-			if err := tx.TeamGroupMember.Create().SetID(uuid.New()).SetGroupID(group.ID).SetUserID(u.ID).Exec(ctx); err != nil {
-				return err
-			}
-		}
-		created = u
-		return nil
-	})
-	return created, err
 }
 
 func normalizeEmail(email string) string {

--- a/backend/biz/team/repo/oidc_test.go
+++ b/backend/biz/team/repo/oidc_test.go
@@ -56,65 +56,6 @@ func TestTeamOIDCConfigSchemaPersistsDefaults(t *testing.T) {
 	}
 }
 
-func TestTeamOIDCRepoAutoCreateMemberCreatesDefaultGroup(t *testing.T) {
-	ctx := context.Background()
-	client := enttest.Open(t, "sqlite3", "file:team_oidc_repo?mode=memory&cache=shared&_fk=1")
-	defer client.Close()
-
-	teamID := uuid.New()
-	_, err := client.Team.Create().SetID(teamID).SetName("研发团队").SetMemberLimit(2).Save(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	r := &TeamOIDCRepo{db: client}
-	user, err := r.AutoCreateMember(ctx, teamID, &domain.OIDCExternalUser{
-		Issuer:        "https://id.example.com",
-		Subject:       "sub-1",
-		Email:         "new@example.com",
-		EmailVerified: true,
-		Name:          "新成员",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if user.Email != "new@example.com" {
-		t.Fatalf("email = %q", user.Email)
-	}
-
-	memberCount, err := client.TeamMember.Query().Count(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if memberCount != 1 {
-		t.Fatalf("member count = %d, want 1", memberCount)
-	}
-	groupMemberCount, err := client.TeamGroupMember.Query().Count(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if groupMemberCount != 1 {
-		t.Fatalf("group member count = %d, want 1", groupMemberCount)
-	}
-}
-
-func TestTeamOIDCRepoAutoCreateMemberHonorsLimit(t *testing.T) {
-	ctx := context.Background()
-	client := enttest.Open(t, "sqlite3", "file:team_oidc_repo_limit?mode=memory&cache=shared&_fk=1")
-	defer client.Close()
-
-	teamID := uuid.New()
-	_, err := client.Team.Create().SetID(teamID).SetName("研发团队").SetMemberLimit(0).Save(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	r := &TeamOIDCRepo{db: client}
-	_, err = r.AutoCreateMember(ctx, teamID, &domain.OIDCExternalUser{Email: "new@example.com", Name: "新成员"})
-	if err == nil {
-		t.Fatal("expected member limit error")
-	}
-}
-
 func TestTeamOIDCRepoBindOIDCIdentitySkipsCreateWhenIdentityExists(t *testing.T) {
 	ctx := context.Background()
 	sqlDB, mock, err := sqlmock.New()

--- a/backend/biz/team/usecase/oidc.go
+++ b/backend/biz/team/usecase/oidc.go
@@ -26,11 +26,12 @@ const oidcStatePrefix = "team_oidc_state:"
 const oidcDebugValueMaxLen = 256
 
 type TeamOIDCUsecase struct {
-	repo   domain.TeamOIDCRepo
-	cfg    *config.Config
-	redis  *redis.Client
-	oidc   *oidcpkg.Client
-	logger *slog.Logger
+	repo          domain.TeamOIDCRepo
+	memberManager domain.MemberManager
+	cfg           *config.Config
+	redis         *redis.Client
+	oidc          *oidcpkg.Client
+	logger        *slog.Logger
 }
 
 func NewTeamOIDCUsecase(i *do.Injector) (domain.TeamOIDCUsecase, error) {
@@ -43,11 +44,12 @@ func NewTeamOIDCLoginUsecase(i *do.Injector) (domain.TeamOIDCLoginUsecase, error
 
 func newTeamOIDCUsecase(i *do.Injector) (*TeamOIDCUsecase, error) {
 	return &TeamOIDCUsecase{
-		repo:   do.MustInvoke[domain.TeamOIDCRepo](i),
-		cfg:    do.MustInvoke[*config.Config](i),
-		redis:  do.MustInvoke[*redis.Client](i),
-		oidc:   oidcpkg.NewClient(nil),
-		logger: do.MustInvoke[*slog.Logger](i).With("module", "usecase.team_oidc"),
+		repo:          do.MustInvoke[domain.TeamOIDCRepo](i),
+		memberManager: do.MustInvoke[domain.MemberManager](i),
+		cfg:           do.MustInvoke[*config.Config](i),
+		redis:         do.MustInvoke[*redis.Client](i),
+		oidc:          oidcpkg.NewClient(nil),
+		logger:        do.MustInvoke[*slog.Logger](i).With("module", "usecase.team_oidc"),
 	}, nil
 }
 
@@ -235,6 +237,10 @@ func (u *TeamOIDCUsecase) HandleCallback(ctx context.Context, req *domain.TeamOI
 		return nil, errcode.ErrOIDCEmailDomainDenied
 	}
 
+	return u.resolveUser(ctx, teamID, cfg.AutoCreateMember, external)
+}
+
+func (u *TeamOIDCUsecase) resolveUser(ctx context.Context, teamID uuid.UUID, autoCreate bool, external *domain.OIDCExternalUser) (*domain.User, error) {
 	identityID := oidcpkg.IdentityID(external.Issuer, external.Subject)
 	u.logger.DebugContext(ctx, "oidc callback: identity resolved",
 		"team_id", teamID,
@@ -251,7 +257,7 @@ func (u *TeamOIDCUsecase) HandleCallback(ctx context.Context, req *domain.TeamOI
 		u.logger.DebugContext(ctx, "oidc callback: identity not bound, checking team member",
 			"team_id", teamID,
 			"email", external.Email,
-			"auto_create_member", cfg.AutoCreateMember,
+			"auto_create_member", autoCreate,
 		)
 		member, err := u.repo.FindTeamMemberByEmail(ctx, teamID, external.Email)
 		if err == nil && member.Edges.User != nil {
@@ -261,21 +267,34 @@ func (u *TeamOIDCUsecase) HandleCallback(ctx context.Context, req *domain.TeamOI
 				"user_id", user.ID,
 				"email", external.Email,
 			)
-		} else if db.IsNotFound(err) && cfg.AutoCreateMember {
+		} else if db.IsNotFound(err) && autoCreate {
 			u.logger.DebugContext(ctx, "oidc callback: auto creating team member",
 				"team_id", teamID,
 				"email", external.Email,
 				"name", oidcDisplayName(external),
 			)
-			user, err = u.repo.AutoCreateMember(ctx, teamID, external)
+			if u.memberManager == nil {
+				return nil, errcode.ErrOIDCTeamMemberRequired
+			}
+			created, err := u.memberManager.AutoCreateOIDCMember(ctx, teamID, external)
 			if err != nil {
+				return nil, err
+			}
+			if created == nil {
+				return nil, errcode.ErrOIDCTeamMemberRequired
+			}
+			if created.IsBlocked {
+				return nil, errcode.ErrUserBlocked
+			}
+			if err := u.repo.BindOIDCIdentity(ctx, created.ID, external); err != nil {
 				return nil, err
 			}
 			u.logger.DebugContext(ctx, "oidc callback: auto created team member",
 				"team_id", teamID,
-				"user_id", user.ID,
+				"user_id", created.ID,
 				"email", external.Email,
 			)
+			return created, nil
 		} else if db.IsNotFound(err) {
 			u.logger.DebugContext(ctx, "oidc callback: team member required",
 				"team_id", teamID,

--- a/backend/biz/team/usecase/oidc_test.go
+++ b/backend/biz/team/usecase/oidc_test.go
@@ -3,15 +3,19 @@ package usecase
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 
 	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/domain"
 )
+
+var ctx = context.Background()
 
 func TestOIDCEmailDomainAllowed(t *testing.T) {
 	if !oidcEmailDomainAllowed("alice@example.com", "example.com") {
@@ -137,4 +141,130 @@ func (s *defaultOIDCRepoStub) GetDefaultEnabledConfig(ctx context.Context) (*db.
 		return nil, errors.New("unexpected empty config")
 	}
 	return s.cfg, nil
+}
+
+type oidcResolveRepoStub struct {
+	domain.TeamOIDCRepo
+	userByIdentity *db.User
+	memberByEmail  *db.TeamMember
+}
+
+func (s *oidcResolveRepoStub) FindUserByOIDCIdentity(ctx context.Context, identityID string) (*db.User, error) {
+	if s.userByIdentity != nil {
+		return s.userByIdentity, nil
+	}
+	return nil, &db.NotFoundError{}
+}
+
+func (s *oidcResolveRepoStub) FindTeamMemberByEmail(ctx context.Context, teamID uuid.UUID, email string) (*db.TeamMember, error) {
+	if s.memberByEmail != nil {
+		return s.memberByEmail, nil
+	}
+	return nil, &db.NotFoundError{}
+}
+
+func (s *oidcResolveRepoStub) BindOIDCIdentity(ctx context.Context, userID uuid.UUID, external *domain.OIDCExternalUser) error {
+	return nil
+}
+
+type oidcMemberManagerStub struct {
+	domain.MemberManager
+	called   bool
+	teamID   uuid.UUID
+	external *domain.OIDCExternalUser
+	user     *domain.User
+	err      error
+}
+
+func (s *oidcMemberManagerStub) AutoCreateOIDCMember(ctx context.Context, teamID uuid.UUID, external *domain.OIDCExternalUser) (*domain.User, error) {
+	s.called = true
+	s.teamID = teamID
+	s.external = external
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.user, nil
+}
+
+func TestTeamOIDCUsecaseResolveUserAutoCreateUsesMemberManager(t *testing.T) {
+	teamID := uuid.New()
+	createdUserID := uuid.New()
+	external := &domain.OIDCExternalUser{
+		Issuer:        "https://id.example.com",
+		Subject:       "sub-1",
+		Email:         "new@example.com",
+		EmailVerified: true,
+		Name:          "新成员",
+	}
+	manager := &oidcMemberManagerStub{
+		user: &domain.User{
+			ID:     createdUserID,
+			Email:  "new@example.com",
+			Name:   "新成员",
+			Status: consts.UserStatusActive,
+		},
+	}
+	u := &TeamOIDCUsecase{
+		repo:          &oidcResolveRepoStub{},
+		memberManager: manager,
+		logger:        slog.Default(),
+	}
+
+	got, err := u.resolveUser(ctx, teamID, true, external)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != createdUserID {
+		t.Fatalf("user id = %s, want %s", got.ID, createdUserID)
+	}
+	if !manager.called {
+		t.Fatal("expected MemberManager.AutoCreateOIDCMember to be called")
+	}
+	if manager.teamID != teamID {
+		t.Fatalf("team id = %s, want %s", manager.teamID, teamID)
+	}
+	if manager.external != external {
+		t.Fatal("external user should be passed through")
+	}
+}
+
+func TestTeamOIDCUsecaseResolveUserExistingMemberSkipsAutoCreate(t *testing.T) {
+	teamID := uuid.New()
+	userID := uuid.New()
+	external := &domain.OIDCExternalUser{
+		Issuer:        "https://id.example.com",
+		Subject:       "sub-1",
+		Email:         "member@example.com",
+		EmailVerified: true,
+		Name:          "已有成员",
+	}
+	manager := &oidcMemberManagerStub{}
+	u := &TeamOIDCUsecase{
+		repo: &oidcResolveRepoStub{
+			memberByEmail: &db.TeamMember{
+				UserID: userID,
+				Edges: db.TeamMemberEdges{
+					User: &db.User{
+						ID:     userID,
+						Email:  "member@example.com",
+						Name:   "已有成员",
+						Status: consts.UserStatusActive,
+					},
+				},
+			},
+		},
+		memberManager: manager,
+		logger:        slog.Default(),
+	}
+
+	got, err := u.resolveUser(ctx, teamID, true, external)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != userID {
+		t.Fatalf("user id = %s, want %s", got.ID, userID)
+	}
+	if manager.called {
+		t.Fatal("auto create should not be called for existing team member")
+	}
 }

--- a/backend/domain/team.go
+++ b/backend/domain/team.go
@@ -17,6 +17,7 @@ type MemberManager interface {
 	AddUser(ctx context.Context, teamUser *TeamUser, req *AddTeamUserReq) (*AddTeamUserResp, error)
 	AddUserWithPassword(ctx context.Context, teamUser *TeamUser, req *AddTeamUserReq) (*AddTeamUserWithPasswordResp, error)
 	AddAdmin(ctx context.Context, teamUser *TeamUser, req *AddTeamAdminReq) (*AddTeamAdminResp, error)
+	AutoCreateOIDCMember(ctx context.Context, teamID uuid.UUID, external *OIDCExternalUser) (*User, error)
 }
 
 // TeamGroupUserUsecase 团队分组成员业务逻辑接口

--- a/backend/domain/team_oidc.go
+++ b/backend/domain/team_oidc.go
@@ -29,7 +29,6 @@ type TeamOIDCRepo interface {
 	FindUserByOIDCIdentity(ctx context.Context, identityID string) (*db.User, error)
 	FindTeamMemberByEmail(ctx context.Context, teamID uuid.UUID, email string) (*db.TeamMember, error)
 	BindOIDCIdentity(ctx context.Context, userID uuid.UUID, external *OIDCExternalUser) error
-	AutoCreateMember(ctx context.Context, teamID uuid.UUID, external *OIDCExternalUser) (*db.User, error)
 }
 
 type TeamOIDCConfig struct {


### PR DESCRIPTION
## 变更内容
- 扩展 MemberManager，新增 OIDC 自动创建成员能力。
- OIDC 回调自动创建成员改为调用 MemberManager，不再由 TeamOIDCRepo 创建成员。
- 删除 OIDC repo 层自动创建成员实现和旧测试，补充 usecase 测试覆盖新委托路径。

## 验证
- GOWORK=off go test ./domain ./biz/team/usecase ./biz/team/repo -count=1

## 说明
- 成员数/license 限制由各产品自己的 MemberManager 实现封装，OIDC 模块不直接感知限制来源。