### PR TITLE
修复英文界面长文案布局溢出

### DIFF
--- a/frontend/src/components/console/nav/free-model-usage-indicator.tsx
+++ b/frontend/src/components/console/nav/free-model-usage-indicator.tsx
@@ -109,7 +109,7 @@ export function RewardsBalanceIndicator() {
       <HoverCardContent
         side="bottom"
         align="end"
-        className="w-80"
+        className="w-96 max-w-[calc(100vw-2rem)]"
       >
         <div className="space-y-4">
           <section className="rounded-lg border bg-muted/20 p-3 text-sm">
@@ -163,9 +163,9 @@ export function RewardsBalanceIndicator() {
 
           <section className="space-y-3">
             <div className="rounded-lg border bg-muted/20 p-3">
-              <div className="flex items-center justify-between gap-3 text-sm">
-                <span className="truncate font-medium">{t("consoleShell.rewards.quota.freeQuota")}</span>
-                <span className="text-xs text-muted-foreground">
+              <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-sm">
+                <span className="shrink-0 font-medium">{t("consoleShell.rewards.quota.freeQuota")}</span>
+                <span className="ml-auto shrink-0 whitespace-nowrap text-right text-xs text-muted-foreground">
                   {tokenLimit > 0 ? t("consoleShell.rewards.quota.remainingToday", { amount: quotaAmountLabel }) : t("consoleShell.rewards.quota.noQuota")}
                 </span>
               </div>

--- a/frontend/src/components/mode-toggle.tsx
+++ b/frontend/src/components/mode-toggle.tsx
@@ -23,7 +23,7 @@ export function ModeToggle() {
           <span className="sr-only">{t("common.theme.toggle")}</span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent align="end" className="w-max min-w-40">
         <DropdownMenuItem onClick={() => setTheme("light")}>
           <Sun />
           {t("common.theme.light")}

--- a/frontend/test/console-nav-rewards-i18n.test.ts
+++ b/frontend/test/console-nav-rewards-i18n.test.ts
@@ -67,3 +67,10 @@ test("侧边栏在线权益入口提供中英文资源", () => {
   assert.match(en.consoleShell.rewards.feedback.template, /\{\{uid\}\}/);
   assert.equal(cn.consoleShell.rewards.feedback.description, "到 MonkeyCode 的 GitHub 提 Issue，并留下你的 UID。\nIssue 被采纳后你将获得 3 万积分的奖励。");
 });
+
+test("权益浮层可容纳英文长文案", () => {
+  assert.match(sourceFiles.freeModelUsage, /className="w-96 max-w-\[calc\(100vw-2rem\)\]"/);
+  assert.match(sourceFiles.freeModelUsage, /className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-sm"/);
+  assert.match(sourceFiles.freeModelUsage, /className="shrink-0 font-medium"/);
+  assert.match(sourceFiles.freeModelUsage, /className="ml-auto shrink-0 whitespace-nowrap text-right text-xs text-muted-foreground"/);
+});

--- a/frontend/test/mode-toggle-i18n.test.ts
+++ b/frontend/test/mode-toggle-i18n.test.ts
@@ -22,3 +22,7 @@ test("主题切换菜单提供中英文资源", () => {
   assert.equal(cn.common.theme.system, "跟随系统");
   assert.equal(en.common.theme.system, "Follow system");
 });
+
+test("主题切换菜单可容纳英文长文案", () => {
+  assert.match(source, /<DropdownMenuContent align="end" className="w-max min-w-40">/);
+});


### PR DESCRIPTION
## 变更内容

- 主题切换菜单根据内容自适应宽度，避免 `Light mode`、`Follow system` 换行溢出
- 扩大会员权益浮层的可用宽度，并让配额标题和数值在空间不足时按完整内容换行
- 增加英文长文案布局回归测试

## 验证

- `node --experimental-strip-types --test test/mode-toggle-i18n.test.ts test/console-nav-rewards-i18n.test.ts`：6 条测试全部通过
- 涉及文件 ESLint 检查通过
- `pnpm build` 生产构建通过
- 前端全量测试 252/260 通过；其余 8 项与最新 `main` 的失败项完全一致，不是本次改动引入
