### PR TITLE
修复 MCP 上游同步缺少配置时静默成功

### DIFF
--- a/backend/biz/setting/usecase/mcp.go
+++ b/backend/biz/setting/usecase/mcp.go
@@ -35,7 +35,7 @@ func NewUserMCPSyncClient(i *do.Injector) (domain.UserMCPSyncClient, error) {
 	cfg := do.MustInvoke[*config.Config](i)
 	logger := do.MustInvoke[*slog.Logger](i).With("module", "usecase.UserMCPSyncClient")
 	if strings.TrimSpace(cfg.MCPHub.URL) == "" || strings.TrimSpace(cfg.MCPHub.Token) == "" {
-		return &noopUserMCPSyncClient{logger: logger}, nil
+		return &unconfiguredUserMCPSyncClient{}, nil
 	}
 	return &httpUserMCPSyncClient{
 		baseURL: cfg.MCPHub.URL,
@@ -125,12 +125,10 @@ func (u *userMCPUsecase) UpdateToolSetting(ctx context.Context, uid, toolID uuid
 	return u.repo.UpsertToolSetting(ctx, uid, toolID, enabled)
 }
 
-type noopUserMCPSyncClient struct {
-	logger *slog.Logger
-}
+type unconfiguredUserMCPSyncClient struct{}
 
-func (c *noopUserMCPSyncClient) SyncUpstream(context.Context, uuid.UUID) error {
-	return nil
+func (c *unconfiguredUserMCPSyncClient) SyncUpstream(context.Context, uuid.UUID) error {
+	return fmt.Errorf("mcp hub sync is not configured")
 }
 
 type httpUserMCPSyncClient struct {

--- a/backend/biz/setting/usecase/mcp_test.go
+++ b/backend/biz/setting/usecase/mcp_test.go
@@ -2,12 +2,20 @@ package usecase
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 
 	"github.com/chaitin/MonkeyCode/backend/domain"
 )
+
+func TestUnconfiguredUserMCPSyncClientReturnsError(t *testing.T) {
+	err := (&unconfiguredUserMCPSyncClient{}).SyncUpstream(context.Background(), uuid.New())
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Fatalf("SyncUpstream() error = %v, want configuration error", err)
+	}
+}
 
 func TestCreatePrivateMCPUpstream(t *testing.T) {
 	repo := &userMCPRepoStub{}


### PR DESCRIPTION
## 变更说明

- MCPHub URL 或 Token 未配置时返回明确错误
- 移除点击同步后直接返回成功的空实现
- 补充未配置同步客户端的单元测试

## 验证

- go test ./biz/mcphub/... ./biz/setting/usecase ./biz/team/usecase