### PR TITLE
修复：Agent 重启确认弹窗支持键盘方向键切换

### DIFF
--- a/docs/superpowers/plans/2026-07-22-agent-restart-dialog-keyboard.md
+++ b/docs/superpowers/plans/2026-07-22-agent-restart-dialog-keyboard.md
@@ -26,7 +26,7 @@
 - Modify: `frontend/src/pages/console/user/task/task-detail.tsx:20-28,111-140,974-997,1472-1506`
 
 **Interfaces:**
-- Consumes: `AlertDialogAction`, `AlertDialogCancel`, `React.KeyboardEvent<HTMLDivElement>`, and the existing `handleConfirmRestartAgent(): Promise<void>` callback.
+- Consumes: `AlertDialogCancel`, `Button`, `React.KeyboardEvent<HTMLDivElement>`, and the existing `handleConfirmRestartAgent(): Promise<void>` callback.
 - Produces: `handleRestartAgentDialogKeyDown(event: React.KeyboardEvent<HTMLDivElement>): void`, `restartAgentCancelRef`, and `restartAgentConfirmRef` within `TaskDetailPage`.
 
 - [x] **Step 1: Write the failing source regression test**
@@ -44,7 +44,6 @@ const pageSource = readFileSync(
 );
 
 test("Agent 重启确认弹窗支持左右方向键切换操作按钮", () => {
-  assert.match(pageSource, /AlertDialogAction,/);
   assert.match(pageSource, /const restartAgentCancelRef = React\.useRef<HTMLButtonElement>\(null\)/);
   assert.match(pageSource, /const restartAgentConfirmRef = React\.useRef<HTMLButtonElement>\(null\)/);
 
@@ -53,11 +52,15 @@ test("Agent 重启确认弹窗支持左右方向键切换操作按钮", () => {
   assert.notEqual(handlerStart, -1, "restart dialog should define an arrow-key handler");
   assert.notEqual(handlerEnd, -1, "restart handler should precede the confirm callback");
   const handlerSource = pageSource.slice(handlerStart, handlerEnd);
-  assert.match(handlerSource, /event\.key === "ArrowLeft"/);
-  assert.match(handlerSource, /event\.preventDefault\(\)/);
-  assert.match(handlerSource, /restartAgentCancelRef\.current\?\.focus\(\)/);
-  assert.match(handlerSource, /event\.key === "ArrowRight"/);
-  assert.match(handlerSource, /restartAgentConfirmRef\.current\?\.focus\(\)/);
+  const leftBranch = handlerSource.match(/if \(event\.key === "ArrowLeft"\) \{([\s\S]*?)\n    \}/);
+  const rightBranch = handlerSource.match(/if \(event\.key === "ArrowRight"\) \{([\s\S]*?)\n    \}/);
+  assert.ok(leftBranch, "restart handler should handle ArrowLeft");
+  assert.ok(rightBranch, "restart handler should handle ArrowRight");
+  assert.match(leftBranch[1], /event\.preventDefault\(\)/);
+  assert.match(leftBranch[1], /restartAgentCancelRef\.current\?\.focus\(\)/);
+  assert.match(rightBranch[1], /event\.preventDefault\(\)/);
+  assert.match(rightBranch[1], /restartAgentConfirmRef\.current\?\.focus\(\)/);
+  assert.doesNotMatch(handlerSource, /event\.key === "Enter"/);
 
   const dialogMatch = pageSource.match(
     /<AlertDialog\s+open=\{restartAgentDialogOpen\}[\s\S]*?<\/AlertDialog>/,
@@ -65,10 +68,13 @@ test("Agent 重启确认弹窗支持左右方向键切换操作按钮", () => {
   assert.ok(dialogMatch, "restart dialog should be present");
   assert.match(dialogMatch[0], /<AlertDialogContent onKeyDown=\{handleRestartAgentDialogKeyDown\}>/);
   assert.match(dialogMatch[0], /<AlertDialogCancel ref=\{restartAgentCancelRef\} disabled=\{restartAgentSubmitting\}>/);
-  assert.match(dialogMatch[0], /<AlertDialogAction[\s\S]*?ref=\{restartAgentConfirmRef\}/);
-  assert.match(dialogMatch[0], /void handleConfirmRestartAgent\(\)/);
-  assert.match(dialogMatch[0], /disabled=\{restartAgentSubmitting\}/);
-  assert.match(dialogMatch[0], /restartAgentSubmitting && <Spinner/);
+  assert.doesNotMatch(dialogMatch[0], /<AlertDialogAction/);
+  const confirmMatch = dialogMatch[0].match(/<Button\s+ref=\{restartAgentConfirmRef\}[\s\S]*?<\/Button>/);
+  assert.ok(confirmMatch, "restart confirm should remain a plain Button");
+  assert.match(confirmMatch[0], /type="button"/);
+  assert.match(confirmMatch[0], /void handleConfirmRestartAgent\(\)/);
+  assert.match(confirmMatch[0], /disabled=\{restartAgentSubmitting\}/);
+  assert.match(confirmMatch[0], /restartAgentSubmitting && <Spinner/);
 });
 ```
 
@@ -82,24 +88,9 @@ node --test test/task-restart-dialog-keyboard.test.mjs
 
 Working directory: `frontend`
 
-Expected: FAIL on the missing `AlertDialogAction` import, refs, or handler.
+Expected: FAIL on the missing refs or keyboard handler.
 
 - [x] **Step 3: Implement the minimal dialog behavior**
-
-Add `AlertDialogAction` to the existing alert-dialog import:
-
-```typescript
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
-```
 
 Add the action refs beside the existing page refs:
 
@@ -139,11 +130,12 @@ Replace the restart Cancel action with:
 </AlertDialogCancel>
 ```
 
-Replace the restart Confirm action with:
+Attach the ref to the existing restart Confirm button:
 
 ```tsx
-<AlertDialogAction
+<Button
   ref={restartAgentConfirmRef}
+  type="button"
   onClick={() => {
     void handleConfirmRestartAgent()
   }}
@@ -151,7 +143,7 @@ Replace the restart Confirm action with:
 >
   {restartAgentSubmitting && <Spinner className="mr-2 size-4" />}
   {t("taskDetail.page.dialogs.confirm")}
-</AlertDialogAction>
+</Button>
 ```
 
 - [x] **Step 4: Run the focused test and verify success**
@@ -190,7 +182,7 @@ Working directory: `frontend`
 
 Expected: TypeScript and Vite build complete successfully.
 
-- [ ] **Step 7: Review and commit the implementation**
+- [x] **Step 7: Review and commit the implementation**
 
 Review:
 
@@ -206,7 +198,7 @@ git add frontend/src/pages/console/user/task/task-detail.tsx frontend/test/task-
 git commit -m "fix(frontend): support keyboard navigation in restart dialog"
 ```
 
-Expected: one implementation commit containing only the dialog behavior and its regression test.
+Expected: one implementation commit containing the dialog behavior, regression test, and execution-plan status updates.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-22-agent-restart-dialog-keyboard.md
+++ b/docs/superpowers/plans/2026-07-22-agent-restart-dialog-keyboard.md
@@ -211,7 +211,7 @@ Expected: one implementation commit containing the dialog behavior, regression t
 - Consumes: the completed Issue #910 branch build.
 - Produces: a local preview URL for manual acceptance testing.
 
-- [ ] **Step 1: Start the project with the deploy-website skill**
+- [x] **Step 1: Start the project with the deploy-website skill**
 
 Start the frontend and required backend services from the Issue #910 worktree using the repository's existing development commands and proxy configuration.
 

--- a/docs/superpowers/plans/2026-07-22-agent-restart-dialog-keyboard.md
+++ b/docs/superpowers/plans/2026-07-22-agent-restart-dialog-keyboard.md
@@ -22,18 +22,18 @@
 ### Task 1: Agent Restart Dialog Keyboard Navigation
 
 **Files:**
-- Create: `frontend/test/task-restart-dialog-keyboard.test.ts`
+- Create: `frontend/test/task-restart-dialog-keyboard.test.mjs`
 - Modify: `frontend/src/pages/console/user/task/task-detail.tsx:20-28,111-140,974-997,1472-1506`
 
 **Interfaces:**
 - Consumes: `AlertDialogAction`, `AlertDialogCancel`, `React.KeyboardEvent<HTMLDivElement>`, and the existing `handleConfirmRestartAgent(): Promise<void>` callback.
 - Produces: `handleRestartAgentDialogKeyDown(event: React.KeyboardEvent<HTMLDivElement>): void`, `restartAgentCancelRef`, and `restartAgentConfirmRef` within `TaskDetailPage`.
 
-- [ ] **Step 1: Write the failing source regression test**
+- [x] **Step 1: Write the failing source regression test**
 
-Create `frontend/test/task-restart-dialog-keyboard.test.ts`:
+Create `frontend/test/task-restart-dialog-keyboard.test.mjs`:
 
-```typescript
+```javascript
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
@@ -72,19 +72,19 @@ test("Agent 重启确认弹窗支持左右方向键切换操作按钮", () => {
 });
 ```
 
-- [ ] **Step 2: Run the focused test and verify the expected failure**
+- [x] **Step 2: Run the focused test and verify the expected failure**
 
 Run:
 
 ```bash
-node --experimental-strip-types --test test/task-restart-dialog-keyboard.test.ts
+node --test test/task-restart-dialog-keyboard.test.mjs
 ```
 
 Working directory: `frontend`
 
 Expected: FAIL on the missing `AlertDialogAction` import, refs, or handler.
 
-- [ ] **Step 3: Implement the minimal dialog behavior**
+- [x] **Step 3: Implement the minimal dialog behavior**
 
 Add `AlertDialogAction` to the existing alert-dialog import:
 
@@ -154,31 +154,31 @@ Replace the restart Confirm action with:
 </AlertDialogAction>
 ```
 
-- [ ] **Step 4: Run the focused test and verify success**
+- [x] **Step 4: Run the focused test and verify success**
 
 Run:
 
 ```bash
-node --experimental-strip-types --test test/task-restart-dialog-keyboard.test.ts
+node --test test/task-restart-dialog-keyboard.test.mjs
 ```
 
 Working directory: `frontend`
 
 Expected: 1 test passes and 0 tests fail.
 
-- [ ] **Step 5: Run targeted lint**
+- [x] **Step 5: Run targeted lint**
 
 Run:
 
 ```bash
-pnpm exec eslint src/pages/console/user/task/task-detail.tsx test/task-restart-dialog-keyboard.test.ts
+pnpm exec eslint src/pages/console/user/task/task-detail.tsx test/task-restart-dialog-keyboard.test.mjs
 ```
 
 Working directory: `frontend`
 
 Expected: exit code 0 with no lint errors.
 
-- [ ] **Step 6: Run the online frontend build**
+- [x] **Step 6: Run the online frontend build**
 
 Run:
 
@@ -196,13 +196,13 @@ Review:
 
 ```bash
 git diff --check
-git diff -- frontend/src/pages/console/user/task/task-detail.tsx frontend/test/task-restart-dialog-keyboard.test.ts
+git diff -- frontend/src/pages/console/user/task/task-detail.tsx frontend/test/task-restart-dialog-keyboard.test.mjs
 ```
 
 Commit:
 
 ```bash
-git add frontend/src/pages/console/user/task/task-detail.tsx frontend/test/task-restart-dialog-keyboard.test.ts
+git add frontend/src/pages/console/user/task/task-detail.tsx frontend/test/task-restart-dialog-keyboard.test.mjs
 git commit -m "fix(frontend): support keyboard navigation in restart dialog"
 ```
 

--- a/docs/superpowers/plans/2026-07-22-agent-restart-dialog-keyboard.md
+++ b/docs/superpowers/plans/2026-07-22-agent-restart-dialog-keyboard.md
@@ -217,7 +217,7 @@ Start the frontend and required backend services from the Issue #910 worktree us
 
 Expected: the preview URL responds successfully and the task page loads.
 
-- [ ] **Step 2: Verify both restart modes manually**
+- [x] **Step 2: Verify both restart modes manually**
 
 For “Restart Agent” and “Restart Agent and clear context”:
 

--- a/docs/superpowers/plans/2026-07-22-agent-restart-dialog-keyboard.md
+++ b/docs/superpowers/plans/2026-07-22-agent-restart-dialog-keyboard.md
@@ -1,0 +1,238 @@
+# Agent Restart Dialog Keyboard Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add left and right arrow focus navigation to both Agent restart confirmation modes tracked by Issue #910.
+
+**Architecture:** Keep the behavior local to `TaskDetailPage` and mirror the slash-command dialog implementation from PR #863. Add source-level regression coverage using the repository's existing Node test pattern, then verify lint, TypeScript, and the online Vite build.
+
+**Tech Stack:** React 19, TypeScript 5.9, Radix AlertDialog, Node `node:test`, ESLint 9, Vite 7
+
+## Global Constraints
+
+- `ArrowLeft` focuses Cancel and prevents the default action.
+- `ArrowRight` focuses Confirm and prevents the default action.
+- `Enter` keeps the native behavior of the focused action.
+- `Tab`, `Shift+Tab`, and `Escape` continue to use Radix AlertDialog behavior.
+- The restart request, loading state, close behavior, copy, and visual layout remain unchanged.
+- Shared UI primitives and unrelated dialogs remain unchanged.
+
+---
+
+### Task 1: Agent Restart Dialog Keyboard Navigation
+
+**Files:**
+- Create: `frontend/test/task-restart-dialog-keyboard.test.ts`
+- Modify: `frontend/src/pages/console/user/task/task-detail.tsx:20-28,111-140,974-997,1472-1506`
+
+**Interfaces:**
+- Consumes: `AlertDialogAction`, `AlertDialogCancel`, `React.KeyboardEvent<HTMLDivElement>`, and the existing `handleConfirmRestartAgent(): Promise<void>` callback.
+- Produces: `handleRestartAgentDialogKeyDown(event: React.KeyboardEvent<HTMLDivElement>): void`, `restartAgentCancelRef`, and `restartAgentConfirmRef` within `TaskDetailPage`.
+
+- [ ] **Step 1: Write the failing source regression test**
+
+Create `frontend/test/task-restart-dialog-keyboard.test.ts`:
+
+```typescript
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const pageSource = readFileSync(
+  new URL("../src/pages/console/user/task/task-detail.tsx", import.meta.url),
+  "utf8",
+);
+
+test("Agent 重启确认弹窗支持左右方向键切换操作按钮", () => {
+  assert.match(pageSource, /AlertDialogAction,/);
+  assert.match(pageSource, /const restartAgentCancelRef = React\.useRef<HTMLButtonElement>\(null\)/);
+  assert.match(pageSource, /const restartAgentConfirmRef = React\.useRef<HTMLButtonElement>\(null\)/);
+
+  const handlerStart = pageSource.indexOf("const handleRestartAgentDialogKeyDown");
+  const handlerEnd = pageSource.indexOf("const handleConfirmRestartAgent", handlerStart);
+  assert.notEqual(handlerStart, -1, "restart dialog should define an arrow-key handler");
+  assert.notEqual(handlerEnd, -1, "restart handler should precede the confirm callback");
+  const handlerSource = pageSource.slice(handlerStart, handlerEnd);
+  assert.match(handlerSource, /event\.key === "ArrowLeft"/);
+  assert.match(handlerSource, /event\.preventDefault\(\)/);
+  assert.match(handlerSource, /restartAgentCancelRef\.current\?\.focus\(\)/);
+  assert.match(handlerSource, /event\.key === "ArrowRight"/);
+  assert.match(handlerSource, /restartAgentConfirmRef\.current\?\.focus\(\)/);
+
+  const dialogMatch = pageSource.match(
+    /<AlertDialog\s+open=\{restartAgentDialogOpen\}[\s\S]*?<\/AlertDialog>/,
+  );
+  assert.ok(dialogMatch, "restart dialog should be present");
+  assert.match(dialogMatch[0], /<AlertDialogContent onKeyDown=\{handleRestartAgentDialogKeyDown\}>/);
+  assert.match(dialogMatch[0], /<AlertDialogCancel ref=\{restartAgentCancelRef\} disabled=\{restartAgentSubmitting\}>/);
+  assert.match(dialogMatch[0], /<AlertDialogAction[\s\S]*?ref=\{restartAgentConfirmRef\}/);
+  assert.match(dialogMatch[0], /void handleConfirmRestartAgent\(\)/);
+  assert.match(dialogMatch[0], /disabled=\{restartAgentSubmitting\}/);
+  assert.match(dialogMatch[0], /restartAgentSubmitting && <Spinner/);
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify the expected failure**
+
+Run:
+
+```bash
+node --experimental-strip-types --test test/task-restart-dialog-keyboard.test.ts
+```
+
+Working directory: `frontend`
+
+Expected: FAIL on the missing `AlertDialogAction` import, refs, or handler.
+
+- [ ] **Step 3: Implement the minimal dialog behavior**
+
+Add `AlertDialogAction` to the existing alert-dialog import:
+
+```typescript
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+```
+
+Add the action refs beside the existing page refs:
+
+```typescript
+const restartAgentCancelRef = React.useRef<HTMLButtonElement>(null)
+const restartAgentConfirmRef = React.useRef<HTMLButtonElement>(null)
+```
+
+Add the keydown handler beside the existing restart callbacks:
+
+```typescript
+const handleRestartAgentDialogKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+  if (event.key === "ArrowLeft") {
+    event.preventDefault()
+    restartAgentCancelRef.current?.focus()
+    return
+  }
+
+  if (event.key === "ArrowRight") {
+    event.preventDefault()
+    restartAgentConfirmRef.current?.focus()
+  }
+}
+```
+
+Add the handler to the Agent restart dialog content:
+
+```tsx
+<AlertDialogContent onKeyDown={handleRestartAgentDialogKeyDown}>
+```
+
+Replace the restart Cancel action with:
+
+```tsx
+<AlertDialogCancel ref={restartAgentCancelRef} disabled={restartAgentSubmitting}>
+  {t("taskDetail.common.cancel")}
+</AlertDialogCancel>
+```
+
+Replace the restart Confirm action with:
+
+```tsx
+<AlertDialogAction
+  ref={restartAgentConfirmRef}
+  onClick={() => {
+    void handleConfirmRestartAgent()
+  }}
+  disabled={restartAgentSubmitting}
+>
+  {restartAgentSubmitting && <Spinner className="mr-2 size-4" />}
+  {t("taskDetail.page.dialogs.confirm")}
+</AlertDialogAction>
+```
+
+- [ ] **Step 4: Run the focused test and verify success**
+
+Run:
+
+```bash
+node --experimental-strip-types --test test/task-restart-dialog-keyboard.test.ts
+```
+
+Working directory: `frontend`
+
+Expected: 1 test passes and 0 tests fail.
+
+- [ ] **Step 5: Run targeted lint**
+
+Run:
+
+```bash
+pnpm exec eslint src/pages/console/user/task/task-detail.tsx test/task-restart-dialog-keyboard.test.ts
+```
+
+Working directory: `frontend`
+
+Expected: exit code 0 with no lint errors.
+
+- [ ] **Step 6: Run the online frontend build**
+
+Run:
+
+```bash
+pnpm run build:online
+```
+
+Working directory: `frontend`
+
+Expected: TypeScript and Vite build complete successfully.
+
+- [ ] **Step 7: Review and commit the implementation**
+
+Review:
+
+```bash
+git diff --check
+git diff -- frontend/src/pages/console/user/task/task-detail.tsx frontend/test/task-restart-dialog-keyboard.test.ts
+```
+
+Commit:
+
+```bash
+git add frontend/src/pages/console/user/task/task-detail.tsx frontend/test/task-restart-dialog-keyboard.test.ts
+git commit -m "fix(frontend): support keyboard navigation in restart dialog"
+```
+
+Expected: one implementation commit containing only the dialog behavior and its regression test.
+
+---
+
+### Task 2: Manual Preview Verification
+
+**Files:**
+- Modify: none
+
+**Interfaces:**
+- Consumes: the completed Issue #910 branch build.
+- Produces: a local preview URL for manual acceptance testing.
+
+- [ ] **Step 1: Start the project with the deploy-website skill**
+
+Start the frontend and required backend services from the Issue #910 worktree using the repository's existing development commands and proxy configuration.
+
+Expected: the preview URL responds successfully and the task page loads.
+
+- [ ] **Step 2: Verify both restart modes manually**
+
+For “Restart Agent” and “Restart Agent and clear context”:
+
+1. Open the confirmation dialog.
+2. Press `ArrowLeft` and verify Cancel receives focus.
+3. Press `ArrowRight` and verify Confirm receives focus.
+4. Press `Enter` and verify the focused action executes.
+5. Reopen the dialog, press `Escape`, and verify it closes.
+
+Expected: both restart modes satisfy Issue #910 without changing loading, disabled, or close behavior.

--- a/docs/superpowers/specs/2026-07-22-agent-restart-dialog-keyboard-design.md
+++ b/docs/superpowers/specs/2026-07-22-agent-restart-dialog-keyboard-design.md
@@ -1,0 +1,49 @@
+# Agent Restart Dialog Keyboard Navigation Design
+
+## Context
+
+Issue #910 reports that the Agent restart confirmation dialog cannot move focus between its Cancel and Confirm actions with the left and right arrow keys. Issue #862 and PR #863 established the expected behavior for the equivalent slash-command confirmation dialog.
+
+## Scope
+
+Apply the existing slash-command dialog keyboard interaction to both Agent restart modes:
+
+- Restart Agent while preserving context.
+- Restart Agent and clear context.
+
+The restart request, loading state, close behavior, copy, and visual layout remain unchanged.
+
+## Interaction Design
+
+The restart dialog owns refs for its Cancel and Confirm actions. A keydown handler on `AlertDialogContent` implements these transitions:
+
+- `ArrowLeft` prevents the default action and focuses Cancel.
+- `ArrowRight` prevents the default action and focuses Confirm.
+- `Enter` keeps the native behavior of the focused action.
+- `Tab`, `Shift+Tab`, and `Escape` continue to use Radix AlertDialog behavior.
+
+The Confirm control uses `AlertDialogAction`, matching the slash-command confirmation dialog and preserving the existing async click handler and disabled state.
+
+## Implementation
+
+Modify `frontend/src/pages/console/user/task/task-detail.tsx`:
+
+1. Add refs for the restart Cancel and Confirm actions.
+2. Add a restart-dialog keydown handler beside the existing restart callbacks.
+3. Attach the handler to the restart `AlertDialogContent`.
+4. Attach the refs to both actions.
+5. Replace the restart Confirm `Button` with `AlertDialogAction`.
+
+No shared UI primitive changes or unrelated dialog refactors are included.
+
+## Verification
+
+Add a focused regression test that verifies:
+
+- The restart dialog binds its keydown handler.
+- `ArrowLeft` focuses Cancel and prevents the default action.
+- `ArrowRight` focuses Confirm and prevents the default action.
+- Both controls expose refs and Confirm uses `AlertDialogAction`.
+- The existing restart callback, submitting guard, spinner, and disabled state remain present.
+
+Run the focused test, frontend lint for changed files, and the online frontend build. Start a preview from the issue branch for manual verification of both restart modes.

--- a/docs/superpowers/specs/2026-07-22-agent-restart-dialog-keyboard-design.md
+++ b/docs/superpowers/specs/2026-07-22-agent-restart-dialog-keyboard-design.md
@@ -22,7 +22,7 @@ The restart dialog owns refs for its Cancel and Confirm actions. A keydown handl
 - `Enter` keeps the native behavior of the focused action.
 - `Tab`, `Shift+Tab`, and `Escape` continue to use Radix AlertDialog behavior.
 
-The Confirm control uses `AlertDialogAction`, matching the slash-command confirmation dialog and preserving the existing async click handler and disabled state.
+The Confirm control remains a plain `Button`, preserving the existing behavior where the dialog closes only after a successful asynchronous restart. Both controls expose refs for focus navigation.
 
 ## Implementation
 
@@ -32,7 +32,7 @@ Modify `frontend/src/pages/console/user/task/task-detail.tsx`:
 2. Add a restart-dialog keydown handler beside the existing restart callbacks.
 3. Attach the handler to the restart `AlertDialogContent`.
 4. Attach the refs to both actions.
-5. Replace the restart Confirm `Button` with `AlertDialogAction`.
+5. Attach the Confirm ref to the existing `Button`.
 
 No shared UI primitive changes or unrelated dialog refactors are included.
 
@@ -43,7 +43,7 @@ Add a focused regression test that verifies:
 - The restart dialog binds its keydown handler.
 - `ArrowLeft` focuses Cancel and prevents the default action.
 - `ArrowRight` focuses Confirm and prevents the default action.
-- Both controls expose refs and Confirm uses `AlertDialogAction`.
+- Both controls expose refs and Confirm remains a plain `Button`.
 - The existing restart callback, submitting guard, spinner, and disabled state remain present.
 
 Run the focused test, frontend lint for changed files, and the online frontend build. Start a preview from the issue branch for manual verification of both restart modes.

--- a/frontend/src/pages/console/user/task/task-detail.tsx
+++ b/frontend/src/pages/console/user/task/task-detail.tsx
@@ -19,6 +19,7 @@ import { TaskUserInputIndex } from "@/components/console/task/task-user-input-in
 import { IS_OFFLINE_EDITION } from "@/utils/edition"
 import {
   AlertDialog,
+  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -126,6 +127,8 @@ export default function TaskDetailPage() {
   const historyLoadedRef = React.useRef(false)
   const chatScrollRef = React.useRef<HTMLDivElement | null>(null)
   const chatInputRef = React.useRef<TaskChatInputBoxHandle>(null)
+  const restartAgentCancelRef = React.useRef<HTMLButtonElement>(null)
+  const restartAgentConfirmRef = React.useRef<HTMLButtonElement>(null)
   const chatContentRef = React.useRef<HTMLDivElement | null>(null)
   const taskMessageListRef = React.useRef<TaskMessageVirtualListHandle | null>(null)
   const taskFileExplorerRef = React.useRef<TaskFileExplorerHandle | null>(null)
@@ -1004,6 +1007,19 @@ export default function TaskDetailPage() {
     setRestartAgentDialogOpen(true)
   }, [canInput])
 
+  const handleRestartAgentDialogKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "ArrowLeft") {
+      event.preventDefault()
+      restartAgentCancelRef.current?.focus()
+      return
+    }
+
+    if (event.key === "ArrowRight") {
+      event.preventDefault()
+      restartAgentConfirmRef.current?.focus()
+    }
+  }
+
   const handleConfirmRestartAgent = React.useCallback(async () => {
     if (restartAgentSubmitting) return
 
@@ -1469,7 +1485,7 @@ export default function TaskDetailPage() {
           setRestartAgentDialogOpen(open)
         }}
       >
-        <AlertDialogContent>
+        <AlertDialogContent onKeyDown={handleRestartAgentDialogKeyDown}>
           <AlertDialogHeader>
             <AlertDialogTitle>
               {restartAgentClearContext
@@ -1483,9 +1499,9 @@ export default function TaskDetailPage() {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={restartAgentSubmitting}>{t("taskDetail.common.cancel")}</AlertDialogCancel>
-            <Button
-              type="button"
+            <AlertDialogCancel ref={restartAgentCancelRef} disabled={restartAgentSubmitting}>{t("taskDetail.common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              ref={restartAgentConfirmRef}
               onClick={() => {
                 void handleConfirmRestartAgent()
               }}
@@ -1493,7 +1509,7 @@ export default function TaskDetailPage() {
             >
               {restartAgentSubmitting && <Spinner className="mr-2 size-4" />}
               {t("taskDetail.page.dialogs.confirm")}
-            </Button>
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/frontend/src/pages/console/user/task/task-detail.tsx
+++ b/frontend/src/pages/console/user/task/task-detail.tsx
@@ -19,7 +19,6 @@ import { TaskUserInputIndex } from "@/components/console/task/task-user-input-in
 import { IS_OFFLINE_EDITION } from "@/utils/edition"
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -1500,8 +1499,9 @@ export default function TaskDetailPage() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel ref={restartAgentCancelRef} disabled={restartAgentSubmitting}>{t("taskDetail.common.cancel")}</AlertDialogCancel>
-            <AlertDialogAction
+            <Button
               ref={restartAgentConfirmRef}
+              type="button"
               onClick={() => {
                 void handleConfirmRestartAgent()
               }}
@@ -1509,7 +1509,7 @@ export default function TaskDetailPage() {
             >
               {restartAgentSubmitting && <Spinner className="mr-2 size-4" />}
               {t("taskDetail.page.dialogs.confirm")}
-            </AlertDialogAction>
+            </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/frontend/test/task-restart-dialog-keyboard.test.mjs
+++ b/frontend/test/task-restart-dialog-keyboard.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const pageSource = readFileSync(
+  new URL("../src/pages/console/user/task/task-detail.tsx", import.meta.url),
+  "utf8",
+);
+
+test("Agent 重启确认弹窗支持左右方向键切换操作按钮", () => {
+  assert.match(pageSource, /AlertDialogAction,/);
+  assert.match(pageSource, /const restartAgentCancelRef = React\.useRef<HTMLButtonElement>\(null\)/);
+  assert.match(pageSource, /const restartAgentConfirmRef = React\.useRef<HTMLButtonElement>\(null\)/);
+
+  const handlerStart = pageSource.indexOf("const handleRestartAgentDialogKeyDown");
+  const handlerEnd = pageSource.indexOf("const handleConfirmRestartAgent", handlerStart);
+  assert.notEqual(handlerStart, -1, "restart dialog should define an arrow-key handler");
+  assert.notEqual(handlerEnd, -1, "restart handler should precede the confirm callback");
+  const handlerSource = pageSource.slice(handlerStart, handlerEnd);
+  assert.match(handlerSource, /event\.key === "ArrowLeft"/);
+  assert.match(handlerSource, /event\.preventDefault\(\)/);
+  assert.match(handlerSource, /restartAgentCancelRef\.current\?\.focus\(\)/);
+  assert.match(handlerSource, /event\.key === "ArrowRight"/);
+  assert.match(handlerSource, /restartAgentConfirmRef\.current\?\.focus\(\)/);
+
+  const dialogMatch = pageSource.match(
+    /<AlertDialog\s+open=\{restartAgentDialogOpen\}[\s\S]*?<\/AlertDialog>/,
+  );
+  assert.ok(dialogMatch, "restart dialog should be present");
+  assert.match(dialogMatch[0], /<AlertDialogContent onKeyDown=\{handleRestartAgentDialogKeyDown\}>/);
+  assert.match(dialogMatch[0], /<AlertDialogCancel ref=\{restartAgentCancelRef\} disabled=\{restartAgentSubmitting\}>/);
+  assert.match(dialogMatch[0], /<AlertDialogAction[\s\S]*?ref=\{restartAgentConfirmRef\}/);
+  assert.match(dialogMatch[0], /void handleConfirmRestartAgent\(\)/);
+  assert.match(dialogMatch[0], /disabled=\{restartAgentSubmitting\}/);
+  assert.match(dialogMatch[0], /restartAgentSubmitting && <Spinner/);
+});

--- a/frontend/test/task-restart-dialog-keyboard.test.mjs
+++ b/frontend/test/task-restart-dialog-keyboard.test.mjs
@@ -8,7 +8,6 @@ const pageSource = readFileSync(
 );
 
 test("Agent 重启确认弹窗支持左右方向键切换操作按钮", () => {
-  assert.match(pageSource, /AlertDialogAction,/);
   assert.match(pageSource, /const restartAgentCancelRef = React\.useRef<HTMLButtonElement>\(null\)/);
   assert.match(pageSource, /const restartAgentConfirmRef = React\.useRef<HTMLButtonElement>\(null\)/);
 
@@ -17,11 +16,15 @@ test("Agent 重启确认弹窗支持左右方向键切换操作按钮", () => {
   assert.notEqual(handlerStart, -1, "restart dialog should define an arrow-key handler");
   assert.notEqual(handlerEnd, -1, "restart handler should precede the confirm callback");
   const handlerSource = pageSource.slice(handlerStart, handlerEnd);
-  assert.match(handlerSource, /event\.key === "ArrowLeft"/);
-  assert.match(handlerSource, /event\.preventDefault\(\)/);
-  assert.match(handlerSource, /restartAgentCancelRef\.current\?\.focus\(\)/);
-  assert.match(handlerSource, /event\.key === "ArrowRight"/);
-  assert.match(handlerSource, /restartAgentConfirmRef\.current\?\.focus\(\)/);
+  const leftBranch = handlerSource.match(/if \(event\.key === "ArrowLeft"\) \{([\s\S]*?)\n    \}/);
+  const rightBranch = handlerSource.match(/if \(event\.key === "ArrowRight"\) \{([\s\S]*?)\n    \}/);
+  assert.ok(leftBranch, "restart handler should handle ArrowLeft");
+  assert.ok(rightBranch, "restart handler should handle ArrowRight");
+  assert.match(leftBranch[1], /event\.preventDefault\(\)/);
+  assert.match(leftBranch[1], /restartAgentCancelRef\.current\?\.focus\(\)/);
+  assert.match(rightBranch[1], /event\.preventDefault\(\)/);
+  assert.match(rightBranch[1], /restartAgentConfirmRef\.current\?\.focus\(\)/);
+  assert.doesNotMatch(handlerSource, /event\.key === "Enter"/);
 
   const dialogMatch = pageSource.match(
     /<AlertDialog\s+open=\{restartAgentDialogOpen\}[\s\S]*?<\/AlertDialog>/,
@@ -29,8 +32,11 @@ test("Agent 重启确认弹窗支持左右方向键切换操作按钮", () => {
   assert.ok(dialogMatch, "restart dialog should be present");
   assert.match(dialogMatch[0], /<AlertDialogContent onKeyDown=\{handleRestartAgentDialogKeyDown\}>/);
   assert.match(dialogMatch[0], /<AlertDialogCancel ref=\{restartAgentCancelRef\} disabled=\{restartAgentSubmitting\}>/);
-  assert.match(dialogMatch[0], /<AlertDialogAction[\s\S]*?ref=\{restartAgentConfirmRef\}/);
-  assert.match(dialogMatch[0], /void handleConfirmRestartAgent\(\)/);
-  assert.match(dialogMatch[0], /disabled=\{restartAgentSubmitting\}/);
-  assert.match(dialogMatch[0], /restartAgentSubmitting && <Spinner/);
+  assert.doesNotMatch(dialogMatch[0], /<AlertDialogAction/);
+  const confirmMatch = dialogMatch[0].match(/<Button\s+ref=\{restartAgentConfirmRef\}[\s\S]*?<\/Button>/);
+  assert.ok(confirmMatch, "restart confirm should remain a plain Button");
+  assert.match(confirmMatch[0], /type="button"/);
+  assert.match(confirmMatch[0], /void handleConfirmRestartAgent\(\)/);
+  assert.match(confirmMatch[0], /disabled=\{restartAgentSubmitting\}/);
+  assert.match(confirmMatch[0], /restartAgentSubmitting && <Spinner/);
 });


### PR DESCRIPTION
## 变更说明

- 为 Agent 重启确认弹窗增加左右方向键焦点切换
- “重启 Agent”和“重启 Agent 并清空上下文”两种模式使用一致的键盘交互
- 保留异步提交、提交期间禁用、成功后关闭和失败后保留弹窗的原有行为
- 增加定向回归测试、设计说明和实施记录

## 解决的问题

- 按 `ArrowLeft` 聚焦“取消”按钮
- 按 `ArrowRight` 聚焦“确认”按钮
- 按 `Enter` 执行当前获得焦点的操作
- 保持 `Escape` 关闭弹窗和 `Tab` 焦点圈定行为

## 历史兼容性

- 交互模式与 PR #863 中内部指令确认弹窗的方向键导航保持一致
- Agent 重启确认按钮继续使用普通 `Button`，确保请求失败时弹窗保持打开并允许重试

## 验证结果

- `node --test test/task-restart-dialog-keyboard.test.mjs`
- `pnpm exec eslint src/pages/console/user/task/task-detail.tsx test/task-restart-dialog-keyboard.test.mjs`
- `pnpm run build:online`
- 已在登录态下人工验证两种重启模式的 `ArrowLeft`、`ArrowRight`、`Enter` 和 `Escape` 行为
- 测试环境：https://4227-e84020e6e952be3c.monkeycode-ai.online

Fixes #910