### PR TITLE
修复虚拟机空闲回收误判

### DIFF
--- a/backend/biz/host/repo/host.go
+++ b/backend/biz/host/repo/host.go
@@ -21,6 +21,7 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/db/model"
 	"github.com/chaitin/MonkeyCode/backend/db/predicate"
 	"github.com/chaitin/MonkeyCode/backend/db/projecttask"
+	"github.com/chaitin/MonkeyCode/backend/db/task"
 	"github.com/chaitin/MonkeyCode/backend/db/taskvirtualmachine"
 	"github.com/chaitin/MonkeyCode/backend/db/teamgroup"
 	"github.com/chaitin/MonkeyCode/backend/db/user"
@@ -610,6 +611,7 @@ func (h *HostRepo) CompleteCreateVirtualMachine(ctx context.Context, id string, 
 func (h *HostRepo) DeleteVirtualMachine(ctx context.Context, uid uuid.UUID, hostID, id string, fn func(*db.VirtualMachine) error) error {
 	return entx.WithTx2(ctx, h.db, func(tx *db.Tx) error {
 		vm, err := tx.VirtualMachine.Query().
+			WithTasks().
 			Where(virtualmachine.ID(id)).
 			Where(virtualmachine.UserID(uid)).
 			First(ctx)
@@ -625,6 +627,27 @@ func (h *HostRepo) DeleteVirtualMachine(ctx context.Context, uid uuid.UUID, host
 			SetIsRecycled(true).
 			Exec(ctx); err != nil {
 			return err
+		}
+
+		taskIDs := make([]uuid.UUID, 0, len(vm.Edges.Tasks))
+		for _, tk := range vm.Edges.Tasks {
+			if tk == nil {
+				continue
+			}
+			taskIDs = append(taskIDs, tk.ID)
+		}
+		if len(taskIDs) > 0 {
+			_, err := tx.Task.Update().
+				Where(
+					task.IDIn(taskIDs...),
+					task.StatusNotIn(consts.TaskStatusFinished, consts.TaskStatusError),
+				).
+				SetStatus(consts.TaskStatusFinished).
+				SetCompletedAt(time.Now()).
+				Save(ctx)
+			if err != nil {
+				return err
+			}
 		}
 
 		_, err = tx.VirtualMachine.Delete().Where(virtualmachine.ID(id)).Exec(ctx)

--- a/backend/biz/host/usecase/host.go
+++ b/backend/biz/host/usecase/host.go
@@ -533,7 +533,7 @@ func (h *HostUsecase) CreateVM(ctx context.Context, user *domain.User, req *doma
 
 // DeleteVM 删除虚拟机
 func (h *HostUsecase) DeleteVM(ctx context.Context, uid uuid.UUID, hostID, vmID string) error {
-	h.logger.InfoContext(ctx, "delete vm", "vmID", vmID)
+	h.logger.InfoContext(ctx, "delete vm", "vmID", vmID, "user_id", uid, "host_id", hostID)
 	return h.repo.DeleteVirtualMachine(ctx, uid, hostID, vmID, func(vm *db.VirtualMachine) error {
 		if err := h.taskflow.VirtualMachiner().Delete(ctx, &taskflow.DeleteVirtualMachineReq{
 			UserID: uid.String(),

--- a/backend/biz/host/usecase/host_test.go
+++ b/backend/biz/host/usecase/host_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/db/enttest"
 	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/pkg/delayqueue"
 	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
 )
 
@@ -334,6 +335,97 @@ func TestHostUsecase_markRecycledTasksFinished(t *testing.T) {
 
 	if len(taskRepo.updatedIDs) != 1 || taskRepo.updatedIDs[0] != processingTask.ID {
 		t.Fatalf("updated task ids = %v, want only %s", taskRepo.updatedIDs, processingTask.ID)
+	}
+}
+
+func TestHostUsecase_DeleteVMFinishesBoundTasks(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:host-usecase-delete-vm-finish-task-test?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	userID := uuid.New()
+	if _, err := client.User.Create().
+		SetID(userID).
+		SetName("tester").
+		SetRole(consts.UserRoleIndividual).
+		SetStatus(consts.UserStatusActive).
+		Save(ctx); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	hostID := "host-1"
+	if _, err := client.Host.Create().
+		SetID(hostID).
+		SetUserID(userID).
+		SetHostname("host").
+		Save(ctx); err != nil {
+		t.Fatalf("create host: %v", err)
+	}
+
+	vmID := "vm-1"
+	if _, err := client.VirtualMachine.Create().
+		SetID(vmID).
+		SetHostID(hostID).
+		SetUserID(userID).
+		SetName("vm").
+		SetEnvironmentID("env-1").
+		Save(ctx); err != nil {
+		t.Fatalf("create vm: %v", err)
+	}
+
+	taskID := uuid.New()
+	if _, err := client.Task.Create().
+		SetID(taskID).
+		SetUserID(userID).
+		SetKind(consts.TaskTypeDevelop).
+		SetContent("content").
+		SetStatus(consts.TaskStatusProcessing).
+		Save(ctx); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := client.TaskVirtualMachine.Create().
+		SetID(uuid.New()).
+		SetTaskID(taskID).
+		SetVirtualmachineID(vmID).
+		Save(ctx); err != nil {
+		t.Fatalf("bind task vm: %v", err)
+	}
+
+	i := do.New()
+	do.ProvideValue(i, client)
+	redisServer := miniredis.RunT(t)
+	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	t.Cleanup(func() { _ = redisClient.Close() })
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	do.ProvideValue(i, &config.Config{})
+	do.ProvideValue(i, logger)
+	do.ProvideValue(i, redisClient)
+	hostRepo, err := repo.NewHostRepo(i)
+	if err != nil {
+		t.Fatalf("new host repo: %v", err)
+	}
+	u := &HostUsecase{
+		repo:          hostRepo,
+		taskflow:      &preinsertTaskflowStub{vm: &preinsertVMCreateStub{db: client}},
+		logger:        logger,
+		vmexpireQueue: delayqueue.NewVMExpireQueue(redisClient, logger),
+	}
+
+	if err := u.DeleteVM(ctx, userID, hostID, vmID); err != nil {
+		t.Fatalf("DeleteVM() error = %v", err)
+	}
+
+	gotTask, err := client.Task.Get(ctx, taskID)
+	if err != nil {
+		t.Fatalf("query task: %v", err)
+	}
+	if gotTask.Status != consts.TaskStatusFinished {
+		t.Fatalf("task status = %s, want %s", gotTask.Status, consts.TaskStatusFinished)
+	}
+	if gotTask.CompletedAt.IsZero() {
+		t.Fatal("expected task completed_at to be set")
 	}
 }
 

--- a/backend/biz/vmidle/usecase/policy_test.go
+++ b/backend/biz/vmidle/usecase/policy_test.go
@@ -14,10 +14,12 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/db/enttest"
 	"github.com/chaitin/MonkeyCode/backend/db/virtualmachine"
 	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/pkg/delayqueue"
 	"github.com/chaitin/MonkeyCode/backend/pkg/taskflow"
 )
 
@@ -107,6 +109,64 @@ func TestRefreshCachesNotFoundVM(t *testing.T) {
 	}
 }
 
+func TestShouldSkipRecycleForRecentTaskLogRefreshesVM(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 7, 10, 34, 38, 0, time.UTC)
+	taskID := uuid.New()
+	vm := &db.VirtualMachine{ID: "vm-recent-log", UserID: uuid.New()}
+	vm.Edges.Tasks = []*db.Task{{ID: taskID, Status: consts.TaskStatusProcessing}}
+	redisClient := newTestRedis(t)
+	logger := slog.Default()
+	repo := &refreshHostRepoStub{vm: vm}
+	r := &vmIdleRefresher{
+		cfg:             &config.Config{VMIdle: config.VMIdle{SleepSeconds: 600, RecycleSeconds: 3600}},
+		redis:           redisClient,
+		logger:          logger,
+		hostRepo:        repo,
+		taskLogActivity: &taskLogActivityStub{latest: map[uuid.UUID]time.Time{taskID: now.Add(-time.Minute)}},
+		sleepQueue:      delayqueue.NewVMSleepQueue(redisClient, logger),
+		notifyQueue:     delayqueue.NewVMNotifyQueue(redisClient, logger),
+		recycleQueue:    delayqueue.NewVMRecycleQueue(redisClient, logger),
+	}
+
+	skip, err := r.shouldSkipRecycleForRecentTaskLog(ctx, vm, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !skip {
+		t.Fatal("expected recent task log to skip recycle")
+	}
+	if repo.getVirtualMachineCalls != 1 {
+		t.Fatalf("GetVirtualMachine calls = %d, want 1", repo.getVirtualMachineCalls)
+	}
+}
+
+func TestShouldSkipRecycleForRecentTaskLogAllowsStaleVM(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 7, 10, 34, 38, 0, time.UTC)
+	taskID := uuid.New()
+	vm := &db.VirtualMachine{ID: "vm-stale-log", UserID: uuid.New()}
+	vm.Edges.Tasks = []*db.Task{{ID: taskID, Status: consts.TaskStatusProcessing}}
+	repo := &refreshHostRepoStub{vm: vm}
+	r := &vmIdleRefresher{
+		cfg:             &config.Config{VMIdle: config.VMIdle{SleepSeconds: 600, RecycleSeconds: 3600}},
+		logger:          slog.Default(),
+		hostRepo:        repo,
+		taskLogActivity: &taskLogActivityStub{latest: map[uuid.UUID]time.Time{taskID: now.Add(-2 * time.Hour)}},
+	}
+
+	skip, err := r.shouldSkipRecycleForRecentTaskLog(ctx, vm, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if skip {
+		t.Fatal("expected stale task log to allow recycle")
+	}
+	if repo.getVirtualMachineCalls != 0 {
+		t.Fatalf("GetVirtualMachine calls = %d, want 0", repo.getVirtualMachineCalls)
+	}
+}
+
 func newTestRedis(t *testing.T) *redis.Client {
 	t.Helper()
 	srv := miniredis.RunT(t)
@@ -137,6 +197,19 @@ type refreshHostRepoStub struct {
 	vm                     *db.VirtualMachine
 	err                    error
 	getVirtualMachineCalls int
+}
+
+type taskLogActivityStub struct {
+	latest map[uuid.UUID]time.Time
+	err    error
+}
+
+func (s *taskLogActivityStub) LatestTaskLogTime(_ context.Context, taskID uuid.UUID) (time.Time, bool, error) {
+	if s.err != nil {
+		return time.Time{}, false, s.err
+	}
+	latest, ok := s.latest[taskID]
+	return latest, ok, nil
 }
 
 func (s *refreshHostRepoStub) List(context.Context, uuid.UUID) ([]*db.Host, error) {

--- a/backend/biz/vmidle/usecase/policy_test.go
+++ b/backend/biz/vmidle/usecase/policy_test.go
@@ -109,6 +109,46 @@ func TestRefreshCachesNotFoundVM(t *testing.T) {
 	}
 }
 
+func TestShouldSkipRecycleForRecentTaskLastActiveAtSkipsClickHouse(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 7, 10, 34, 38, 0, time.UTC)
+	taskID := uuid.New()
+	vm := &db.VirtualMachine{ID: "vm-recent-pg-activity", UserID: uuid.New()}
+	vm.Edges.Tasks = []*db.Task{{
+		ID:           taskID,
+		Status:       consts.TaskStatusProcessing,
+		LastActiveAt: now.Add(-time.Minute),
+	}}
+	redisClient := newTestRedis(t)
+	logger := slog.Default()
+	repo := &refreshHostRepoStub{vm: vm}
+	activity := &taskLogActivityStub{err: errors.New("unexpected clickhouse query")}
+	r := &vmIdleRefresher{
+		cfg:             &config.Config{VMIdle: config.VMIdle{SleepSeconds: 600, RecycleSeconds: 3600}},
+		redis:           redisClient,
+		logger:          logger,
+		hostRepo:        repo,
+		taskLogActivity: activity,
+		sleepQueue:      delayqueue.NewVMSleepQueue(redisClient, logger),
+		notifyQueue:     delayqueue.NewVMNotifyQueue(redisClient, logger),
+		recycleQueue:    delayqueue.NewVMRecycleQueue(redisClient, logger),
+	}
+
+	skip, err := r.shouldSkipRecycleForRecentActivity(ctx, vm, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !skip {
+		t.Fatal("expected recent task last_active_at to skip recycle")
+	}
+	if activity.calls != 0 {
+		t.Fatalf("clickhouse calls = %d, want 0", activity.calls)
+	}
+	if repo.getVirtualMachineCalls != 1 {
+		t.Fatalf("GetVirtualMachine calls = %d, want 1", repo.getVirtualMachineCalls)
+	}
+}
+
 func TestShouldSkipRecycleForRecentTaskLogRefreshesVM(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 7, 7, 10, 34, 38, 0, time.UTC)
@@ -129,7 +169,7 @@ func TestShouldSkipRecycleForRecentTaskLogRefreshesVM(t *testing.T) {
 		recycleQueue:    delayqueue.NewVMRecycleQueue(redisClient, logger),
 	}
 
-	skip, err := r.shouldSkipRecycleForRecentTaskLog(ctx, vm, now)
+	skip, err := r.shouldSkipRecycleForRecentActivity(ctx, vm, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +195,7 @@ func TestShouldSkipRecycleForRecentTaskLogAllowsStaleVM(t *testing.T) {
 		taskLogActivity: &taskLogActivityStub{latest: map[uuid.UUID]time.Time{taskID: now.Add(-2 * time.Hour)}},
 	}
 
-	skip, err := r.shouldSkipRecycleForRecentTaskLog(ctx, vm, now)
+	skip, err := r.shouldSkipRecycleForRecentActivity(ctx, vm, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,9 +242,11 @@ type refreshHostRepoStub struct {
 type taskLogActivityStub struct {
 	latest map[uuid.UUID]time.Time
 	err    error
+	calls  int
 }
 
 func (s *taskLogActivityStub) LatestTaskLogTime(_ context.Context, taskID uuid.UUID) (time.Time, bool, error) {
+	s.calls++
 	if s.err != nil {
 		return time.Time{}, false, s.err
 	}

--- a/backend/biz/vmidle/usecase/vmidle.go
+++ b/backend/biz/vmidle/usecase/vmidle.go
@@ -464,7 +464,7 @@ func (r *vmIdleRefresher) recycleConsumer() {
 					return nil
 				}
 
-				skip, err := r.shouldSkipRecycleForRecentTaskLog(ctx, vm, time.Now())
+				skip, err := r.shouldSkipRecycleForRecentActivity(ctx, vm, time.Now())
 				if err != nil {
 					return err
 				}
@@ -498,8 +498,8 @@ func (r *vmIdleRefresher) recycleConsumer() {
 	}
 }
 
-func (r *vmIdleRefresher) shouldSkipRecycleForRecentTaskLog(ctx context.Context, vm *db.VirtualMachine, now time.Time) (bool, error) {
-	if r.taskLogActivity == nil || vm == nil {
+func (r *vmIdleRefresher) shouldSkipRecycleForRecentActivity(ctx context.Context, vm *db.VirtualMachine, now time.Time) (bool, error) {
+	if vm == nil {
 		return false, nil
 	}
 	policy, err := r.resolvePolicyForVM(ctx, vm)
@@ -510,40 +510,55 @@ func (r *vmIdleRefresher) shouldSkipRecycleForRecentTaskLog(ctx context.Context,
 		return false, nil
 	}
 
-	taskIDs, err := r.activeTaskIDs(ctx, vm)
+	activeTasks, err := r.activeRecycleTasks(ctx, vm)
 	if err != nil {
 		return false, err
 	}
-	if len(taskIDs) == 0 {
+	if len(activeTasks) == 0 {
 		return false, nil
 	}
 
 	cutoff := now.Add(-time.Duration(policy.EffectiveRecycleSeconds) * time.Second)
-	for _, taskID := range taskIDs {
-		latest, ok, err := r.taskLogActivity.LatestTaskLogTime(ctx, taskID)
+	for _, tk := range activeTasks {
+		if tk.LastActiveAt.IsZero() || !tk.LastActiveAt.After(cutoff) {
+			continue
+		}
+		return r.skipRecycleAndRefresh(ctx, vm, tk.ID, tk.LastActiveAt, cutoff, "pg_task_last_active_at")
+	}
+
+	if r.taskLogActivity == nil {
+		return false, nil
+	}
+	for _, tk := range activeTasks {
+		latest, ok, err := r.taskLogActivity.LatestTaskLogTime(ctx, tk.ID)
 		if err != nil {
-			return false, fmt.Errorf("get latest task log time for task %s: %w", taskID, err)
+			return false, fmt.Errorf("get latest task log time for task %s: %w", tk.ID, err)
 		}
 		if !ok || !latest.After(cutoff) {
 			continue
 		}
 
-		r.logger.InfoContext(ctx, "skip vm recycle because task has recent log",
-			"vm_id", vm.ID,
-			"task_id", taskID.String(),
-			"latest_log_at", latest.UTC().Format(time.RFC3339Nano),
-			"cutoff", cutoff.UTC().Format(time.RFC3339Nano))
-		if err := r.Refresh(ctx, vm.ID); err != nil {
-			return false, fmt.Errorf("refresh vm idle timer after recent task log: %w", err)
-		}
-		return true, nil
+		return r.skipRecycleAndRefresh(ctx, vm, tk.ID, latest, cutoff, "clickhouse_task_log")
 	}
 	return false, nil
 }
 
-func (r *vmIdleRefresher) activeTaskIDs(ctx context.Context, vm *db.VirtualMachine) ([]uuid.UUID, error) {
+func (r *vmIdleRefresher) skipRecycleAndRefresh(ctx context.Context, vm *db.VirtualMachine, taskID uuid.UUID, activeAt, cutoff time.Time, source string) (bool, error) {
+	r.logger.InfoContext(ctx, "skip vm recycle because task has recent activity",
+		"vm_id", vm.ID,
+		"task_id", taskID.String(),
+		"source", source,
+		"active_at", activeAt.UTC().Format(time.RFC3339Nano),
+		"cutoff", cutoff.UTC().Format(time.RFC3339Nano))
+	if err := r.Refresh(ctx, vm.ID); err != nil {
+		return false, fmt.Errorf("refresh vm idle timer after recent task activity: %w", err)
+	}
+	return true, nil
+}
+
+func (r *vmIdleRefresher) activeRecycleTasks(ctx context.Context, vm *db.VirtualMachine) ([]*db.Task, error) {
 	seen := make(map[uuid.UUID]struct{}, len(vm.Edges.Tasks))
-	taskIDs := make([]uuid.UUID, 0, len(vm.Edges.Tasks))
+	activeTasks := make([]*db.Task, 0, len(vm.Edges.Tasks))
 	for _, tk := range vm.Edges.Tasks {
 		if tk == nil {
 			continue
@@ -555,10 +570,10 @@ func (r *vmIdleRefresher) activeTaskIDs(ctx context.Context, vm *db.VirtualMachi
 			continue
 		}
 		seen[tk.ID] = struct{}{}
-		taskIDs = append(taskIDs, tk.ID)
+		activeTasks = append(activeTasks, tk)
 	}
 	if len(vm.Edges.Tasks) > 0 {
-		return taskIDs, nil
+		return activeTasks, nil
 	}
 
 	taskIDStr, err := r.hostRepo.GetTaskIDByVMID(ctx, vm.ID)
@@ -572,7 +587,17 @@ func (r *vmIdleRefresher) activeTaskIDs(ctx context.Context, vm *db.VirtualMachi
 	if err != nil {
 		return nil, fmt.Errorf("invalid task id %q: %w", taskIDStr, err)
 	}
-	return []uuid.UUID{taskID}, nil
+	if r.taskRepo == nil {
+		return []*db.Task{{ID: taskID}}, nil
+	}
+	tk, err := r.taskRepo.GetByID(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("get task %s: %w", taskID, err)
+	}
+	if tk.Status == consts.TaskStatusFinished || tk.Status == consts.TaskStatusError {
+		return nil, nil
+	}
+	return []*db.Task{tk}, nil
 }
 
 func (r *vmIdleRefresher) markRecycledTasksFinished(ctx context.Context, vm *db.VirtualMachine) error {

--- a/backend/biz/vmidle/usecase/vmidle.go
+++ b/backend/biz/vmidle/usecase/vmidle.go
@@ -17,6 +17,7 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/pkg/clickhouse"
 	"github.com/chaitin/MonkeyCode/backend/pkg/delayqueue"
 	"github.com/chaitin/MonkeyCode/backend/pkg/entx"
 	"github.com/chaitin/MonkeyCode/backend/pkg/notify/dispatcher"
@@ -104,11 +105,16 @@ type vmIdleRefresher struct {
 	hostRepo         domain.HostRepo
 	taskRepo         domain.TaskRepo
 	teamPolicyRepo   domain.TeamPolicyRepo
+	taskLogActivity  taskLogActivityReader
 	notifyDispatcher *dispatcher.Dispatcher
 	sleepQueue       *delayqueue.VMSleepQueue
 	notifyQueue      *delayqueue.VMNotifyQueue
 	recycleQueue     *delayqueue.VMRecycleQueue
 	schedules        []notifySchedule
+}
+
+type taskLogActivityReader interface {
+	LatestTaskLogTime(ctx context.Context, taskID uuid.UUID) (time.Time, bool, error)
 }
 
 type vmIdleNotifyJob struct {
@@ -125,6 +131,14 @@ type vmIdleSchedulePlan struct {
 
 func NewVMIdleRefresher(i *do.Injector) (VMIdleRefresher, error) {
 	cfg := do.MustInvoke[*config.Config](i)
+	taskLogActivity, err := do.Invoke[*clickhouse.Client](i)
+	if err != nil {
+		return nil, err
+	}
+	var activityReader taskLogActivityReader
+	if taskLogActivity != nil {
+		activityReader = taskLogActivity
+	}
 	r := &vmIdleRefresher{
 		cfg:              cfg,
 		redis:            do.MustInvoke[*redis.Client](i),
@@ -133,6 +147,7 @@ func NewVMIdleRefresher(i *do.Injector) (VMIdleRefresher, error) {
 		hostRepo:         do.MustInvoke[domain.HostRepo](i),
 		taskRepo:         do.MustInvoke[domain.TaskRepo](i),
 		teamPolicyRepo:   do.MustInvoke[domain.TeamPolicyRepo](i),
+		taskLogActivity:  activityReader,
 		notifyDispatcher: do.MustInvoke[*dispatcher.Dispatcher](i),
 		sleepQueue:       do.MustInvoke[*delayqueue.VMSleepQueue](i),
 		notifyQueue:      do.MustInvoke[*delayqueue.VMNotifyQueue](i),
@@ -449,6 +464,14 @@ func (r *vmIdleRefresher) recycleConsumer() {
 					return nil
 				}
 
+				skip, err := r.shouldSkipRecycleForRecentTaskLog(ctx, vm, time.Now())
+				if err != nil {
+					return err
+				}
+				if skip {
+					return nil
+				}
+
 				if err := r.hostRepo.UpdateVirtualMachine(ctx, vm.ID, func(vmuo *db.VirtualMachineUpdateOne) error {
 					vmuo.SetIsRecycled(true)
 					return nil
@@ -473,6 +496,83 @@ func (r *vmIdleRefresher) recycleConsumer() {
 		logger.Warn("recycle consumer error, retrying...", "error", err)
 		time.Sleep(10 * time.Second)
 	}
+}
+
+func (r *vmIdleRefresher) shouldSkipRecycleForRecentTaskLog(ctx context.Context, vm *db.VirtualMachine, now time.Time) (bool, error) {
+	if r.taskLogActivity == nil || vm == nil {
+		return false, nil
+	}
+	policy, err := r.resolvePolicyForVM(ctx, vm)
+	if err != nil {
+		return false, err
+	}
+	if !policy.RecycleEnabled || policy.EffectiveRecycleSeconds <= 0 {
+		return false, nil
+	}
+
+	taskIDs, err := r.activeTaskIDs(ctx, vm)
+	if err != nil {
+		return false, err
+	}
+	if len(taskIDs) == 0 {
+		return false, nil
+	}
+
+	cutoff := now.Add(-time.Duration(policy.EffectiveRecycleSeconds) * time.Second)
+	for _, taskID := range taskIDs {
+		latest, ok, err := r.taskLogActivity.LatestTaskLogTime(ctx, taskID)
+		if err != nil {
+			return false, fmt.Errorf("get latest task log time for task %s: %w", taskID, err)
+		}
+		if !ok || !latest.After(cutoff) {
+			continue
+		}
+
+		r.logger.InfoContext(ctx, "skip vm recycle because task has recent log",
+			"vm_id", vm.ID,
+			"task_id", taskID.String(),
+			"latest_log_at", latest.UTC().Format(time.RFC3339Nano),
+			"cutoff", cutoff.UTC().Format(time.RFC3339Nano))
+		if err := r.Refresh(ctx, vm.ID); err != nil {
+			return false, fmt.Errorf("refresh vm idle timer after recent task log: %w", err)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func (r *vmIdleRefresher) activeTaskIDs(ctx context.Context, vm *db.VirtualMachine) ([]uuid.UUID, error) {
+	seen := make(map[uuid.UUID]struct{}, len(vm.Edges.Tasks))
+	taskIDs := make([]uuid.UUID, 0, len(vm.Edges.Tasks))
+	for _, tk := range vm.Edges.Tasks {
+		if tk == nil {
+			continue
+		}
+		if tk.Status == consts.TaskStatusFinished || tk.Status == consts.TaskStatusError {
+			continue
+		}
+		if _, ok := seen[tk.ID]; ok {
+			continue
+		}
+		seen[tk.ID] = struct{}{}
+		taskIDs = append(taskIDs, tk.ID)
+	}
+	if len(vm.Edges.Tasks) > 0 {
+		return taskIDs, nil
+	}
+
+	taskIDStr, err := r.hostRepo.GetTaskIDByVMID(ctx, vm.ID)
+	if err != nil {
+		return nil, fmt.Errorf("get task id by vm %s: %w", vm.ID, err)
+	}
+	if taskIDStr == "" {
+		return nil, nil
+	}
+	taskID, err := uuid.Parse(taskIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid task id %q: %w", taskIDStr, err)
+	}
+	return []uuid.UUID{taskID}, nil
 }
 
 func (r *vmIdleRefresher) markRecycledTasksFinished(ctx context.Context, vm *db.VirtualMachine) error {

--- a/backend/pkg/clickhouse/client.go
+++ b/backend/pkg/clickhouse/client.go
@@ -20,6 +20,7 @@ import (
 	migrateclickhouse "github.com/golang-migrate/migrate/v4/database/clickhouse"
 	"github.com/golang-migrate/migrate/v4/source"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/google/uuid"
 
 	"github.com/chaitin/MonkeyCode/backend/config"
 )
@@ -236,6 +237,25 @@ type TeamConversationListResult struct {
 	Rows        []TeamConversationRow
 	NextCursor  string
 	HasNextPage bool
+}
+
+func (c *Client) LatestTaskLogTime(ctx context.Context, taskID uuid.UUID) (time.Time, bool, error) {
+	if c == nil || c.db == nil {
+		return time.Time{}, false, fmt.Errorf("clickhouse client is nil")
+	}
+	tableIdentifier, err := quoteIdentifier(c.Table())
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	query := fmt.Sprintf(`SELECT maxOrNull(ts) AS ts FROM %s WHERE task_id = ?`, tableIdentifier)
+	var latest sql.NullTime
+	if err := c.db.QueryRowContext(ctx, query, taskID.String()).Scan(&latest); err != nil {
+		return time.Time{}, false, err
+	}
+	if !latest.Valid {
+		return time.Time{}, false, nil
+	}
+	return latest.Time, true, nil
 }
 
 func (c *Client) InsertModelUsageEvent(ctx context.Context, event ModelUsageEvent) error {

--- a/backend/pkg/clickhouse/client_test.go
+++ b/backend/pkg/clickhouse/client_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"io"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/golang-migrate/migrate/v4/source"
+	"github.com/google/uuid"
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/chaitin/MonkeyCode/backend/config"
@@ -323,6 +326,60 @@ func TestBuildMigrationSourcesUseUTCDateTimeColumns(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestLatestTaskLogTime(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqlDB.Close()
+	client := NewWithDBTables(sqlDB, "task_logs_test", "model_usage_events_test")
+	taskID := uuid.New()
+	latest := time.Date(2026, 7, 7, 2, 33, 3, 722859301, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT maxOrNull(ts) AS ts FROM `task_logs_test` WHERE task_id = ?")).
+		WithArgs(taskID.String()).
+		WillReturnRows(sqlmock.NewRows([]string{"ts"}).AddRow(latest))
+
+	got, ok, err := client.LatestTaskLogTime(context.Background(), taskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected latest task log time")
+	}
+	if !got.Equal(latest) {
+		t.Fatalf("latest = %s, want %s", got, latest)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLatestTaskLogTimeNoRows(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sqlDB.Close()
+	client := NewWithDBTables(sqlDB, "task_logs_test", "model_usage_events_test")
+	taskID := uuid.New()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT maxOrNull(ts) AS ts FROM `task_logs_test` WHERE task_id = ?")).
+		WithArgs(taskID.String()).
+		WillReturnRows(sqlmock.NewRows([]string{"ts"}).AddRow(nil))
+
+	_, ok, err := client.LatestTaskLogTime(context.Background(), taskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("expected no latest task log time")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## 背景

排查异常 VM agent_8cc1d9e4-3278-4b81-a832-eb0a5fbc1de8 时，最初怀疑 VM idle 回收误判。后续从日志文件 Logs-2026-07-07 14_22_52.json 复盘发现，真实删除入口是 HostUsecase.DeleteVM 打出的 delete vm，既不是 vm:expire，也不是 vm:idle:recycle consumer。该路径会删除/软删 VM，但原实现不会结束关联任务，导致 VM 已删除、任务仍保持 processing。

## 变更

- 修复用户删除 VM 后关联任务未结束的问题：HostRepo.DeleteVirtualMachine 在同一事务内加载 VM 关联任务，并将未完成任务置为 finished、设置 completed_at。
- 增强 DeleteVM 日志字段，追加 user_id 和 host_id，后续可以直接区分用户删除与系统回收。
- 为 ClickHouse client 增加按 task_id 查询最新任务日志时间的方法。
- 在 VM idle recycle consumer 真正设置 is_recycled 和删除 VM 前，增加二次活动校验。
- 校验顺序为：先看 Postgres 里关联任务的 last_active_at，若仍在回收策略窗口内则刷新 VM idle timer 并跳过回收；若 PG 已过期，再查询 ClickHouse task_logs 的最新日志时间做兜底。
- 若 ClickHouse 查询失败，返回错误中止本次回收，等待队列重试，避免误回收。
- 补充删除 VM 结束任务、ClickHouse 查询、PG first guard、ClickHouse fallback 的单测。

## 验证

GOWORK=off go test ./biz/host/repo ./biz/host/usecase ./biz/vmidle/usecase ./pkg/clickhouse
GOWORK=off go test ./...

说明：不带 GOWORK=off 时，外层 go.work 引用了当前机器不存在的 product-version-api 模块，会导致 go test 加载模块失败。