### PR TITLE
refactor: 将 Skills 按钮从聊天输入框移至页面顶栏终端按钮左侧

### DIFF
--- a/frontend/src/components/console/task/chat-inputbox.tsx
+++ b/frontend/src/components/console/task/chat-inputbox.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from "react"
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupTextarea } from "@/components/ui/input-group"
-import { IconCommand, IconDots, IconLoader, IconPalette, IconPuzzle, IconReload, IconTrash, IconSend, IconSparkles, IconTerminal2, IconUpload } from "@tabler/icons-react"
+import { IconCommand, IconDots, IconLoader, IconPalette, IconReload, IconTrash, IconSend, IconSparkles, IconTerminal2, IconUpload } from "@tabler/icons-react"
 import React from "react"
 import { VoiceInputButton } from "./voice-input-button"
 import type { TaskMessageHandlerStatus } from "@/components/console/task/task-message-handler"
@@ -14,8 +14,7 @@ import { isCompressibleImageFile, MAX_TASK_UPLOAD_FILE_SIZE_BYTES, MAX_TASK_UPLO
 import { toast } from "sonner"
 import { TaskWhiteboardDialog } from "./task-whiteboard-dialog"
 import { TaskAttachmentPreviewDialog } from "./task-attachment-preview-dialog"
-import { TaskSkillsUpdateDialog } from "./task-skills-update-dialog"
-import type { SwitchAgentResourcesResponse } from "./task-control-client"
+
 import { IS_OFFLINE_EDITION } from "@/utils/edition"
 import { MAX_TASK_CONTENT_LENGTH } from "./task-content-limit"
 import { useTranslation } from "react-i18next"
@@ -60,12 +59,6 @@ interface TaskChatInputBoxProps {
   onCancel?: () => void
   onRequestRestartAgent?: (clearContext: boolean) => void
   whiteboardPersistenceKey?: string
-  skillIds?: string[]
-  pluginIds?: string[]
-  onSwitchAgentResources?: (
-    skillIds: string[],
-    pluginIds: string[],
-  ) => Promise<SwitchAgentResourcesResponse | null> | undefined
 }
 
 export interface TaskChatInputBoxHandle {
@@ -114,7 +107,7 @@ const removeTaskInputDraft = (taskId: string) => {
   writeTaskInputDraft(taskId, "")
 }
 
-export const TaskChatInputBox = React.forwardRef<TaskChatInputBoxHandle, TaskChatInputBoxProps>(function TaskChatInputBox({ taskId, streamStatus, availableCommands, onSend, sending, queueSize, executionTimeMs = 0, onCancel, onRequestRestartAgent, whiteboardPersistenceKey = "task-whiteboard", skillIds, pluginIds, onSwitchAgentResources }, ref) {
+export const TaskChatInputBox = React.forwardRef<TaskChatInputBoxHandle, TaskChatInputBoxProps>(function TaskChatInputBox({ taskId, streamStatus, availableCommands, onSend, sending, queueSize, executionTimeMs = 0, onCancel, onRequestRestartAgent, whiteboardPersistenceKey = "task-whiteboard" }, ref) {
   const { t } = useTranslation()
   const [content, setContent] = useState(() => readTaskInputDraft(taskId))
   const [isComposing, setIsComposing] = useState(false)
@@ -124,7 +117,6 @@ export const TaskChatInputBox = React.forwardRef<TaskChatInputBoxHandle, TaskCha
   const [isDragActive, setIsDragActive] = useState(false)
   const [whiteboardDialogOpen, setWhiteboardDialogOpen] = useState(false)
   const [whiteboardFileIndex, setWhiteboardFileIndex] = useState(1)
-  const [skillsDialogOpen, setSkillsDialogOpen] = useState(false)
   const [previewFile, setPreviewFile] = useState<TaskUploadedFile | null>(null)
   const [uploadedFiles, setUploadedFiles] = useState<TaskUploadedFile[]>([])
   const [slashCommandConfirmOpen, setSlashCommandConfirmOpen] = useState(false)
@@ -1042,31 +1034,6 @@ export const TaskChatInputBox = React.forwardRef<TaskChatInputBoxHandle, TaskCha
                 </TooltipTrigger>
                 <TooltipContent>{t("taskDetail.chat.whiteboard")}</TooltipContent>
               </Tooltip>
-              {onSwitchAgentResources && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon-sm"
-                      className={cn(
-                        "rounded-full",
-                        (skillIds?.length ?? 0) > 0 && "text-primary hover:text-primary",
-                      )}
-                      disabled={!canUseIdleControls}
-                      aria-label={t("taskDetail.chat.skills")}
-                      onClick={() => setSkillsDialogOpen(true)}
-                    >
-                      <IconPuzzle />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {canUseIdleControls
-                      ? t("taskDetail.chat.skills")
-                      : t("taskDetail.chat.skillsDisabledTooltip")}
-                  </TooltipContent>
-                </Tooltip>
-              )}
               {uploadedFiles.map((uploadedFile) => (
                 <TaskUploadedFileItem
                   key={uploadedFile.accessUrl}
@@ -1172,15 +1139,6 @@ export const TaskChatInputBox = React.forwardRef<TaskChatInputBoxHandle, TaskCha
           }
         }}
       />
-      {onSwitchAgentResources && (
-        <TaskSkillsUpdateDialog
-          open={skillsDialogOpen}
-          onOpenChange={setSkillsDialogOpen}
-          initialSkillIds={skillIds ?? []}
-          pluginIds={pluginIds ?? []}
-          onSwitch={onSwitchAgentResources}
-        />
-      )}
       <AlertDialog open={slashCommandConfirmOpen} onOpenChange={setSlashCommandConfirmOpen}>
         <AlertDialogContent onKeyDown={handleSlashCommandDialogKeyDown}>
           <AlertDialogHeader>

--- a/frontend/src/i18n/resources/cn.ts
+++ b/frontend/src/i18n/resources/cn.ts
@@ -4067,7 +4067,7 @@ const cn = {
       skillsDisabledTooltip: "任务空闲时才可以更新技能",
       skillsDialog: {
         title: "更新任务技能",
-        description: "勾选想在本任务里使用的技能，保存后 Agent 会用新的技能重启。",
+        description: "更新当前开发任务支持的 Skills，新勾选的 Skills 会下发到开发环境，取消勾选的 Skills 会从开发环境中删除。",
         empty: "暂无可用技能",
         save: "保存",
         toast: {

--- a/frontend/src/i18n/resources/en.ts
+++ b/frontend/src/i18n/resources/en.ts
@@ -4067,7 +4067,7 @@ const en = {
       skillsDisabledTooltip: "Skills can only be updated while the task is idle",
       skillsDialog: {
         title: "Update task skills",
-        description: "Select the skills to use for this task. The agent will restart with the new skill list after saving.",
+        description: "Update the Skills supported by the current development task. Newly selected Skills will be deployed to the development environment, and deselected Skills will be removed from the development environment.",
         empty: "No skills available",
         save: "Save",
         toast: {

--- a/frontend/src/pages/console/user/task/task-detail.tsx
+++ b/frontend/src/pages/console/user/task/task-detail.tsx
@@ -14,6 +14,7 @@ import { TaskPreviewPanel } from "@/components/console/task/task-preview-panel"
 import type { AvailableCommands, TaskPlan, TaskStreamStatus, TaskUserInput } from "@/components/console/task/task-shared"
 import { TaskStreamClient, type TaskStreamClientState, type TaskStreamCloseReason, type TaskStreamConnectionState } from "@/components/console/task/task-stream-client"
 import { TaskTerminalPanel } from "@/components/console/task/task-terminal-panel"
+import { TaskSkillsUpdateDialog } from "@/components/console/task/task-skills-update-dialog"
 import { TaskUserInputIndex } from "@/components/console/task/task-user-input-index"
 import { IS_OFFLINE_EDITION } from "@/utils/edition"
 import {
@@ -49,7 +50,7 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 import { canUseModelBySubscription, formatTokens, getBrandFromModel, getBuiltinModelName, getModelDisplayName, getOwnerTypeBadge, getTaskDisplayName, isBuiltinPublicModelPackage, stripBuiltinPublicModelPackagePrefix } from "@/utils/common"
 import { apiRequest } from "@/utils/requestUtils"
-import { IconChevronDown, IconDeviceDesktop, IconFile, IconReload, IconTerminal2, IconUpload } from "@tabler/icons-react"
+import { IconChevronDown, IconDeviceDesktop, IconFile, IconPuzzle, IconReload, IconTerminal2, IconUpload } from "@tabler/icons-react"
 import React from "react"
 import { useParams } from "react-router-dom"
 import { toast } from "sonner"
@@ -113,6 +114,7 @@ export default function TaskDetailPage() {
   const [restartAgentSubmitting, setRestartAgentSubmitting] = React.useState(false)
   const [restartAgentClearContext, setRestartAgentClearContext] = React.useState(false)
   const [publishConfirmDialogOpen, setPublishConfirmDialogOpen] = React.useState(false)
+  const [skillsDialogOpen, setSkillsDialogOpen] = React.useState(false)
   const [modelSwitchDialogOpen, setModelSwitchDialogOpen] = React.useState(false)
   const [modelSwitchSubmitting, setModelSwitchSubmitting] = React.useState(false)
   const [pendingSwitchModel, setPendingSwitchModel] = React.useState<DomainModel | null>(null)
@@ -1339,6 +1341,16 @@ export default function TaskDetailPage() {
             <Button
               variant="ghost"
               size="sm"
+              className="h-7 min-w-0 gap-1 px-2 text-sm font-normal"
+              onClick={() => setSkillsDialogOpen(true)}
+              disabled={!taskInteractive}
+            >
+              <IconPuzzle className="size-3.5" />
+              {t("taskDetail.chat.skills")}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
               className={cn("hidden h-7 min-w-0 gap-1 px-2 text-sm font-normal md:inline-flex", terminalPanelOpen && "text-primary bg-accent")}
               onClick={toggleTerminalPanel}
               disabled={!taskInteractive}
@@ -1538,9 +1550,6 @@ export default function TaskDetailPage() {
                         sending={sending}
                         queueSize={0}
                         executionTimeMs={timeCost}
-                        skillIds={task?.extra?.skill_ids ?? []}
-                        pluginIds={task?.extra?.plugin_ids ?? []}
-                        onSwitchAgentResources={handleSwitchAgentResources}
                       />
                     ) : (
                       <div className="flex items-center justify-center w-full border bg-muted/50 rounded-md p-2 text-xs text-muted-foreground">
@@ -1628,6 +1637,13 @@ export default function TaskDetailPage() {
           </DialogContent>
         </Dialog>
       )}
+      <TaskSkillsUpdateDialog
+        open={skillsDialogOpen}
+        onOpenChange={setSkillsDialogOpen}
+        initialSkillIds={task?.extra?.skill_ids ?? []}
+        pluginIds={task?.extra?.plugin_ids ?? []}
+        onSwitch={handleSwitchAgentResources}
+      />
     </div>
   )
 }


### PR DESCRIPTION
- 将技能按钮从 chat-inputbox 底栏移至 task-detail 页顶操作栏，位于终端按钮左边
- 更新技能选择对话框中英文描述文案
- 移除了 chat-inputbox 中不再需要的 skillIds/pluginIds/onSwitchAgentResources props