### PR TITLE
fix: stop composer blur bleeding over messages on iOS 26

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -22,6 +22,7 @@
         "expo-document-picker": "~55.0.14",
         "expo-file-system": "~55.0.23",
         "expo-font": "~55.0.8",
+        "expo-glass-effect": "~55.0.11",
         "expo-image-manipulator": "~55.0.18",
         "expo-image-picker": "~55.0.21",
         "expo-linking": "~55.0.16",
@@ -4495,9 +4496,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4512,9 +4510,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4529,9 +4524,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4546,9 +4538,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4563,9 +4552,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4580,9 +4566,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4597,9 +4580,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4614,9 +4594,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4631,9 +4608,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4648,9 +4622,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10180,9 +10151,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10202,9 +10170,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -10226,9 +10191,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10248,9 +10210,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -26,6 +26,7 @@
     "expo-document-picker": "~55.0.14",
     "expo-file-system": "~55.0.23",
     "expo-font": "~55.0.8",
+    "expo-glass-effect": "~55.0.11",
     "expo-image-manipulator": "~55.0.18",
     "expo-image-picker": "~55.0.21",
     "expo-linking": "~55.0.16",

--- a/mobile/src/components/glass.tsx
+++ b/mobile/src/components/glass.tsx
@@ -1,11 +1,29 @@
 /**
  * 液态玻璃容器。
- * 用 expo-blur 实现真实毛玻璃（模糊层 + 薄边 + 顶部高光）。
+ * iOS 26+ 用 expo-glass-effect（系统 UIGlassEffect）；旧 iOS 回退 expo-blur 毛玻璃。
+ * 换掉 UIVisualEffectView 方案的原因：它的高斯模糊会越过 bounds 向外渗出约一个
+ * blur radius，iOS 26 上 RN 层的裁剪约束不住（Apple 标注裁剪其宿主为未定义行为），
+ * composer 顶边上方会浮出一条把消息糊住的毛玻璃光晕。UIGlassEffect 严格按 bounds 渲染。
  */
 import { BlurView } from 'expo-blur';
 import React from 'react';
 import { Platform, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 import { useTheme } from '@/theme';
+
+// 懒加载 + 容错：OTA 包可能跑在还没编入 ExpoGlassEffect 原生模块的旧安装包上，
+// 顶层 import 触发 requireNativeModule 抛错会直接崩 App；失败则永远走 BlurView 回退。
+let glassEffectMod: typeof import('expo-glass-effect') | null | undefined;
+function liquidGlassModule(): typeof import('expo-glass-effect') | null {
+  if (glassEffectMod === undefined) {
+    try {
+      const mod = require('expo-glass-effect') as typeof import('expo-glass-effect');
+      glassEffectMod = mod.isLiquidGlassAvailable() ? mod : null;
+    } catch {
+      glassEffectMod = null;
+    }
+  }
+  return glassEffectMod;
+}
 
 interface GlassProps {
   children?: React.ReactNode;
@@ -37,6 +55,20 @@ export function Glass({ children, style, radius = 0, intensity = 36, border = tr
     return (
       <View style={[radiusStyle, shadow && t.shLift, style]}>
         <View style={[StyleSheet.absoluteFill, radiusStyle, { backgroundColor: t.glassSolid }, borderStyle]} />
+        {children}
+      </View>
+    );
+  }
+
+  // iOS 26+：系统液态玻璃。intensity 在此路径无效（材质强度由系统定），观感靠 veil 统一；
+  // colorScheme 跟随 App 内主题开关而非系统外观，避免强制深/浅色时玻璃底色错位。
+  const glassEffect = liquidGlassModule();
+  if (glassEffect) {
+    const { GlassView } = glassEffect;
+    return (
+      <View style={[radiusStyle, shadow && t.shLift, style]}>
+        <GlassView glassEffectStyle="regular" colorScheme={t.glassTint} style={[StyleSheet.absoluteFill, radiusStyle]} />
+        <View style={[StyleSheet.absoluteFill, radiusStyle, { backgroundColor: t.glassVeil }, borderStyle]} />
         {children}
       </View>
     );


### PR DESCRIPTION
UIVisualEffectView's gaussian blur spreads ~one blur radius beyond its bounds. After 6423056 removed the outer clip (required to fix the iOS 26 first-mount blur failure), that bleed escapes above the composer's top edge and frosts the last line of the agent reply — RN-level clipping cannot contain it since clipping the effect view's host is documented undefined behavior.

Switch Glass to expo-glass-effect's GlassView (system UIGlassEffect) on iOS 26+, which renders strictly within its corner-configured shape, and keep the BlurView path as fallback for older iOS / non-liquid-glass builds. The module is lazy-required with a try/catch so OTA bundles running on binaries without the native module fall back instead of crashing. colorScheme follows the in-app theme toggle rather than the system appearance.