### PR TITLE
修复私有地址检测导致的 HTTP/2 协议错配

### DIFF
--- a/backend/pkg/netguard/guard.go
+++ b/backend/pkg/netguard/guard.go
@@ -89,18 +89,36 @@ func (g *Guard) HTTPClient(base *http.Client) *http.Client {
 }
 
 func (g *Guard) transport(base *http.Transport) http.RoundTripper {
+	forceHTTP2 := shouldForceHTTP2(base)
+
 	direct := base.Clone()
 	direct.Proxy = nil
 	direct.DialContext = g.dialContext
+	direct.ForceAttemptHTTP2 = forceHTTP2
 
 	proxied := base.Clone()
 	proxied.DialContext = g.dialContext
+	proxied.ForceAttemptHTTP2 = forceHTTP2
 	return &guardedTransport{
 		guard:   g,
 		base:    base,
 		direct:  direct,
 		proxied: proxied,
 	}
+}
+
+func shouldForceHTTP2(transport *http.Transport) bool {
+	if transport.ForceAttemptHTTP2 {
+		return true
+	}
+	if transport.Protocols != nil || transport.TLSNextProto != nil {
+		return false
+	}
+	return transport.TLSClientConfig == nil &&
+		transport.Dial == nil &&
+		transport.DialContext == nil &&
+		transport.DialTLS == nil &&
+		transport.DialTLSContext == nil
 }
 
 type validatingTransport struct {

--- a/backend/pkg/netguard/guard_test.go
+++ b/backend/pkg/netguard/guard_test.go
@@ -84,3 +84,33 @@ func TestHTTPClientBlocksPrivateProxy(t *testing.T) {
 		t.Fatalf("Do() error = %v, want ErrPrivateNetwork", err)
 	}
 }
+
+func TestHTTPClientPreservesAutomaticHTTP2(t *testing.T) {
+	client := New(true).HTTPClient(&http.Client{Transport: &http.Transport{}})
+	transport, ok := client.Transport.(*guardedTransport)
+	if !ok {
+		t.Fatalf("Transport type = %T, want *guardedTransport", client.Transport)
+	}
+	if !transport.direct.ForceAttemptHTTP2 {
+		t.Fatal("direct transport ForceAttemptHTTP2 = false")
+	}
+	if !transport.proxied.ForceAttemptHTTP2 {
+		t.Fatal("proxied transport ForceAttemptHTTP2 = false")
+	}
+}
+
+func TestHTTPClientPreservesDisabledHTTP2(t *testing.T) {
+	client := New(true).HTTPClient(&http.Client{Transport: &http.Transport{
+		DialContext: (&net.Dialer{}).DialContext,
+	}})
+	transport, ok := client.Transport.(*guardedTransport)
+	if !ok {
+		t.Fatalf("Transport type = %T, want *guardedTransport", client.Transport)
+	}
+	if transport.direct.ForceAttemptHTTP2 {
+		t.Fatal("direct transport ForceAttemptHTTP2 = true")
+	}
+	if transport.proxied.ForceAttemptHTTP2 {
+		t.Fatal("proxied transport ForceAttemptHTTP2 = true")
+	}
+}


### PR DESCRIPTION
## 问题

私有地址检测通过自定义 `DialContext` 固定 DNS 解析结果。包装自建 `http.Transport` 时，Go 不再自动启用 HTTP/2，但克隆后的 TLS 配置仍可能通过 ALPN 协商为 `h2`，导致客户端把 HTTP/2 SETTINGS 帧按 HTTP/1.x 响应解析并报 `malformed HTTP response`。

## 修改

- 在注入安全拨号器前识别 Transport 原有的 HTTP/2 自动启用行为
- 为直连和代理 Transport 显式保留该行为
- 尊重调用方原本通过自定义协议或拨号配置禁用 HTTP/2 的设置
- 增加启用与禁用场景的回归测试

## 测试

- `go test ./pkg/netguard ./biz/setting/usecase ./biz/team/usecase ./biz/llmproxy`
- `go test -race ./pkg/netguard`