### PR TITLE
fix(frontend): restore chat input focus after upload

### DIFF
--- a/frontend/src/components/console/task/chat-inputbox.tsx
+++ b/frontend/src/components/console/task/chat-inputbox.tsx
@@ -580,6 +580,9 @@ export const TaskChatInputBox = React.forwardRef<TaskChatInputBoxHandle, TaskCha
     nextAttachmentFileIndexRef.current += 1
     setSelectedUploadFile(null)
     setShouldAutoUpload(false)
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus()
+    })
   }
 
   const handleWhiteboardUploaded = (file: TaskUploadedFile) => {


### PR DESCRIPTION
## Summary
- Restore chat input focus after an attachment upload succeeds
- Cover file picker, drag-and-drop, paste upload, and whiteboard upload through the shared upload callback

## Verification
- pnpm lint
- pnpm run build:online
- Manually verified upload flow in the preview environment

Fixes #830