### PR TITLE
fix(frontend): open workspace links in file preview

### DIFF
--- a/frontend/src/components/common/markdown.tsx
+++ b/frontend/src/components/common/markdown.tsx
@@ -147,6 +147,10 @@ interface MarkdownProps {
   allowHtml?: boolean
   /** Whether internal links should navigate in-app. */
   allowInternalLink?: boolean
+  /** VM id used to route workspace file links to the file manager. */
+  fileLinkEnvid?: string
+  /** Opens workspace file links in the current task context. */
+  onWorkspaceFileClick?: (path: string) => void
   className?: string
 }
 
@@ -191,7 +195,32 @@ function resolveRelativePath(href: string, currentPath: string): string {
   }
 }
 
-export const Markdown = memo(function Markdown({ children, allowHtml = false, allowInternalLink = true, className }: MarkdownProps) {
+function resolveWorkspaceFileLink(href: string | undefined, envid: string | undefined): string | null {
+  if (!href || !envid) return null
+
+  try {
+    const url = new URL(href, window.location.origin)
+    if (url.origin !== window.location.origin) return null
+    if (url.pathname !== "/workspace" && !url.pathname.startsWith("/workspace/")) return null
+
+    const path = url.pathname
+    const searchParams = new URLSearchParams({ envid })
+
+    if (path === "/workspace") {
+      searchParams.set("path", path)
+    } else {
+      const parentPath = path.substring(0, path.lastIndexOf("/")) || "/"
+      searchParams.set("path", parentPath)
+      searchParams.set("open", path)
+    }
+
+    return `/console/files?${searchParams.toString()}`
+  } catch {
+    return null
+  }
+}
+
+export const Markdown = memo(function Markdown({ children, allowHtml = false, allowInternalLink = true, fileLinkEnvid, onWorkspaceFileClick, className }: MarkdownProps) {
   const location = useLocation()
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === "dark"
@@ -199,8 +228,25 @@ export const Markdown = memo(function Markdown({ children, allowHtml = false, al
   const components = useMemo<Components>(() => ({
     a({ href, children, ...props }) {
       if (isInternalLink(href)) {
+        const fileManagerPath = allowInternalLink ? resolveWorkspaceFileLink(href, fileLinkEnvid) : null
         const absolutePath = resolveRelativePath(href as string, location.pathname)
-        return <Link to={allowInternalLink ? absolutePath : ""} {...props}>{children}</Link>
+        const workspacePath = fileManagerPath ? new URL(href as string, window.location.origin).pathname : null
+        return (
+          <Link
+            to={allowInternalLink ? fileManagerPath ?? absolutePath : ""}
+            onClick={(event) => {
+              if (!workspacePath || !onWorkspaceFileClick || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+                return
+              }
+
+              event.preventDefault()
+              onWorkspaceFileClick(workspacePath)
+            }}
+            {...props}
+          >
+            {children}
+          </Link>
+        )
       }
 
       return (
@@ -211,7 +257,7 @@ export const Markdown = memo(function Markdown({ children, allowHtml = false, al
     },
     p: MarkdownParagraph,
     pre: ({ children }) => <MarkdownCodeBlock isDark={isDark}>{children}</MarkdownCodeBlock>,
-  }), [allowInternalLink, isDark, location.pathname])
+  }), [allowInternalLink, fileLinkEnvid, isDark, location.pathname, onWorkspaceFileClick])
 
   return (
     <div className={cn("markdown-body pb-2", isDark ? "markdown-body-dark" : "markdown-body-light", className)}>

--- a/frontend/src/components/common/markdown.tsx
+++ b/frontend/src/components/common/markdown.tsx
@@ -203,10 +203,10 @@ function resolveWorkspaceFileLink(href: string | undefined, envid: string | unde
     if (url.origin !== window.location.origin) return null
     if (url.pathname !== "/workspace" && !url.pathname.startsWith("/workspace/")) return null
 
-    const path = url.pathname
+    const path = url.pathname === "/workspace" ? "/" : url.pathname.substring("/workspace".length)
     const searchParams = new URLSearchParams({ envid })
 
-    if (path === "/workspace") {
+    if (path === "/") {
       searchParams.set("path", path)
     } else {
       const parentPath = path.substring(0, path.lastIndexOf("/")) || "/"

--- a/frontend/src/components/console/task/message-text.tsx
+++ b/frontend/src/components/console/task/message-text.tsx
@@ -2,11 +2,11 @@ import "@/utils/plain-text-markdown.css"
 import type { MessageType } from "./message"
 import { Markdown } from "@/components/common/markdown"
 
-export const TextMessageItem = ({ message }: { message: MessageType }) => {
+export const TextMessageItem = ({ message, fileLinkEnvid, onWorkspaceFileClick }: { message: MessageType, fileLinkEnvid?: string, onWorkspaceFileClick?: (path: string) => void }) => {
   return (
     <div className="flex flex-col w-full rounded-md px-1 max-w-[100%] mt-0.5">
       <div className="text-sm">
-        <Markdown allowHtml>{message.data.content || ''}</Markdown>
+        <Markdown allowHtml fileLinkEnvid={fileLinkEnvid} onWorkspaceFileClick={onWorkspaceFileClick}>{message.data.content || ''}</Markdown>
       </div>
     </div>
   )

--- a/frontend/src/components/console/task/message-userinput.tsx
+++ b/frontend/src/components/console/task/message-userinput.tsx
@@ -1,5 +1,3 @@
-import ReactMarkdown from "react-markdown"
-import remarkGfm from "remark-gfm"
 import "@/utils/plain-text-markdown.css"
 import type { MessageType } from "./message"
 import { IconCopy, IconFile } from "@tabler/icons-react"
@@ -10,8 +8,9 @@ import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { toast } from "sonner"
 import { useTranslation } from "react-i18next"
+import { Markdown } from "@/components/common/markdown"
 
-export const UserInputMessageItem = ({ message }: { message: MessageType }) => {
+export const UserInputMessageItem = ({ message, fileLinkEnvid, onWorkspaceFileClick }: { message: MessageType, fileLinkEnvid?: string, onWorkspaceFileClick?: (path: string) => void }) => {
   const { t } = useTranslation()
   const [previewFile, setPreviewFile] = React.useState<TaskAttachmentPreviewFile | null>(null)
   const content = typeof message.data.content === "string" ? message.data.content : ""
@@ -42,21 +41,9 @@ export const UserInputMessageItem = ({ message }: { message: MessageType }) => {
       <div className="flex flex-col rounded-md bg-accent/50 px-4 py-3 break-all">
         {content && (
           <div className="user-message-markdown break-all">
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              components={{
-                p({children, ...props}) {
-                  if (typeof children === 'string') {
-                    return (children as string).split('\n').map((line: string, index: number) => (
-                      <p key={index} {...props}>{line}</p>
-                    ))
-                  } else {
-                    return <p {...props}>{children}</p>
-                  }
-                }
-              }}>
+            <Markdown fileLinkEnvid={fileLinkEnvid} onWorkspaceFileClick={onWorkspaceFileClick}>
               {content}
-            </ReactMarkdown>
+            </Markdown>
           </div>
         )}
         {attachments.length > 0 && (

--- a/frontend/src/components/console/task/message.tsx
+++ b/frontend/src/components/console/task/message.tsx
@@ -80,15 +80,15 @@ const shouldRenderMessage = (message: MessageType) => {
   return true
 }
 
-const MessageItem = ({ message, cli, isLatest = false }: { message: MessageType, cli?: ConstsCliName, isLatest?: boolean }) => {
+const MessageItem = ({ message, cli, isLatest = false, fileLinkEnvid, onWorkspaceFileClick }: { message: MessageType, cli?: ConstsCliName, isLatest?: boolean, fileLinkEnvid?: string, onWorkspaceFileClick?: (path: string) => void }) => {
   const renderMessage = (message: MessageType) => {
     switch (message.type) {
       case 'agent_message_chunk':
-        return <TextMessageItem message={message} />
+        return <TextMessageItem message={message} fileLinkEnvid={fileLinkEnvid} onWorkspaceFileClick={onWorkspaceFileClick} />
       case 'agent_thought_chunk':
         return <ThoughtMessageItem message={message} isLatest={isLatest} />
       case 'user_input':
-        return <UserInputMessageItem message={message} />
+        return <UserInputMessageItem message={message} fileLinkEnvid={fileLinkEnvid} onWorkspaceFileClick={onWorkspaceFileClick} />
       case 'tool_call':
         return <ToolCallMessageItem message={message} cli={cli} />
       case 'error_message':

--- a/frontend/src/components/console/task/task-file-explorer.tsx
+++ b/frontend/src/components/console/task/task-file-explorer.tsx
@@ -54,6 +54,10 @@ interface TaskFileExplorerProps {
   envid?: string
 }
 
+export interface TaskFileExplorerHandle {
+  openFile: (path: string) => Promise<FileItem | null>
+}
+
 const sortFiles = (files: RepoFileStatus[]) => {
   return files.sort((a, b) => {
     const getTypePriority = (file: RepoFileStatus) => {
@@ -161,6 +165,12 @@ function tryDecodeAsText(bytes: Uint8Array): { text: string; isText: boolean } {
   } catch {
     return { text: '', isText: false }
   }
+}
+
+function normalizeWorkspacePath(path: string): string {
+  if (path === "/workspace") return ""
+  if (path.startsWith("/workspace/")) return path.substring("/workspace/".length)
+  return path
 }
 
 interface FileItem {
@@ -390,7 +400,7 @@ const DirNode = forwardRef<DirNodeRef, {
 
 DirNode.displayName = 'DirNode'
 
-export const TaskFileExplorer = ({
+export const TaskFileExplorer = forwardRef<TaskFileExplorerHandle, TaskFileExplorerProps>(function TaskFileExplorer({
   className,
   disabled,
   repository,
@@ -398,7 +408,7 @@ export const TaskFileExplorer = ({
   onChangesCountChange,
   onClosePanel,
   envid,
-}: TaskFileExplorerProps): React.JSX.Element => {
+}, ref): React.JSX.Element {
   const { t } = useTranslation()
   const rootRef = useRef<DirNodeRef>(null)
   const lastRefreshSignalRef = useRef<number | undefined>(undefined)
@@ -528,17 +538,19 @@ export const TaskFileExplorer = ({
 
   const openFile = useCallback(async (path: string) => {
     if (!envid || !path) return null
-    const bytes = await fetchFileContent(path)
+    const filePath = normalizeWorkspacePath(path)
+    if (!filePath) return null
+    const bytes = await fetchFileContent(filePath)
     if (!bytes) return null
-    const isBinaryByExt = isBinaryExtension(path)
-    const isImage = isImageExtension(path)
+    const isBinaryByExt = isBinaryExtension(filePath)
+    const isImage = isImageExtension(filePath)
     const isTooLarge = bytes.length > MAX_FILE_SIZE
     const { text, isText } = isBinaryByExt ? { text: '', isText: false } : tryDecodeAsText(bytes)
     const isBinary = isBinaryByExt || !isText
-    const imageDataUrl = isImage ? createImageDataUrl(path, bytes) : null
+    const imageDataUrl = isImage ? createImageDataUrl(filePath, bytes) : null
     const file: FileItem = {
-      name: path.split('/').pop() || path,
-      path,
+      name: filePath.split('/').pop() || filePath,
+      path: filePath,
       bytes,
       content: isText ? text : null,
       isBinary,
@@ -551,6 +563,8 @@ export const TaskFileExplorer = ({
     setCurrentFile(file)
     return file
   }, [envid, fetchFileContent])
+
+  useImperativeHandle(ref, () => ({ openFile }), [openFile])
 
   const clearCurrentFile = useCallback(() => {
     setFileLoading(false)
@@ -888,4 +902,4 @@ export const TaskFileExplorer = ({
       </Dialog>
     </div>
   )
-}
+})

--- a/frontend/src/components/console/task/task-message-virtual-list.tsx
+++ b/frontend/src/components/console/task/task-message-virtual-list.tsx
@@ -27,6 +27,8 @@ export interface TaskMessageVirtualListScrollOptions {
 interface TaskMessageVirtualListProps {
   messages: MessageType[]
   cli?: ConstsCliName
+  fileLinkEnvid?: string
+  onWorkspaceFileClick?: (path: string) => void
   contentRef?: React.Ref<HTMLDivElement>
   className?: string
   getScrollContainer: () => HTMLDivElement | null
@@ -80,6 +82,8 @@ const TaskMessageVirtualList = React.forwardRef<TaskMessageVirtualListHandle, Ta
     const {
       messages,
       cli,
+      fileLinkEnvid,
+      onWorkspaceFileClick,
       contentRef,
       className,
       getScrollContainer,
@@ -261,6 +265,8 @@ const TaskMessageVirtualList = React.forwardRef<TaskMessageVirtualListHandle, Ta
                     message={renderableMessages[row.messageIndex]}
                     cli={cli}
                     isLatest={renderableMessages[row.messageIndex]?.id === latestMessageId}
+                    fileLinkEnvid={fileLinkEnvid}
+                    onWorkspaceFileClick={onWorkspaceFileClick}
                   />
                 </div>
               )}

--- a/frontend/src/pages/console/user/file-manager.tsx
+++ b/frontend/src/pages/console/user/file-manager.tsx
@@ -113,6 +113,10 @@ const sortFiles = (files: TaskflowFile[]) => {
   })
 }
 
+const getParentPath = (path: string) => normalizePath(path.substring(0, path.lastIndexOf('/')) || '/')
+
+const getFileName = (path: string) => path.split('/').filter(Boolean).pop() || ''
+
 const getFileIcon = (file: TaskflowFile) => {
   const kind = file.kind === TaskflowFileKind.FileKindSymlink ? file.symlink_kind : file.kind
   switch (kind) {
@@ -134,6 +138,7 @@ export default function FileManagerPage() {
   const [vm, setVm] = useState<DomainVirtualMachine | null>(null)
   const [envid] = useState<string>(searchParams.get('envid') || '')
   const [currentPath, setCurrentPath] = useState<string>(normalizePath(searchParams.get('path') || '/'))
+  const [pendingOpenPath, setPendingOpenPath] = useState<string>(normalizePath(searchParams.get('open') || ''))
   const [editFileDialogOpen, setEditFileDialogOpen] = useState(false)
   const [editingFile, setEditingFile] = useState<string | null>(null)
   const [createFolderDialogOpen, setCreateFolderDialogOpen] = useState(false)
@@ -194,6 +199,36 @@ export default function FileManagerPage() {
 
     fetchFiles()
   }, [fetchFiles])
+
+  useEffect(() => {
+    if (!pendingOpenPath || loading || getParentPath(pendingOpenPath) !== currentPath) {
+      return
+    }
+
+    const fileName = getFileName(pendingOpenPath)
+    const file = files.find((item) => item.name === fileName)
+
+    if (!file) {
+      return
+    }
+
+    setPendingOpenPath('')
+
+    if (file.kind === TaskflowFileKind.FileKindDir || (file.kind === TaskflowFileKind.FileKindSymlink && file.symlink_kind === TaskflowFileKind.FileKindDir)) {
+      ChangeDirectory(file.name || pendingOpenPath)
+      return
+    }
+
+    if (file.kind === TaskflowFileKind.FileKindFile) {
+      if (file.size && file.size > 1024 * 1024) {
+        toast.error(t("consoleFiles.toast.editTooLarge"))
+        return
+      }
+
+      setEditingFile(pendingOpenPath)
+      setEditFileDialogOpen(true)
+    }
+  }, [currentPath, files, loading, pendingOpenPath, t])
 
   const ChangeDirectory = (path: string) => {
     if (path.startsWith('/')) {

--- a/frontend/src/pages/console/user/task/task-detail.tsx
+++ b/frontend/src/pages/console/user/task/task-detail.tsx
@@ -9,7 +9,7 @@ import { TaskMessageHandler, type TaskMessageHandlerStatus } from "@/components/
 import type { MessageType } from "@/components/console/task/message"
 import { TaskMessageVirtualList, type TaskMessageVirtualListHandle, type TaskMessageVirtualListScrollOptions } from "@/components/console/task/task-message-virtual-list"
 import { TaskPreparingView, useShouldShowPreparing } from "@/components/console/task/task-preparing-dialog"
-import { TaskFileExplorer } from "@/components/console/task/task-file-explorer"
+import { TaskFileExplorer, type TaskFileExplorerHandle } from "@/components/console/task/task-file-explorer"
 import { TaskPreviewPanel } from "@/components/console/task/task-preview-panel"
 import type { AvailableCommands, TaskPlan, TaskStreamStatus, TaskUserInput } from "@/components/console/task/task-shared"
 import { TaskStreamClient, type TaskStreamClientState, type TaskStreamCloseReason, type TaskStreamConnectionState } from "@/components/console/task/task-stream-client"
@@ -116,6 +116,7 @@ export default function TaskDetailPage() {
   const [modelSwitchDialogOpen, setModelSwitchDialogOpen] = React.useState(false)
   const [modelSwitchSubmitting, setModelSwitchSubmitting] = React.useState(false)
   const [pendingSwitchModel, setPendingSwitchModel] = React.useState<DomainModel | null>(null)
+  const [pendingWorkspaceFilePath, setPendingWorkspaceFilePath] = React.useState<string | null>(null)
   const taskControlClientRef = React.useRef<TaskControlClient | null>(null)
   const streamClientRef = React.useRef<TaskStreamClient | null>(null)
   const historyLoadingRef = React.useRef(false)
@@ -125,6 +126,7 @@ export default function TaskDetailPage() {
   const chatInputRef = React.useRef<TaskChatInputBoxHandle>(null)
   const chatContentRef = React.useRef<HTMLDivElement | null>(null)
   const taskMessageListRef = React.useRef<TaskMessageVirtualListHandle | null>(null)
+  const taskFileExplorerRef = React.useRef<TaskFileExplorerHandle | null>(null)
   const autoScrollFrameRef = React.useRef<number | null>(null)
   const autoScrollLockTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   const autoScrollIntentLockedRef = React.useRef(false)
@@ -1067,6 +1069,29 @@ export default function TaskDetailPage() {
     return taskMessageListRef.current?.scrollToMessage(messageId, options) ?? false
   }, [])
 
+  const openWorkspaceFileLink = React.useCallback((path: string) => {
+    if (!path) return
+
+    const fileExplorer = taskFileExplorerRef.current
+    if (fileExplorer) {
+      void fileExplorer.openFile(path)
+      return
+    }
+
+    setPendingWorkspaceFilePath(path)
+    setActiveSidePanel("files")
+  }, [])
+
+  React.useEffect(() => {
+    if (activeSidePanel !== "files" || !pendingWorkspaceFilePath || !taskFileExplorerRef.current) {
+      return
+    }
+
+    const path = pendingWorkspaceFilePath
+    setPendingWorkspaceFilePath(null)
+    void taskFileExplorerRef.current.openFile(path)
+  }, [activeSidePanel, pendingWorkspaceFilePath])
+
   const scheduleChatScrollToBottom = React.useCallback((behavior: ScrollBehavior = "smooth", options?: { forceAutoScroll?: boolean }) => {
     const container = getChatScrollContainer()
     if (!container) return
@@ -1450,6 +1475,8 @@ export default function TaskDetailPage() {
                         contentRef={chatContentRef}
                         messages={messages}
                         cli={task?.cli_name}
+                        fileLinkEnvid={envid}
+                        onWorkspaceFileClick={openWorkspaceFileLink}
                         getScrollContainer={getChatScrollContainer}
                         showHistoryLoadButton={showHistoryLoadButton}
                         historyLoading={historyLoading}
@@ -1503,6 +1530,7 @@ export default function TaskDetailPage() {
                       {activeSidePanel === "files" && (
                         <div className="flex-1 min-h-0 overflow-hidden">
                           <TaskFileExplorer
+                            ref={taskFileExplorerRef}
                             disabled={!taskInteractive}
                             repository={taskControlClientRef.current}
                             refreshSignal={fileRefreshSignal}


### PR DESCRIPTION
Fixes #824

## Changes
- Route task Markdown workspace links to the task file preview dialog on normal left click.
- Preserve file-manager deep links for copied links or opening in a new tab.
- Support opening file-manager deep links with an `open` query parameter.
- Reuse the task file explorer preview logic for text, image, binary, and large-file handling.

## Verification
- `pnpm lint`
- `pnpm run build:online`
- Manual test: sent `[.gitignore](/workspace/.gitignore)` in a task and confirmed the link opens the file preview dialog in the task page.