### PR TITLE
fix: GitHub PAT 模式下仓库列表总数为 0

### DIFF
--- a/backend/pkg/git/github/github.go
+++ b/backend/pkg/git/github/github.go
@@ -325,11 +325,17 @@ func (g *Github) listUserReposPage(ctx context.Context, client *github.Client, p
 			Description: r.GetDescription(),
 		})
 	}
+	var totalCount int64
+	if resp.NextPage == 0 {
+		totalCount = int64((page-1)*size + len(repos))
+	} else if resp.LastPage > 0 {
+		totalCount = int64(resp.LastPage) * int64(size)
+	}
+
 	return &domain.RepositoryPage{
 		Repositories: items,
 		PageInfo: &web.PageInfo{
-			// GitHub /user/repos 不返回总数，前端以 has_next_page 翻页
-			TotalCount:  0,
+			TotalCount:  totalCount,
 			HasNextPage: resp.NextPage != 0,
 		},
 	}, nil


### PR DESCRIPTION
/user/repos 不像 /installation/repositories 那样返回 total_count， 改为从响应 Link 头的 LastPage 推算总数。