### PR TITLE
后端通知文案按区域输出

### DIFF
--- a/backend/biz/notify/handler/v1/notify.go
+++ b/backend/biz/notify/handler/v1/notify.go
@@ -14,8 +14,9 @@ import (
 
 // NotifyHandler 通知渠道管理 HTTP 处理器
 type NotifyHandler struct {
-	channelUsecase domain.NotifyChannelUsecase
-	logger         *slog.Logger
+	channelUsecase       domain.NotifyChannelUsecase
+	serverConfigProvider domain.ServerConfigProvider
+	logger               *slog.Logger
 }
 
 // NewNotifyHandler 创建通知处理器并注册路由
@@ -24,9 +25,11 @@ func NewNotifyHandler(i *do.Injector) (*NotifyHandler, error) {
 	auth := do.MustInvoke[*middleware.AuthMiddleware](i)
 	targetActive := do.MustInvoke[*middleware.TargetActiveMiddleware](i)
 
+	provider, _ := do.Invoke[domain.ServerConfigProvider](i)
 	h := &NotifyHandler{
-		channelUsecase: do.MustInvoke[domain.NotifyChannelUsecase](i),
-		logger:         do.MustInvoke[*slog.Logger](i).With("module", "handler.notify"),
+		channelUsecase:       do.MustInvoke[domain.NotifyChannelUsecase](i),
+		serverConfigProvider: provider,
+		logger:               do.MustInvoke[*slog.Logger](i).With("module", "handler.notify"),
 	}
 
 	// 用户接口
@@ -293,7 +296,7 @@ func (h *NotifyHandler) TestTeamChannel(c *web.Context, req domain.IDReq[uuid.UU
 //	@Router			/api/v1/users/notify/event-types [get]
 func (h *NotifyHandler) ListEventTypes(c *web.Context, _ struct{}) error {
 	_placeholder()
-	return c.Success(consts.AllNotifyEventTypes)
+	return c.Success(h.eventTypes(c))
 }
 
 // ListEventTypes 列出所有支持的事件类型
@@ -309,3 +312,15 @@ func (h *NotifyHandler) ListEventTypes(c *web.Context, _ struct{}) error {
 //	@Failure		500	{object}	web.Resp									"服务器内部错误"
 //	@Router			/api/v1/teams/notify/event-types [get]
 func _placeholder() {}
+
+func (h *NotifyHandler) eventTypes(c *web.Context) []consts.NotifyEventTypeInfo {
+	if h.serverConfigProvider == nil {
+		return consts.NotifyEventTypesForRegion("")
+	}
+	info, err := h.serverConfigProvider.GetServerConfig(c.Request().Context())
+	if err != nil {
+		h.logger.WarnContext(c.Request().Context(), "failed to get server config for notify event labels", "error", err)
+		return consts.NotifyEventTypesForRegion("")
+	}
+	return consts.NotifyEventTypesForRegion(string(info.Region))
+}

--- a/backend/consts/notify.go
+++ b/backend/consts/notify.go
@@ -31,6 +31,30 @@ var AllNotifyEventTypes = []NotifyEventTypeInfo{
 	{Type: NotifyEventQuotaUltraExhausted, Name: "今日旗舰模型额度已耗尽", Description: "旗舰模型当日免费额度耗尽提醒"},
 }
 
+var globalNotifyEventTypes = []NotifyEventTypeInfo{
+	{Type: NotifyEventTaskCreated, Name: "Create task", Description: "New task created"},
+	{Type: NotifyEventTaskEnded, Name: "Conversation completed", Description: "A conversation round in the task has completed"},
+	{Type: NotifyEventVMExpiringSoon, Name: "Development environment expiring soon", Description: "Development environment expiration reminder"},
+	{Type: NotifyEventQuotaRefreshed, Name: "Member free quota refreshed", Description: "Daily free quota refresh reminder for members"},
+	{Type: NotifyEventQuotaBasicExhausted, Name: "Basic model quota exhausted today", Description: "Daily free quota exhaustion reminder for Basic models"},
+	{Type: NotifyEventQuotaProExhausted, Name: "Pro model quota exhausted today", Description: "Daily free quota exhaustion reminder for Pro models"},
+	{Type: NotifyEventQuotaUltraExhausted, Name: "Ultra model quota exhausted today", Description: "Daily free quota exhaustion reminder for Ultra models"},
+}
+
+// NotifyEventTypesForRegion 返回指定产品区域的通知事件展示文案。
+func NotifyEventTypesForRegion(region string) []NotifyEventTypeInfo {
+	if region == "global" {
+		return cloneNotifyEventTypes(globalNotifyEventTypes)
+	}
+	return cloneNotifyEventTypes(AllNotifyEventTypes)
+}
+
+func cloneNotifyEventTypes(src []NotifyEventTypeInfo) []NotifyEventTypeInfo {
+	out := make([]NotifyEventTypeInfo, len(src))
+	copy(out, src)
+	return out
+}
+
 // WechatMPFixedNotifyEventTypes 是微信公众号渠道固定接收的事件集合。
 var WechatMPFixedNotifyEventTypes = []NotifyEventType{
 	NotifyEventVMExpiringSoon,

--- a/backend/consts/notify_test.go
+++ b/backend/consts/notify_test.go
@@ -1,0 +1,30 @@
+package consts
+
+import "testing"
+
+func TestNotifyEventTypesForRegion(t *testing.T) {
+	cnEvents := NotifyEventTypesForRegion("cn")
+	if got := cnEvents[0].Name; got != "创建任务" {
+		t.Fatalf("cn first event name = %q, want 创建任务", got)
+	}
+	if got := cnEvents[4].Name; got != "今日基础模型额度已耗尽" {
+		t.Fatalf("cn quota event name = %q, want 今日基础模型额度已耗尽", got)
+	}
+
+	globalEvents := NotifyEventTypesForRegion("global")
+	if got := globalEvents[0].Name; got != "Create task" {
+		t.Fatalf("global first event name = %q, want Create task", got)
+	}
+	if got := globalEvents[4].Name; got != "Basic model quota exhausted today" {
+		t.Fatalf("global quota event name = %q, want Basic model quota exhausted today", got)
+	}
+}
+
+func TestNotifyEventTypesForRegionReturnsCopy(t *testing.T) {
+	events := NotifyEventTypesForRegion("global")
+	events[0].Name = "changed"
+
+	if got := NotifyEventTypesForRegion("global")[0].Name; got != "Create task" {
+		t.Fatalf("global event name after mutation = %q, want Create task", got)
+	}
+}


### PR DESCRIPTION
## 变更
- 通知事件类型增加国内中文、海外英文两套展示文案
- 事件类型接口按 server config 的 region 返回对应文案
- 保持事件 type 枚举不变，并返回 slice 副本避免外部修改全局表

## 验证
- go test ./consts ./biz/notify/handler/v1