### PR TITLE
fix: avoid repeated skill requests for empty lists

### DIFF
--- a/frontend/src/components/console/project/start-develop-task-dialog.tsx
+++ b/frontend/src/components/console/project/start-develop-task-dialog.tsx
@@ -61,6 +61,7 @@ export default function StartDevelopTaskDialog({
   const [skillPopoverOpen, setSkillPopoverOpen] = useState(false)
   const [selectedSkill, setSelectedSkill] = useState<string[]>(defaultSkills)
   const [skillList, setSkillList] = useState<DomainSkill[]>([])
+  const [skillsLoaded, setSkillsLoaded] = useState(false)
   const [activeSkillTag, setActiveSkillTag] = useState(ALL_SKILLS_TAG)
   const { images, models, hosts, subscription } = useCommonData()
   const { t } = useTranslation()
@@ -145,11 +146,12 @@ export default function StartDevelopTaskDialog({
       return
     }
 
-    if (skillList.length === 0) {
+    if (!skillsLoaded) {
       apiRequest("v1SkillsList", {}, [], (resp) => {
         if (resp.code === 0) {
           const skills = resp.data || []
           setSkillList(skills)
+          setSkillsLoaded(true)
           setSelectedSkill((prev) => filterSelectableSkillIds(prev, skills))
         } else {
           toast.error(resp.message || t("taskWorkflow.toast.fetchSkillsFailed"))
@@ -159,7 +161,7 @@ export default function StartDevelopTaskDialog({
     }
 
     setSelectedSkill((prev) => filterSelectableSkillIds(prev, skillList))
-  }, [open, skillList, skillList.length, t])
+  }, [open, skillList, skillsLoaded, t])
 
   useEffect(() => {
     if (!open) {

--- a/frontend/src/components/console/task/create-default-task-dialog.tsx
+++ b/frontend/src/components/console/task/create-default-task-dialog.tsx
@@ -116,6 +116,7 @@ export default function CreateDefaultTaskDialog({
   const [selectedRepoFromMyRepos, setSelectedRepoFromMyRepos] = useState(false)
   const [selectedSkill, setSelectedSkill] = useState<string[]>(defaultSkills)
   const [skillList, setSkillList] = useState<DomainSkill[]>([])
+  const [skillsLoaded, setSkillsLoaded] = useState(false)
   const [activeSkillTag, setActiveSkillTag] = useState(ALL_SKILLS_TAG)
   const [advancedOptionsOpen, setAdvancedOptionsOpen] = useState(false)
   const [selectedModelId, setSelectedModelId] = useState("")
@@ -195,11 +196,12 @@ export default function CreateDefaultTaskDialog({
       return
     }
 
-    if (skillList.length === 0) {
+    if (!skillsLoaded) {
       apiRequest("v1SkillsList", {}, [], (resp) => {
         if (resp.code === 0) {
           const skills = resp.data || []
           setSkillList(skills)
+          setSkillsLoaded(true)
           setSelectedSkill((prev) => filterSelectableSkillIds(prev, skills))
         } else {
           toast.error(resp.message || t("taskWorkflow.toast.fetchSkillsFailed"))
@@ -208,7 +210,7 @@ export default function CreateDefaultTaskDialog({
     } else {
       setSelectedSkill((prev) => filterSelectableSkillIds(prev, skillList))
     }
-  }, [open, skillList, skillList.length, t])
+  }, [open, skillList, skillsLoaded, t])
 
   useEffect(() => {
     if (!open || models.length === 0) {

--- a/frontend/test/start-develop-task-dialog.test.ts
+++ b/frontend/test/start-develop-task-dialog.test.ts
@@ -7,6 +7,11 @@ const dialogSource = readFileSync(
   "utf8",
 );
 
+const createDefaultDialogSource = readFileSync(
+  new URL("../src/components/console/task/create-default-task-dialog.tsx", import.meta.url),
+  "utf8",
+);
+
 test("项目启动任务弹窗允许选择系统镜像并提交选中的镜像", () => {
   assert.match(dialogSource, /selectedImageId/);
   assert.match(dialogSource, /setSelectedImageId\(selectImage\(images, true\)\)/);
@@ -48,4 +53,13 @@ test("项目启动任务弹窗在高级选项里支持 Skills 并提交选中项
   assert.match(dialogSource, /<TaskSkillSelector/);
   assert.match(dialogSource, /selectedSkills=\{selectedSkill\}/);
   assert.match(dialogSource, /skill_ids: selectedSkill/);
+});
+
+test("启动任务弹窗在 skill 列表为空时不会重复请求", () => {
+  for (const source of [dialogSource, createDefaultDialogSource]) {
+    assert.match(source, /const \[skillsLoaded, setSkillsLoaded\] = useState\(false\)/);
+    assert.match(source, /if \(!skillsLoaded\) \{[\s\S]*?apiRequest\("v1SkillsList"/);
+    assert.match(source, /setSkillList\(skills\)[\s\S]*?setSkillsLoaded\(true\)/);
+    assert.doesNotMatch(source, /if \(skillList\.length === 0\) \{[\s\S]*?apiRequest\("v1SkillsList"/);
+  }
 });


### PR DESCRIPTION
## Summary
- track whether skills have loaded independently from the returned list length
- stop both task creation dialogs from repeatedly requesting an empty skills list
- add regression coverage for empty skill responses

## Testing
- `node --test test/start-develop-task-dialog.test.ts`
- `npx tsc -b --pretty false`