### PR TITLE
适配 Taskflow 水平扩展协议

### DIFF
--- a/backend/pkg/request/ops.go
+++ b/backend/pkg/request/ops.go
@@ -35,7 +35,12 @@ func WithTransport(tr *http.Transport) ReqOpt {
 // WithHeader 设置请求头
 func WithHeader(h Header) Opt {
 	return func(ctx *Ctx) {
-		ctx.header = h
+		if ctx.header == nil {
+			ctx.header = make(Header, len(h))
+		}
+		for k, v := range h {
+			ctx.header[k] = v
+		}
 	}
 }
 

--- a/backend/pkg/request/request.go
+++ b/backend/pkg/request/request.go
@@ -150,7 +150,7 @@ func sendRequest[T any](c *Client, method, path string, opts ...Opt) (*T, error)
 
 	// Check HTTP status code
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(b))
+		return nil, &HTTPError{StatusCode: resp.StatusCode, Body: b}
 	}
 
 	var rr T
@@ -232,7 +232,7 @@ func PostURL[T any](ctx context.Context, rawURL string, body any, opts ...Opt) (
 		return nil, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(b))
+		return nil, &HTTPError{StatusCode: resp.StatusCode, Body: b}
 	}
 
 	var rr T

--- a/backend/pkg/request/request_error_test.go
+++ b/backend/pkg/request/request_error_test.go
@@ -1,0 +1,56 @@
+package request
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestClientReturnsHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"code":"REQUEST_CONFLICT"}`))
+	}))
+	defer server.Close()
+
+	endpoint, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := NewClient(endpoint.Scheme, endpoint.Host, time.Second)
+	_, err = Get[any](client, context.Background(), "/")
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("error = %T, want *HTTPError", err)
+	}
+	if httpErr.StatusCode != http.StatusConflict || string(httpErr.Body) != `{"code":"REQUEST_CONFLICT"}` {
+		t.Fatalf("unexpected HTTP error: %+v", httpErr)
+	}
+}
+
+func TestWithHeaderMergesOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Route") != "route" || r.Header.Get("X-Fence") != "fence" {
+			t.Fatalf("unexpected headers: %v", r.Header)
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	endpoint, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := NewClient(endpoint.Scheme, endpoint.Host, time.Second)
+	_, err = Get[any](client, context.Background(), "/",
+		WithHeader(Header{"X-Route": "route"}),
+		WithHeader(Header{"X-Fence": "fence"}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/pkg/request/types.go
+++ b/backend/pkg/request/types.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 )
 
@@ -28,3 +29,16 @@ type Query map[string]string
 
 // Header 请求头
 type Header map[string]string
+
+// HTTPError 保留非成功响应的状态码和响应体，供上层协议解析。
+type HTTPError struct {
+	StatusCode int
+	Body       []byte
+}
+
+func (e *HTTPError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, string(e.Body))
+}

--- a/backend/pkg/taskflow/filemanage.go
+++ b/backend/pkg/taskflow/filemanage.go
@@ -27,9 +27,10 @@ func newFileManageClient(client *request.Client) FileManager {
 
 // Operate implements FileManager.
 func (f *fileManageClient) Operate(ctx context.Context, req FileReq) ([]*File, error) {
-	resp, err := request.Post[Resp[[]*File]](f.client, ctx, "/internal/files", req)
+	resp, err := request.Post[Resp[[]*File]](f.client, ctx, "/internal/files", req,
+		routeOption(CapabilityFileManager, req.ID))
 	if err != nil {
-		return []*File{}, err
+		return []*File{}, parseTaskflowError(err)
 	}
 	if resp.Code != 0 {
 		return nil, fmt.Errorf("%s", resp.Message)
@@ -58,9 +59,12 @@ func (f *fileManageClient) Download(ctx context.Context, req FileReq, fn func(ui
 	values.Add("path", req.Path)
 	u.RawQuery = values.Encode()
 
-	conn, _, err := websocket.Dial(ctx, u.String(), &websocket.DialOptions{HTTPHeader: telemetry.TraceHeader(ctx)})
+	header := telemetry.TraceHeader(ctx)
+	header.Set(HeaderRouteCapability, string(CapabilityFileManager))
+	header.Set(HeaderRouteTargetID, req.ID)
+	conn, response, err := websocket.Dial(ctx, u.String(), &websocket.DialOptions{HTTPHeader: header})
 	if err != nil {
-		return err
+		return parseWebsocketError(response, err)
 	}
 	defer conn.Close(websocket.StatusGoingAway, "Closing connection due to context cancellation or other reasons.")
 	conn.SetReadLimit(-1)
@@ -131,9 +135,12 @@ func (f *fileManageClient) Upload(ctx context.Context, req FileReq, data <-chan 
 	values.Add("path", req.Path)
 	u.RawQuery = values.Encode()
 
-	conn, _, err := websocket.Dial(ctx, u.String(), &websocket.DialOptions{HTTPHeader: telemetry.TraceHeader(ctx)})
+	header := telemetry.TraceHeader(ctx)
+	header.Set(HeaderRouteCapability, string(CapabilityFileManager))
+	header.Set(HeaderRouteTargetID, req.ID)
+	conn, response, err := websocket.Dial(ctx, u.String(), &websocket.DialOptions{HTTPHeader: header})
 	if err != nil {
-		return err
+		return parseWebsocketError(response, err)
 	}
 	defer conn.Close(websocket.StatusNormalClosure, "upload completed")
 	conn.SetReadLimit(-1)

--- a/backend/pkg/taskflow/portforward.go
+++ b/backend/pkg/taskflow/portforward.go
@@ -18,15 +18,18 @@ func (p *portForwardClient) List(ctx context.Context, req ListPortforwadReq) (*L
 	resp, err := request.Get[Resp[*ListPortforwadResp]](p.client, ctx, "/internal/port-forward", request.WithQuery(request.Query{
 		"id":         req.ID,
 		"request_id": req.RequestId,
-	}))
+	}), routeOption(CapabilityAgent, req.ID))
 	if err != nil {
-		return nil, err
+		return nil, parseTaskflowError(err)
 	}
 	return resp.Data, nil
 }
 
 func (p *portForwardClient) Create(ctx context.Context, req CreatePortForward) (*PortForwardInfo, error) {
-	resp, err := request.Post[Resp[*PortForwardInfo]](p.client, ctx, "/internal/port-forward", req)
+	resp, err := executeMutation(ctx, targetScope("vm", req.ID), "", func(ctx context.Context) (*Resp[*PortForwardInfo], error) {
+		return request.Post[Resp[*PortForwardInfo]](p.client, ctx, "/internal/port-forward", req,
+			fencedRouteOption(ctx, CapabilityAgent, req.ID))
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -34,12 +37,18 @@ func (p *portForwardClient) Create(ctx context.Context, req CreatePortForward) (
 }
 
 func (p *portForwardClient) Close(ctx context.Context, req ClosePortForward) error {
-	_, err := request.Post[Resp[any]](p.client, ctx, "/internal/port-forward/close", req)
-	return err
+	return executeMutationError(ctx, targetScope("vm", req.ID), req.ForwardID, func(ctx context.Context) error {
+		_, err := request.Post[Resp[any]](p.client, ctx, "/internal/port-forward/close", req,
+			fencedRouteOption(ctx, CapabilityAgent, req.ID))
+		return err
+	})
 }
 
 func (p *portForwardClient) Update(ctx context.Context, req UpdatePortForward) (*PortForwardInfo, error) {
-	resp, err := request.Put[Resp[*PortForwardInfo]](p.client, ctx, "/internal/port-forward", req)
+	resp, err := executeMutation(ctx, targetScope("vm", req.ID), "", func(ctx context.Context) (*Resp[*PortForwardInfo], error) {
+		return request.Put[Resp[*PortForwardInfo]](p.client, ctx, "/internal/port-forward", req,
+			fencedRouteOption(ctx, CapabilityAgent, req.ID))
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/taskflow/routing.go
+++ b/backend/pkg/taskflow/routing.go
@@ -1,0 +1,221 @@
+package taskflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/pkg/request"
+)
+
+type ConnectionCapability string
+
+const (
+	CapabilityOrchestrator ConnectionCapability = "orchestrator"
+	CapabilityAgent        ConnectionCapability = "agent"
+	CapabilityFileManager  ConnectionCapability = "filemanager"
+	CapabilityTask         ConnectionCapability = "task"
+	CapabilityTerminal     ConnectionCapability = "terminal"
+)
+
+type ErrorCode string
+
+const (
+	ErrorInvalidRoute        ErrorCode = "INVALID_ROUTE"
+	ErrorOwnerNotFound       ErrorCode = "OWNER_NOT_FOUND"
+	ErrorOwnerChanged        ErrorCode = "OWNER_CHANGED"
+	ErrorOwnerUnavailable    ErrorCode = "OWNER_UNAVAILABLE"
+	ErrorRegistryUnavailable ErrorCode = "REGISTRY_UNAVAILABLE"
+	ErrorNodeDraining        ErrorCode = "NODE_DRAINING"
+	ErrorRequestProcessing   ErrorCode = "REQUEST_PROCESSING"
+	ErrorRequestNotFound     ErrorCode = "REQUEST_NOT_FOUND"
+	ErrorResultUnknown       ErrorCode = "RESULT_UNKNOWN"
+	ErrorResultNotCached     ErrorCode = "RESULT_NOT_CACHED"
+	ErrorStreamNotFound      ErrorCode = "STREAM_NOT_FOUND"
+	ErrorRequestConflict     ErrorCode = "REQUEST_CONFLICT"
+)
+
+const (
+	HeaderRouteCapability = "X-Taskflow-Capability"
+	HeaderRouteTargetID   = "X-Taskflow-Target-Id"
+	HeaderRequestID       = "X-Taskflow-Request-Id"
+	HeaderRequestScope    = "X-Taskflow-Request-Scope"
+)
+
+type ExecutionState string
+
+const (
+	ExecutionNotDispatched ExecutionState = "not_dispatched"
+	ExecutionDispatched    ExecutionState = "dispatched"
+	ExecutionUnknown       ExecutionState = "unknown"
+)
+
+type TaskflowError struct {
+	Code           ErrorCode      `json:"code"`
+	Message        string         `json:"message"`
+	Retryable      bool           `json:"retryable"`
+	ExecutionState ExecutionState `json:"execution_state"`
+	RequestID      string         `json:"request_id,omitempty"`
+}
+
+func (e *TaskflowError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Message == "" {
+		return string(e.Code)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+func (e *TaskflowError) CanAutoRetry() bool {
+	return e != nil && e.Retryable && e.ExecutionState == ExecutionNotDispatched
+}
+
+type requestFenceContextKey struct{}
+
+type requestFenceMetadata struct {
+	scope     string
+	requestID string
+}
+
+func WithRequestFence(ctx context.Context, scope, requestID string) context.Context {
+	return context.WithValue(ctx, requestFenceContextKey{}, requestFenceMetadata{
+		scope:     strings.TrimSpace(scope),
+		requestID: strings.TrimSpace(requestID),
+	})
+}
+
+func routeOption(capability ConnectionCapability, targetID string) request.Opt {
+	return request.WithHeader(request.Header{
+		HeaderRouteCapability: string(capability),
+		HeaderRouteTargetID:   targetID,
+	})
+}
+
+func fencedRouteOption(ctx context.Context, capability ConnectionCapability, targetID string) request.Opt {
+	header := request.Header{
+		HeaderRouteCapability: string(capability),
+		HeaderRouteTargetID:   targetID,
+	}
+	if metadata, ok := requestFenceFromContext(ctx); ok {
+		header[HeaderRequestScope] = metadata.scope
+		header[HeaderRequestID] = metadata.requestID
+	}
+	return request.WithHeader(header)
+}
+
+func requestFenceFromContext(ctx context.Context) (requestFenceMetadata, bool) {
+	if ctx == nil {
+		return requestFenceMetadata{}, false
+	}
+	metadata, ok := ctx.Value(requestFenceContextKey{}).(requestFenceMetadata)
+	return metadata, ok && metadata.scope != "" && metadata.requestID != ""
+}
+
+func ensureRequestFence(ctx context.Context, scope, requestID string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := requestFenceFromContext(ctx); ok {
+		return ctx
+	}
+	if strings.TrimSpace(scope) == "" {
+		scope = "backend"
+	}
+	if strings.TrimSpace(requestID) == "" {
+		requestID = uuid.NewString()
+	}
+	return WithRequestFence(ctx, scope, requestID)
+}
+
+func targetScope(kind, targetID string) string {
+	if strings.TrimSpace(targetID) == "" {
+		return "backend"
+	}
+	return kind + ":" + targetID
+}
+
+func parseTaskflowError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var protocolErr *TaskflowError
+	if errors.As(err, &protocolErr) {
+		return protocolErr
+	}
+	var httpErr *request.HTTPError
+	if !errors.As(err, &httpErr) {
+		return err
+	}
+	if json.Unmarshal(httpErr.Body, &protocolErr) == nil && protocolErr != nil && protocolErr.Code != "" {
+		return protocolErr
+	}
+	return err
+}
+
+func parseWebsocketError(response *http.Response, err error) error {
+	if response == nil || response.Body == nil {
+		return err
+	}
+	defer response.Body.Close()
+	body, readErr := io.ReadAll(response.Body)
+	if readErr != nil {
+		return err
+	}
+	var protocolErr TaskflowError
+	if json.Unmarshal(body, &protocolErr) == nil && protocolErr.Code != "" {
+		return &protocolErr
+	}
+	return err
+}
+
+func executeMutation[T any](
+	ctx context.Context,
+	scope string,
+	requestID string,
+	fn func(context.Context) (T, error),
+) (T, error) {
+	ctx = ensureRequestFence(ctx, scope, requestID)
+	var zero T
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		value, err := fn(ctx)
+		if err == nil {
+			return value, nil
+		}
+		err = parseTaskflowError(err)
+		lastErr = err
+		var protocolErr *TaskflowError
+		if attempt > 0 || !errors.As(err, &protocolErr) || !protocolErr.CanAutoRetry() {
+			return zero, err
+		}
+		timer := time.NewTimer(100 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return zero, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return zero, lastErr
+}
+
+func executeMutationError(
+	ctx context.Context,
+	scope string,
+	requestID string,
+	fn func(context.Context) error,
+) error {
+	_, err := executeMutation(ctx, scope, requestID, func(ctx context.Context) (struct{}, error) {
+		return struct{}{}, fn(ctx)
+	})
+	return err
+}

--- a/backend/pkg/taskflow/routing_test.go
+++ b/backend/pkg/taskflow/routing_test.go
@@ -1,0 +1,115 @@
+package taskflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/chaitin/MonkeyCode/backend/pkg/request"
+)
+
+func TestMutationWritesHeadersAndSafelyRetries(t *testing.T) {
+	taskID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	var requestIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(HeaderRouteCapability) != string(CapabilityAgent) {
+			t.Errorf("capability = %q", r.Header.Get(HeaderRouteCapability))
+		}
+		if r.Header.Get(HeaderRouteTargetID) != "vm-1" {
+			t.Errorf("target id = %q", r.Header.Get(HeaderRouteTargetID))
+		}
+		if r.Header.Get(HeaderRequestScope) != "task:"+taskID.String() {
+			t.Errorf("request scope = %q", r.Header.Get(HeaderRequestScope))
+		}
+		requestIDs = append(requestIDs, r.Header.Get(HeaderRequestID))
+		if len(requestIDs) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(&TaskflowError{
+				Code:           ErrorRegistryUnavailable,
+				Message:        "registry unavailable",
+				Retryable:      true,
+				ExecutionState: ExecutionNotDispatched,
+				RequestID:      taskID.String(),
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(Resp[any]{})
+	}))
+	defer server.Close()
+
+	taskClient := newTestTaskClient(t, server.URL)
+	err := taskClient.Create(context.Background(), CreateTaskReq{ID: taskID, VMID: "vm-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(requestIDs) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requestIDs))
+	}
+	if requestIDs[0] != taskID.String() || requestIDs[1] != requestIDs[0] {
+		t.Fatalf("request ids = %v", requestIDs)
+	}
+}
+
+func TestMutationUsesExplicitFence(t *testing.T) {
+	taskID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(HeaderRouteCapability) != string(CapabilityTask) || r.Header.Get(HeaderRouteTargetID) != taskID.String() {
+			t.Errorf("unexpected route headers: %v", r.Header)
+		}
+		if r.Header.Get(HeaderRequestScope) != "team:1" || r.Header.Get(HeaderRequestID) != "request-1" {
+			t.Errorf("unexpected fence headers: %v", r.Header)
+		}
+		_ = json.NewEncoder(w).Encode(Resp[any]{})
+	}))
+	defer server.Close()
+
+	ctx := WithRequestFence(context.Background(), "team:1", "request-1")
+	err := newTestTaskClient(t, server.URL).Stop(ctx, TaskReq{Task: &Task{ID: taskID}})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMutationDoesNotRetryUnknownExecution(t *testing.T) {
+	taskID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(&TaskflowError{
+			Code:           ErrorOwnerUnavailable,
+			Message:        "owner unavailable",
+			Retryable:      true,
+			ExecutionState: ExecutionUnknown,
+		})
+	}))
+	defer server.Close()
+
+	err := newTestTaskClient(t, server.URL).Continue(context.Background(), TaskReq{Task: &Task{ID: taskID}})
+	var protocolErr *TaskflowError
+	if !errors.As(err, &protocolErr) {
+		t.Fatalf("error = %T, want *TaskflowError", err)
+	}
+	if requests != 1 {
+		t.Fatalf("request count = %d, want 1", requests)
+	}
+	if protocolErr.CanAutoRetry() {
+		t.Fatal("unknown execution state must not be retried")
+	}
+}
+
+func newTestTaskClient(t *testing.T, rawURL string) TaskManager {
+	t.Helper()
+	endpoint, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return newTaskClient(request.NewClient(endpoint.Scheme, endpoint.Host, time.Second))
+}

--- a/backend/pkg/taskflow/task.go
+++ b/backend/pkg/taskflow/task.go
@@ -22,8 +22,11 @@ func (t *taskClient) Create(ctx context.Context, req CreateTaskReq) error {
 	ctx = telemetry.WithTaskID(ctx, req.ID.String())
 	ctx = telemetry.WithVMID(ctx, req.VMID)
 	telemetry.MarkCritical(ctx)
-	_, err := request.Post[Resp[any]](t.client, ctx, "/internal/task", req)
-	return err
+	return executeMutationError(ctx, targetScope("task", req.ID.String()), req.ID.String(), func(ctx context.Context) error {
+		_, err := request.Post[Resp[any]](t.client, ctx, "/internal/task", req,
+			fencedRouteOption(ctx, CapabilityAgent, req.VMID))
+		return err
+	})
 }
 
 // Restart implements TaskManager.
@@ -31,7 +34,10 @@ func (t *taskClient) Restart(ctx context.Context, req RestartTaskReq) (*RestartT
 	ctx = telemetry.WithTaskID(ctx, req.ID.String())
 	ctx = telemetry.WithRequestID(ctx, req.RequestId)
 	telemetry.MarkCritical(ctx)
-	resp, err := request.Post[Resp[*RestartTaskResp]](t.client, ctx, "/internal/task/restart", req)
+	resp, err := executeMutation(ctx, targetScope("task", req.ID.String()), req.RequestId, func(ctx context.Context) (*Resp[*RestartTaskResp], error) {
+		return request.Post[Resp[*RestartTaskResp]](t.client, ctx, "/internal/task/restart", req,
+			fencedRouteOption(ctx, CapabilityTask, req.ID.String()))
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +48,12 @@ func (t *taskClient) Restart(ctx context.Context, req RestartTaskReq) (*RestartT
 func (t *taskClient) Stop(ctx context.Context, req TaskReq) error {
 	ctx = taskContext(ctx, req)
 	telemetry.MarkCritical(ctx)
-	_, err := request.Post[Resp[any]](t.client, ctx, "/internal/task/stop", req)
-	return err
+	taskID := taskReqID(req)
+	return executeMutationError(ctx, targetScope("task", taskID), "", func(ctx context.Context) error {
+		_, err := request.Post[Resp[any]](t.client, ctx, "/internal/task/stop", req,
+			fencedRouteOption(ctx, CapabilityTask, taskID))
+		return err
+	})
 }
 
 // Cancel implements TaskManager.
@@ -51,16 +61,24 @@ func (t *taskClient) Cancel(ctx context.Context, req TaskReq) error {
 	ctx = taskContext(ctx, req)
 	telemetry.MarkCritical(ctx)
 	telemetry.SetOutcome(ctx, "cancelled")
-	_, err := request.Post[Resp[any]](t.client, ctx, "/internal/task/cancel", req)
-	return err
+	taskID := taskReqID(req)
+	return executeMutationError(ctx, targetScope("task", taskID), "", func(ctx context.Context) error {
+		_, err := request.Post[Resp[any]](t.client, ctx, "/internal/task/cancel", req,
+			fencedRouteOption(ctx, CapabilityTask, taskID))
+		return err
+	})
 }
 
 // Continue implements TaskManager.
 func (t *taskClient) Continue(ctx context.Context, req TaskReq) error {
 	ctx = taskContext(ctx, req)
 	telemetry.MarkCritical(ctx)
-	_, err := request.Post[Resp[any]](t.client, ctx, "/internal/task/continue", req)
-	return err
+	taskID := taskReqID(req)
+	return executeMutationError(ctx, targetScope("task", taskID), "", func(ctx context.Context) error {
+		_, err := request.Post[Resp[any]](t.client, ctx, "/internal/task/continue", req,
+			fencedRouteOption(ctx, CapabilityTask, taskID))
+		return err
+	})
 }
 
 func taskContext(ctx context.Context, req TaskReq) context.Context {
@@ -75,48 +93,65 @@ func taskContext(ctx context.Context, req TaskReq) context.Context {
 
 // AutoApprove implements TaskManager.
 func (t *taskClient) AutoApprove(ctx context.Context, req TaskApproveReq) error {
-	_, err := request.Post[Resp[any]](t.client, ctx, "/internal/task/auto-approve", req)
-	return err
+	return executeMutationError(ctx, targetScope("task", req.ID.String()), "", func(ctx context.Context) error {
+		_, err := request.Post[Resp[any]](t.client, ctx, "/internal/task/auto-approve", req,
+			fencedRouteOption(ctx, CapabilityTask, req.ID.String()))
+		return err
+	})
 }
 
 // AskUserQuestion implements TaskManager.
 func (t *taskClient) AskUserQuestion(ctx context.Context, req AskUserQuestionResponse) error {
-	_, err := request.Post[Resp[any]](t.client, ctx, "/internal/task/ask-user-question", req)
-	return err
+	return executeMutationError(ctx, targetScope("task", req.TaskId), req.RequestId, func(ctx context.Context) error {
+		_, err := request.Post[Resp[any]](t.client, ctx, "/internal/task/ask-user-question", req,
+			fencedRouteOption(ctx, CapabilityTask, req.TaskId))
+		return err
+	})
 }
 
 // ListFiles implements TaskManager.
 func (t *taskClient) ListFiles(ctx context.Context, req RepoListFilesReq) (*RepoListFiles, error) {
-	resp, err := request.Post[Resp[*RepoListFiles]](t.client, ctx, "/internal/task/repo-list-files", req)
+	resp, err := request.Post[Resp[*RepoListFiles]](t.client, ctx, "/internal/task/repo-list-files", req,
+		routeOption(CapabilityTask, req.TaskId))
 	if err != nil {
-		return nil, err
+		return nil, parseTaskflowError(err)
 	}
 	return resp.Data, nil
 }
 
 // ReadFile implements TaskManager.
 func (t *taskClient) ReadFile(ctx context.Context, req RepoReadFileReq) (*RepoReadFile, error) {
-	resp, err := request.Post[Resp[*RepoReadFile]](t.client, ctx, "/internal/task/repo-read-file", req)
+	resp, err := request.Post[Resp[*RepoReadFile]](t.client, ctx, "/internal/task/repo-read-file", req,
+		routeOption(CapabilityTask, req.TaskId))
 	if err != nil {
-		return nil, err
+		return nil, parseTaskflowError(err)
 	}
 	return resp.Data, nil
 }
 
 // FileDiff implements TaskManager.
 func (t *taskClient) FileDiff(ctx context.Context, req RepoFileDiffReq) (*RepoFileDiff, error) {
-	resp, err := request.Post[Resp[*RepoFileDiff]](t.client, ctx, "/internal/task/repo-file-diff", req)
+	resp, err := request.Post[Resp[*RepoFileDiff]](t.client, ctx, "/internal/task/repo-file-diff", req,
+		routeOption(CapabilityTask, req.TaskId))
 	if err != nil {
-		return nil, err
+		return nil, parseTaskflowError(err)
 	}
 	return resp.Data, nil
 }
 
 // FileChanges implements TaskManager.
 func (t *taskClient) FileChanges(ctx context.Context, req RepoFileChangesReq) (*RepoFileChanges, error) {
-	resp, err := request.Post[Resp[*RepoFileChanges]](t.client, ctx, "/internal/task/repo-file-changes", req)
+	resp, err := request.Post[Resp[*RepoFileChanges]](t.client, ctx, "/internal/task/repo-file-changes", req,
+		routeOption(CapabilityTask, req.TaskId))
 	if err != nil {
-		return nil, err
+		return nil, parseTaskflowError(err)
 	}
 	return resp.Data, nil
+}
+
+func taskReqID(req TaskReq) string {
+	if req.Task == nil {
+		return ""
+	}
+	return req.Task.ID.String()
 }

--- a/backend/pkg/taskflow/vm.go
+++ b/backend/pkg/taskflow/vm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync/atomic"
 
 	"github.com/coder/websocket"
 
@@ -22,7 +23,10 @@ func newVirtualMachineClient(client *request.Client) VirtualMachiner {
 
 // Create implements VirtualMachiner.
 func (v *virtualMachineClient) Create(ctx context.Context, req *CreateVirtualMachineReq) (*VirtualMachine, error) {
-	resp, err := request.Post[Resp[*VirtualMachine]](v.client, ctx, "/internal/vm", req)
+	resp, err := executeMutation(ctx, targetScope("vm", req.ID), req.ID, func(ctx context.Context) (*Resp[*VirtualMachine], error) {
+		return request.Post[Resp[*VirtualMachine]](v.client, ctx, "/internal/vm", req,
+			fencedRouteOption(ctx, CapabilityOrchestrator, req.HostID))
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -36,8 +40,13 @@ func (v *virtualMachineClient) Delete(ctx context.Context, req *DeleteVirtualMac
 		"host_id": req.HostID,
 		"user_id": req.UserID,
 	}
-	_, err := request.Delete[any](v.client, ctx, "/internal/vm", request.WithQuery(q))
-	return err
+	return executeMutationError(ctx, targetScope("vm", req.ID), req.ID, func(ctx context.Context) error {
+		_, err := request.Delete[any](v.client, ctx, "/internal/vm",
+			request.WithQuery(q),
+			fencedRouteOption(ctx, CapabilityOrchestrator, req.HostID),
+		)
+		return err
+	})
 }
 
 // IsVirtualMachineNotFound 判断删除失败是否表示远端环境已经不存在。
@@ -50,9 +59,12 @@ func (v *virtualMachineClient) List(ctx context.Context, id string) ([]*VirtualM
 	q := request.Query{
 		"id": id,
 	}
-	resp, err := request.Get[Resp[[]*VirtualMachine]](v.client, ctx, "/internal/vm/list", request.WithQuery(q))
+	resp, err := request.Get[Resp[[]*VirtualMachine]](v.client, ctx, "/internal/vm/list",
+		request.WithQuery(q),
+		routeOption(CapabilityOrchestrator, id),
+	)
 	if err != nil {
-		return []*VirtualMachine{}, err
+		return []*VirtualMachine{}, parseTaskflowError(err)
 	}
 	return resp.Data, nil
 }
@@ -86,6 +98,7 @@ func (v *virtualMachineClient) Terminal(ctx context.Context, req *TerminalReq) (
 		wsScheme = "wss"
 	}
 
+	var preferTerminal atomic.Bool
 	dial := func(ctx context.Context) (*websocket.Conn, error) {
 		u := &url.URL{
 			Scheme: wsScheme,
@@ -101,10 +114,25 @@ func (v *virtualMachineClient) Terminal(ctx context.Context, req *TerminalReq) (
 		values.Add("mode", fmt.Sprintf("%d", req.Mode))
 		u.RawQuery = values.Encode()
 
-		conn, _, err := websocket.Dial(ctx, u.String(), &websocket.DialOptions{HTTPHeader: telemetry.TraceHeader(ctx)})
+		capability := CapabilityAgent
+		targetID := req.ID
+		if preferTerminal.Load() {
+			capability = CapabilityTerminal
+			targetID = req.TerminalID
+		}
+		header := telemetry.TraceHeader(ctx)
+		header.Set(HeaderRouteCapability, string(capability))
+		header.Set(HeaderRouteTargetID, targetID)
+		conn, response, err := websocket.Dial(ctx, u.String(), &websocket.DialOptions{HTTPHeader: header})
 		if err != nil {
+			err = parseWebsocketError(response, err)
+			protocolErr, isProtocolErr := err.(*TaskflowError)
+			if capability == CapabilityTerminal && isProtocolErr && protocolErr.Code == ErrorOwnerNotFound {
+				preferTerminal.Store(false)
+			}
 			return nil, err
 		}
+		preferTerminal.Store(true)
 		return conn, nil
 	}
 
@@ -164,35 +192,41 @@ func (v *virtualMachineClient) Reports(ctx context.Context, req ReportSubscribeR
 
 // TerminalList implements VirtualMachiner.
 func (v *virtualMachineClient) TerminalList(ctx context.Context, id string) ([]*Terminal, error) {
-	resp, err := request.Get[Resp[[]*Terminal]](v.client, ctx, "/internal/terminal", request.WithQuery(
-		request.Query{"id": id},
-	))
+	resp, err := request.Get[Resp[[]*Terminal]](v.client, ctx, "/internal/terminal",
+		request.WithQuery(request.Query{"id": id}),
+		routeOption(CapabilityAgent, id),
+	)
 	if err != nil {
-		return nil, err
+		return nil, parseTaskflowError(err)
 	}
 	return resp.Data, nil
 }
 
 // CloseTerminal implements VirtualMachiner.
 func (v *virtualMachineClient) CloseTerminal(ctx context.Context, req *CloseTerminalReq) error {
-	_, err := request.Delete[any](v.client, ctx, "/internal/terminal", request.WithBody(req))
-	return err
+	return executeMutationError(ctx, targetScope("vm", req.ID), req.TerminalID, func(ctx context.Context) error {
+		_, err := request.Delete[any](v.client, ctx, "/internal/terminal",
+			request.WithBody(req),
+			fencedRouteOption(ctx, CapabilityAgent, req.ID),
+		)
+		return err
+	})
 }
 
 // Hibernate implements [VirtualMachiner].
 func (v *virtualMachineClient) Hibernate(ctx context.Context, req *HibernateVirtualMachineReq) error {
-	_, err := request.Post[Resp[any]](v.client, ctx, "/internal/vm/hibernate", req)
-	if err != nil {
+	return executeMutationError(ctx, targetScope("vm", req.ID), "", func(ctx context.Context) error {
+		_, err := request.Post[Resp[any]](v.client, ctx, "/internal/vm/hibernate", req,
+			fencedRouteOption(ctx, CapabilityOrchestrator, req.HostID))
 		return err
-	}
-	return nil
+	})
 }
 
 // Resume implements [VirtualMachiner].
 func (v *virtualMachineClient) Resume(ctx context.Context, req *ResumeVirtualMachineReq) error {
-	_, err := request.Post[Resp[any]](v.client, ctx, "/internal/vm/resume", req)
-	if err != nil {
+	return executeMutationError(ctx, targetScope("vm", req.ID), "", func(ctx context.Context) error {
+		_, err := request.Post[Resp[any]](v.client, ctx, "/internal/vm/resume", req,
+			fencedRouteOption(ctx, CapabilityOrchestrator, req.HostID))
 		return err
-	}
-	return nil
+	})
 }

--- a/backend/pkg/taskflow/vm_test.go
+++ b/backend/pkg/taskflow/vm_test.go
@@ -1,9 +1,19 @@
 package taskflow
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/chaitin/MonkeyCode/backend/pkg/request"
 )
 
 func TestIsVirtualMachineNotFound(t *testing.T) {
@@ -16,5 +26,62 @@ func TestIsVirtualMachineNotFound(t *testing.T) {
 	}
 	if IsVirtualMachineNotFound(nil) {
 		t.Fatal("nil must not be recognized as not found")
+	}
+}
+
+func TestTerminalReconnectFallsBackOnlyOnOwnerNotFound(t *testing.T) {
+	var routes []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		routes = append(routes, r.Header.Get(HeaderRouteCapability)+":"+r.Header.Get(HeaderRouteTargetID))
+		if len(routes) == 2 {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(&TaskflowError{
+				Code:           ErrorOwnerNotFound,
+				Message:        "terminal owner not found",
+				Retryable:      true,
+				ExecutionState: ExecutionNotDispatched,
+			})
+			return
+		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		go func() {
+			for {
+				if _, _, err := conn.Read(context.Background()); err != nil {
+					return
+				}
+			}
+		}()
+	}))
+	defer server.Close()
+
+	endpoint, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := request.NewClient(endpoint.Scheme, endpoint.Host, 3*time.Second)
+	vmClient := newVirtualMachineClient(client)
+	sheller, err := vmClient.Terminal(context.Background(), &TerminalReq{
+		ID:         "vm-1",
+		TerminalID: "terminal-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	shell := sheller.(*Shell)
+	defer shell.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := shell.reconnect(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"agent:vm-1", "terminal:terminal-1", "agent:vm-1"}
+	if fmt.Sprint(routes) != fmt.Sprint(want) {
+		t.Fatalf("routes = %v, want %v", routes, want)
 	}
 }


### PR DESCRIPTION
## 变更内容

- 为 Taskflow 路由请求补充 capability 和 target ID Header
- 为变更请求补充请求栅栏，并在单次业务调用的安全重试中复用 Request ID
- 解析 Taskflow 稳定错误体，仅在 retryable=true 且 execution_state=not_dispatched 时重试一次
- 适配 VM、任务、文件管理、端口转发和终端 WebSocket 路由
- 终端首次按 Agent/VM 路由，重连按 Terminal ID 路由，仅 OWNER_NOT_FOUND 时回退 Agent
- 保留非成功 HTTP 响应的状态码和响应体，支持上层协议错误解析

## 兼容性

- Taskflow 默认仍按单实例运行，不需要 Peer TLS 或额外 Compose 配置
- 新 Backend 携带的 Header 会被旧 Taskflow 忽略，因此建议先升级 Backend，再升级 Taskflow
- 未提供持久业务 Request ID 的调用会在客户端调用入口生成一次 ID，可覆盖客户端内部安全重试；跨 HTTP 请求的重复提交不在本次范围内

## 验证

- go test ./pkg/request ./pkg/taskflow
- go test -race ./pkg/request ./pkg/taskflow
- go vet ./pkg/request ./pkg/taskflow
- go test ./... 除 main 基线已有的 biz/host/usecase 和 pkg/lifecycle 测试桩编译问题外，其余通过；该问题已在未修改的 main 上复现