### PR TITLE
为黄色报错提示增加复制功能

### DIFF
--- a/frontend/src/components/console/task/message-alert.tsx
+++ b/frontend/src/components/console/task/message-alert.tsx
@@ -1,19 +1,54 @@
 import { Badge } from "@/components/ui/badge"
-import { IconAlertTriangle } from "@tabler/icons-react"
+import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { IconAlertTriangle, IconCopy } from "@tabler/icons-react"
+import { toast } from "sonner"
+import { useTranslation } from "react-i18next"
 import type { MessageType } from "./message"
 
 export const AlertMessageItem = ({ message }: { message: MessageType }) => {
+  const { t } = useTranslation()
   const level = message.data.level ?? "info"
+  const text = message.data.text || ""
+
+  const handleCopy = async () => {
+    if (!text) return
+
+    try {
+      await navigator.clipboard.writeText(text)
+      toast.success(t("taskDetail.alert.copySuccess"))
+    } catch (error) {
+      toast.error(t("taskDetail.alert.copyFailed"))
+      console.error("Copy alert message failed:", error)
+    }
+  }
 
   return (
     <Badge className={level === "warning"
-      ? "max-w-[80%] bg-yellow-100 text-yellow-900 whitespace-normal dark:bg-yellow-950/40 dark:text-yellow-200"
-      : "max-w-[80%] bg-muted text-muted-foreground whitespace-normal"
+      ? "group/alert-message max-w-[80%] bg-yellow-100 text-yellow-900 whitespace-normal dark:bg-yellow-950/40 dark:text-yellow-200"
+      : "group/alert-message max-w-[80%] bg-muted text-muted-foreground whitespace-normal"
     }>
       {level === "warning" && <IconAlertTriangle className="size-4" />}
       <div className="min-w-0 flex-1 line-clamp-1 break-all">
-        {message.data.text}
+        {text}
       </div>
+      {text && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="size-5 shrink-0 opacity-0 transition-opacity hover:bg-black/5 group-hover/alert-message:opacity-100 group-focus-within/alert-message:opacity-100 dark:hover:bg-white/10"
+              aria-label={t("taskDetail.alert.copy")}
+              onClick={handleCopy}
+            >
+              <IconCopy className="size-3" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t("taskDetail.alert.copy")}</TooltipContent>
+        </Tooltip>
+      )}
     </Badge>
   )
 }

--- a/frontend/src/i18n/resources/cn.ts
+++ b/frontend/src/i18n/resources/cn.ts
@@ -4107,6 +4107,9 @@ const cn = {
       llmRetry: "模型调用失败，正在重试：{{message}}",
       compactStarted: "启动上下文压缩",
       compactEnded: "上下文压缩完成",
+      copy: "复制提示内容",
+      copySuccess: "提示内容已复制到剪贴板",
+      copyFailed: "复制提示内容失败",
     },
     files: {
       title: "项目文件",

--- a/frontend/src/i18n/resources/en.ts
+++ b/frontend/src/i18n/resources/en.ts
@@ -4107,6 +4107,9 @@ const en = {
       llmRetry: "Model call failed. Retrying: {{message}}",
       compactStarted: "Starting context compression",
       compactEnded: "Context compression completed",
+      copy: "Copy alert message",
+      copySuccess: "Alert message copied to clipboard",
+      copyFailed: "Failed to copy alert message",
     },
     files: {
       title: "Project files",


### PR DESCRIPTION
## 变更内容
- 为任务中的黄色报错提示条增加复制按钮
- 支持一键复制完整报错提示，例如截图中的“模型调用失败，正在重试第 1 次：Bad Gateway”
- 页面仍保持单行紧凑展示，长报错不会撑高消息列表
- 增加复制按钮、复制成功和复制失败的中英文文案

## 截图参考
![黄色报错提示复制功能](https://raw.githubusercontent.com/2379278408/MonkeyCode/pr-assets/.github/pr-assets/871-yellow-alert-copy.png)

截图中黄色报错条右侧展示复制图标，hover 提示为“复制提示内容”。点击后复制黄色提示条中的报错文本，便于用户反馈、排查或记录。

## 验证
- pnpm lint
- pnpm run build:online
- 已通过人工预览验证

Closes #860