### PR TITLE
fix: 拒绝无用户 ID 的宿主机安装令牌

### DIFF
--- a/backend/biz/host/handler/v1/internal.go
+++ b/backend/biz/host/handler/v1/internal.go
@@ -334,6 +334,9 @@ return nil
 				h.logger.With("error", uerr).ErrorContext(ctx, "failed to unmarshal user from redis token")
 				return nil, uerr
 			}
+			if u.ID == uuid.Nil {
+				return nil, fmt.Errorf("invalid host install token user")
+			}
 			h.logger.With("user_id", u.ID).DebugContext(ctx, "get result from redis by lua")
 
 			typeUser := &taskflow.TokenUser{

--- a/backend/biz/host/handler/v1/internal_auth_test.go
+++ b/backend/biz/host/handler/v1/internal_auth_test.go
@@ -175,6 +175,26 @@ func TestCheckTokenLogsMissingAgentVMBelowError(t *testing.T) {
 	}
 }
 
+func TestHostAuthRejectsInstallTokenWithoutUserID(t *testing.T) {
+	rdb := newTestRedis(t)
+	ctx := context.Background()
+	token := "install-token-without-user"
+	if err := rdb.Set(ctx, "host:token:"+token, `{"token":"`+token+`"}`, time.Minute).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	h := &InternalHostHandler{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		redis:  rdb,
+		repo:   &internalHostRepoStub{},
+	}
+
+	_, err := h.hostAuth(ctx, token, "")
+	if err == nil {
+		t.Fatal("host auth error is nil")
+	}
+}
+
 type internalHostRepoStub struct {
 	vm               *db.VirtualMachine
 	accessTokenVM    *db.VirtualMachine


### PR DESCRIPTION
## 变更内容
- 主站消费宿主机安装 token 时校验用户 ID
- 拒绝零 UUID，避免畸形 token 继续写入 hosts.user_id
- 增加 hostAuth 回归测试

## 验证
- GOWORK=off go test ./biz/host/... -count=1