### PR TITLE
refactor: 清理附件对象存储注入

### DIFF
--- a/backend/biz/task/usecase/attachment.go
+++ b/backend/biz/task/usecase/attachment.go
@@ -73,10 +73,10 @@ func (a *TaskUsecase) taskAttachmentsToTaskflow(ctx context.Context, attachments
 	for _, attachment := range attachments {
 		raw := strings.TrimSpace(attachment.URL)
 		if key, ok := asseturl.Parse(raw); ok {
-			if a == nil || a.cfg == nil || !a.cfg.ObjectStorage.Enabled || a.attachmentSigner == nil {
+			if a == nil || a.cfg == nil || !a.cfg.ObjectStorage.Enabled || a.objectStore == nil {
 				return nil, errcode.ErrBadRequest.Wrap(fmt.Errorf("object storage is disabled"))
 			}
-			u, err := a.attachmentSigner.PresignGet(ctx, key, attachmentPresignExpires(a.cfg))
+			u, err := a.objectStore.PresignGet(ctx, key, attachmentPresignExpires(a.cfg))
 			if err != nil {
 				return nil, err
 			}

--- a/backend/biz/task/usecase/attachment_test.go
+++ b/backend/biz/task/usecase/attachment_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"fmt"
+	"io"
 	"testing"
 	"time"
 
@@ -92,10 +93,10 @@ func TestValidateAttachmentsRejectsBadInputs(t *testing.T) {
 }
 
 func TestTaskAttachmentsToTaskflowConvertsAssetURLToHTTPPresignURL(t *testing.T) {
-	signer := &fakeAttachmentSigner{}
+	store := &fakeObjectStore{}
 	u := &TaskUsecase{
-		cfg:              &config.Config{},
-		attachmentSigner: signer,
+		cfg:         &config.Config{},
+		objectStore: store,
 	}
 	u.cfg.ObjectStorage.Enabled = true
 	got, err := u.taskAttachmentsToTaskflow(context.Background(), []domain.TaskAttachment{
@@ -111,14 +112,14 @@ func TestTaskAttachmentsToTaskflowConvertsAssetURLToHTTPPresignURL(t *testing.T)
 	if got[0].URL != wantURL {
 		t.Fatalf("url = %q, want %q", got[0].URL, wantURL)
 	}
-	if signer.key != "tmp/task-attachments/11111111-1111-1111-1111-111111111111_hash.png" {
-		t.Fatalf("key = %q", signer.key)
+	if store.key != "tmp/task-attachments/11111111-1111-1111-1111-111111111111_hash.png" {
+		t.Fatalf("key = %q", store.key)
 	}
 }
 
 func TestTaskAttachmentsToTaskflowKeepsExternalURL(t *testing.T) {
-	signer := &fakeAttachmentSigner{}
-	u := &TaskUsecase{attachmentSigner: signer}
+	store := &fakeObjectStore{}
+	u := &TaskUsecase{objectStore: store}
 	got, err := u.taskAttachmentsToTaskflow(context.Background(), []domain.TaskAttachment{
 		{URL: "https://oss.example.com/temp/a.txt", Filename: "a.txt"},
 	})
@@ -128,13 +129,13 @@ func TestTaskAttachmentsToTaskflowKeepsExternalURL(t *testing.T) {
 	if got[0].URL != "https://oss.example.com/temp/a.txt" {
 		t.Fatalf("url = %q", got[0].URL)
 	}
-	if signer.key != "" {
-		t.Fatalf("signer called for http url: %q", signer.key)
+	if store.key != "" {
+		t.Fatalf("store called for http url: %q", store.key)
 	}
 }
 
 func TestTaskAttachmentsToTaskflowRejectsAssetURLWhenObjectStorageDisabled(t *testing.T) {
-	u := &TaskUsecase{attachmentSigner: &fakeAttachmentSigner{}}
+	u := &TaskUsecase{objectStore: &fakeObjectStore{}}
 	_, err := u.taskAttachmentsToTaskflow(context.Background(), []domain.TaskAttachment{
 		{URL: asseturl.Build("tmp/task-attachments/11111111-1111-1111-1111-111111111111_hash.png"), Filename: "a.png"},
 	})
@@ -143,13 +144,21 @@ func TestTaskAttachmentsToTaskflowRejectsAssetURLWhenObjectStorageDisabled(t *te
 	}
 }
 
-type fakeAttachmentSigner struct {
+type fakeObjectStore struct {
 	key     string
 	expires time.Duration
 }
 
-func (f *fakeAttachmentSigner) PresignGet(_ context.Context, key string, expires time.Duration) (string, error) {
+func (f *fakeObjectStore) GetObject(context.Context, string) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeObjectStore) PresignGet(_ context.Context, key string, expires time.Duration) (string, error) {
 	f.key = key
 	f.expires = expires
 	return fmt.Sprintf("http://agent.local/%s", key), nil
+}
+
+func (f *fakeObjectStore) PutFile(context.Context, string, string, io.Reader) error {
+	return fmt.Errorf("not implemented")
 }

--- a/backend/biz/task/usecase/task.go
+++ b/backend/biz/task/usecase/task.go
@@ -63,7 +63,7 @@ type TaskUsecase struct {
 	idleRefresher         vmidle.VMIdleRefresher
 	dbClient              *db.Client
 	resolver              agentresource.ResolverInterface
-	attachmentSigner      domain.AttachmentURLSigner
+	objectStore           agentresource.ObjectStore
 }
 
 // NewTaskUsecase 创建任务业务逻辑实例
@@ -92,10 +92,8 @@ func NewTaskUsecase(i *do.Injector) (domain.TaskUsecase, error) {
 		u.resolver = r
 	}
 
-	if signer, err := do.Invoke[domain.AttachmentURLSigner](i); err == nil {
-		u.attachmentSigner = signer
-	} else if store, err := do.Invoke[agentresource.ObjectStore](i); err == nil {
-		u.attachmentSigner = store
+	if store, err := do.Invoke[agentresource.ObjectStore](i); err == nil {
+		u.objectStore = store
 	}
 
 	// 可选注入 TaskHook

--- a/backend/domain/task.go
+++ b/backend/domain/task.go
@@ -117,10 +117,6 @@ type TaskAttachment struct {
 	Filename string `json:"filename"`
 }
 
-type AttachmentURLSigner interface {
-	PresignGet(ctx context.Context, key string, expires time.Duration) (string, error)
-}
-
 // Validate 验证请求参数
 func (r *CreateTaskReq) Validate() error {
 	if r.Resource == nil {


### PR DESCRIPTION
## Summary
- 移除独立的 AttachmentURLSigner 抽象
- TaskUsecase 直接复用现有 agentresource.ObjectStore 做相对附件路径签名
- 保持 http/https 附件原样透传，相对路径仅在 object_storage.enabled=true 时签名

## Test Plan
- [x] GOWORK=off go test ./pkg/asseturl ./pkg/oss ./biz/agentresource ./biz/uploader/handler/http/v1 ./biz/task/usecase
- [x] GOWORK=off go test ./...

## Notes
- 原 PR #748 已合并，本 PR 仅做后续代码清理
- 未改动 monkeycode-ai