### PR TITLE
fix: render repository images in project READMEs

### DIFF
--- a/backend/biz/project/handler/v1/project.go
+++ b/backend/biz/project/handler/v1/project.go
@@ -431,6 +431,7 @@ func (h *ProjectHandler) GetProjectMedia(c *web.Context, req domain.GetProjectBl
 		return c.String(http.StatusBadRequest, "invalid media path")
 	}
 	req.Path = cleanPath
+	req.MaxSize = maxProjectMediaSize
 
 	user := middleware.GetUser(c)
 	resp, err := h.usecase.GetProjectBlob(c.Request().Context(), user.ID, &req)
@@ -448,7 +449,7 @@ func (h *ProjectHandler) GetProjectMedia(c *web.Context, req domain.GetProjectBl
 	}
 
 	headers := c.Response().Header()
-	headers.Set("Cache-Control", "private, max-age=3600")
+	headers.Set("Cache-Control", "private, no-cache")
 	headers.Set("X-Content-Type-Options", "nosniff")
 	if resp.Sha != "" {
 		etag := strconv.Quote(resp.Sha)

--- a/backend/biz/project/handler/v1/project.go
+++ b/backend/biz/project/handler/v1/project.go
@@ -414,7 +414,7 @@ func (h *ProjectHandler) GetProjectBlob(c *web.Context, req domain.GetProjectBlo
 //	@Summary		获取项目图片
 //	@Description	获取项目中的栅格图片原始内容，用于 README 等页面内联展示
 //	@Tags			【用户】项目管理
-//	@Produce		image/png
+//	@Produce		image/png,image/jpeg,image/gif,image/webp
 //	@Security		MonkeyCodeAIAuth
 //	@Param			id		path		string	true	"项目ID"
 //	@Param			path	query		string	true	"图片路径"

--- a/backend/biz/project/handler/v1/project.go
+++ b/backend/biz/project/handler/v1/project.go
@@ -4,6 +4,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
 
 	"github.com/GoYoko/web"
 	"github.com/google/uuid"
@@ -58,10 +63,20 @@ func NewProjectHandler(i *do.Injector) (*ProjectHandler, error) {
 	gt.Use(auth.Auth(), targetActive.TargetActive())
 	gt.GET("", web.BindHandler(h.GetProjectTree))
 	gt.GET("/blob", web.BindHandler(h.GetProjectBlob))
+	gt.GET("/media", web.BindHandler(h.GetProjectMedia))
 	gt.GET("/logs", web.BindHandler(h.GetProjectLogs))
 	gt.GET("/archive", web.BindHandler(h.GetProjectArchive))
 
 	return h, nil
+}
+
+const maxProjectMediaSize = 10 << 20 // 10 MiB
+
+var allowedProjectMediaTypes = map[string]struct{}{
+	"image/gif":  {},
+	"image/jpeg": {},
+	"image/png":  {},
+	"image/webp": {},
 }
 
 // List 项目列表
@@ -392,6 +407,78 @@ func (h *ProjectHandler) GetProjectBlob(c *web.Context, req domain.GetProjectBlo
 		return err
 	}
 	return c.Success(resp)
+}
+
+// GetProjectMedia 获取可安全内联展示的项目图片
+//
+//	@Summary		获取项目图片
+//	@Description	获取项目中的栅格图片原始内容，用于 README 等页面内联展示
+//	@Tags			【用户】项目管理
+//	@Produce		image/png
+//	@Security		MonkeyCodeAIAuth
+//	@Param			id		path		string	true	"项目ID"
+//	@Param			path	query		string	true	"图片路径"
+//	@Param			ref		query		string	false	"分支"
+//	@Success		200		{file}		"成功"
+//	@Failure		400		{string}	string	"无效路径"
+//	@Failure		401		{string}	string	"未授权"
+//	@Failure		413		{string}	string	"图片过大"
+//	@Failure		415		{string}	string	"不支持的媒体类型"
+//	@Router			/api/v1/users/projects/{id}/tree/media [get]
+func (h *ProjectHandler) GetProjectMedia(c *web.Context, req domain.GetProjectBlobReq) error {
+	cleanPath, ok := cleanRepositoryMediaPath(req.Path)
+	if !ok {
+		return c.String(http.StatusBadRequest, "invalid media path")
+	}
+	req.Path = cleanPath
+
+	user := middleware.GetUser(c)
+	resp, err := h.usecase.GetProjectBlob(c.Request().Context(), user.ID, &req)
+	if err != nil {
+		return err
+	}
+
+	if resp.Size > maxProjectMediaSize || len(resp.Content) > maxProjectMediaSize {
+		return c.String(http.StatusRequestEntityTooLarge, "media file is too large")
+	}
+
+	contentType := http.DetectContentType(resp.Content)
+	if _, ok := allowedProjectMediaTypes[contentType]; !ok {
+		return c.String(http.StatusUnsupportedMediaType, "unsupported media type")
+	}
+
+	headers := c.Response().Header()
+	headers.Set("Cache-Control", "private, max-age=3600")
+	headers.Set("X-Content-Type-Options", "nosniff")
+	if resp.Sha != "" {
+		etag := strconv.Quote(resp.Sha)
+		headers.Set("ETag", etag)
+		if requestETagMatches(c.Request().Header.Get("If-None-Match"), etag) {
+			return c.NoContent(http.StatusNotModified)
+		}
+	}
+
+	headers.Set("Content-Disposition", mime.FormatMediaType("inline", map[string]string{"filename": path.Base(req.Path)}))
+	headers.Set("Content-Length", strconv.Itoa(len(resp.Content)))
+	return c.Blob(http.StatusOK, contentType, resp.Content)
+}
+
+func cleanRepositoryMediaPath(raw string) (string, bool) {
+	cleaned := path.Clean(strings.TrimLeft(strings.TrimSpace(raw), "/"))
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", false
+	}
+	return cleaned, true
+}
+
+func requestETagMatches(header, etag string) bool {
+	for value := range strings.SplitSeq(header, ",") {
+		value = strings.TrimSpace(value)
+		if value == "*" || value == etag || strings.TrimPrefix(value, "W/") == etag {
+			return true
+		}
+	}
+	return false
 }
 
 // GetProjectLogs 获取项目提交日志

--- a/backend/biz/project/handler/v1/project_media_test.go
+++ b/backend/biz/project/handler/v1/project_media_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 var testPNG = []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0, 0}
+var testJPEG = []byte{0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0}
 
 func TestProjectMediaReturnsInlinePNG(t *testing.T) {
 	userID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
@@ -46,7 +47,7 @@ func TestProjectMediaReturnsInlinePNG(t *testing.T) {
 	if got := rec.Header().Get(echo.HeaderContentLength); got != "12" {
 		t.Fatalf("Content-Length = %q, want 12", got)
 	}
-	if got := rec.Header().Get(echo.HeaderCacheControl); got != "private, max-age=3600" {
+	if got := rec.Header().Get(echo.HeaderCacheControl); got != "private, no-cache" {
 		t.Fatalf("Cache-Control = %q", got)
 	}
 	if got := rec.Header().Get("ETag"); got != `"png-sha"` {
@@ -55,8 +56,27 @@ func TestProjectMediaReturnsInlinePNG(t *testing.T) {
 	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
 		t.Fatalf("X-Content-Type-Options = %q", got)
 	}
-	if stub.uid != userID || stub.req == nil || stub.req.ID != projectID || stub.req.Path != "docs/demo.png" || stub.req.Ref != "main" {
+	if stub.uid != userID || stub.req == nil || stub.req.ID != projectID || stub.req.Path != "docs/demo.png" || stub.req.Ref != "main" || stub.req.MaxSize != maxProjectMediaSize {
 		t.Fatalf("usecase request = uid %s, req %#v", stub.uid, stub.req)
+	}
+}
+
+func TestProjectMediaDetectsJPEGContentBehindPNGFilename(t *testing.T) {
+	h := &ProjectHandler{usecase: &projectMediaUsecaseStub{
+		blob: &domain.ProjectBlob{Content: testJPEG, Sha: "jpeg-sha", Size: len(testJPEG)},
+	}}
+	w := web.New()
+	w.GET("/projects/:id/tree/media", web.BindHandler(h.GetProjectMedia), projectMediaUser(uuid.New()))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/projects/"+uuid.NewString()+"/tree/media?path=demo.png", nil)
+	w.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get(echo.HeaderContentType); got != "image/jpeg" {
+		t.Fatalf("Content-Type = %q, want image/jpeg", got)
 	}
 }
 

--- a/backend/biz/project/handler/v1/project_media_test.go
+++ b/backend/biz/project/handler/v1/project_media_test.go
@@ -1,0 +1,151 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoYoko/web"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	"github.com/chaitin/MonkeyCode/backend/domain"
+	"github.com/chaitin/MonkeyCode/backend/middleware"
+)
+
+var testPNG = []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0, 0}
+
+func TestProjectMediaReturnsInlinePNG(t *testing.T) {
+	userID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	projectID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	stub := &projectMediaUsecaseStub{
+		blob: &domain.ProjectBlob{Content: testPNG, Sha: "png-sha", Size: len(testPNG)},
+	}
+	h := &ProjectHandler{usecase: stub}
+	w := web.New()
+	w.GET("/api/v1/users/projects/:id/tree/media", web.BindHandler(h.GetProjectMedia), projectMediaUser(userID))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/projects/"+projectID.String()+"/tree/media?path=docs%2Fdemo.png&ref=main", nil)
+	w.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Equal(rec.Body.Bytes(), testPNG) {
+		t.Fatalf("body = %v, want PNG bytes", rec.Body.Bytes())
+	}
+	if got := rec.Header().Get(echo.HeaderContentType); got != "image/png" {
+		t.Fatalf("Content-Type = %q, want image/png", got)
+	}
+	if got := rec.Header().Get(echo.HeaderContentDisposition); got != `inline; filename=demo.png` {
+		t.Fatalf("Content-Disposition = %q", got)
+	}
+	if got := rec.Header().Get(echo.HeaderContentLength); got != "12" {
+		t.Fatalf("Content-Length = %q, want 12", got)
+	}
+	if got := rec.Header().Get(echo.HeaderCacheControl); got != "private, max-age=3600" {
+		t.Fatalf("Cache-Control = %q", got)
+	}
+	if got := rec.Header().Get("ETag"); got != `"png-sha"` {
+		t.Fatalf("ETag = %q", got)
+	}
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q", got)
+	}
+	if stub.uid != userID || stub.req == nil || stub.req.ID != projectID || stub.req.Path != "docs/demo.png" || stub.req.Ref != "main" {
+		t.Fatalf("usecase request = uid %s, req %#v", stub.uid, stub.req)
+	}
+}
+
+func TestProjectMediaReturnsNotModifiedForMatchingETag(t *testing.T) {
+	stub := &projectMediaUsecaseStub{
+		blob: &domain.ProjectBlob{Content: testPNG, Sha: "png-sha", Size: len(testPNG)},
+	}
+	h := &ProjectHandler{usecase: stub}
+	w := web.New()
+	w.GET("/projects/:id/tree/media", web.BindHandler(h.GetProjectMedia), projectMediaUser(uuid.New()))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/projects/"+uuid.NewString()+"/tree/media?path=demo.png", nil)
+	req.Header.Set("If-None-Match", `"png-sha"`)
+	w.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("304 body = %q, want empty", rec.Body.String())
+	}
+}
+
+func TestProjectMediaRejectsUnsafeOrOversizedContent(t *testing.T) {
+	tests := []struct {
+		name       string
+		blob       *domain.ProjectBlob
+		wantStatus int
+	}{
+		{name: "HTML with png extension", blob: &domain.ProjectBlob{Content: []byte("<!doctype html><script>alert(1)</script>"), Size: 40}, wantStatus: http.StatusUnsupportedMediaType},
+		{name: "SVG", blob: &domain.ProjectBlob{Content: []byte(`<svg xmlns="http://www.w3.org/2000/svg"/>`), Size: 43}, wantStatus: http.StatusUnsupportedMediaType},
+		{name: "oversized image", blob: &domain.ProjectBlob{Content: testPNG, Size: maxProjectMediaSize + 1}, wantStatus: http.StatusRequestEntityTooLarge},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &ProjectHandler{usecase: &projectMediaUsecaseStub{blob: tt.blob}}
+			w := web.New()
+			w.GET("/projects/:id/tree/media", web.BindHandler(h.GetProjectMedia), projectMediaUser(uuid.New()))
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/projects/"+uuid.NewString()+"/tree/media?path=demo.png", nil)
+			w.Echo().ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d, body = %s", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestProjectMediaRejectsPathOutsideRepository(t *testing.T) {
+	stub := &projectMediaUsecaseStub{blob: &domain.ProjectBlob{Content: testPNG}}
+	h := &ProjectHandler{usecase: stub}
+	w := web.New()
+	w.GET("/projects/:id/tree/media", web.BindHandler(h.GetProjectMedia), projectMediaUser(uuid.New()))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/projects/"+uuid.NewString()+"/tree/media?path=..%2Fsecret.png", nil)
+	w.Echo().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if stub.req != nil {
+		t.Fatalf("usecase received unsafe path: %#v", stub.req)
+	}
+}
+
+type projectMediaUsecaseStub struct {
+	domain.ProjectUsecase
+	blob *domain.ProjectBlob
+	uid  uuid.UUID
+	req  *domain.GetProjectBlobReq
+}
+
+func (s *projectMediaUsecaseStub) GetProjectBlob(_ context.Context, uid uuid.UUID, req *domain.GetProjectBlobReq) (*domain.ProjectBlob, error) {
+	s.uid = uid
+	reqCopy := *req
+	s.req = &reqCopy
+	return s.blob, nil
+}
+
+func projectMediaUser(userID uuid.UUID) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			middleware.SetUser(c, &domain.User{ID: userID})
+			return next(c)
+		}
+	}
+}

--- a/backend/biz/project/usecase/project.go
+++ b/backend/biz/project/usecase/project.go
@@ -415,7 +415,7 @@ func (u *ProjectUsecase) GetProjectBlob(ctx context.Context, uid uuid.UUID, req 
 	}
 	resp, err := client.Blob(ctx, &domain.BlobOptions{
 		Token: cctx.Token, Owner: cctx.Owner, Repo: cctx.Repo,
-		Ref: ref, Path: req.Path,
+		Ref: ref, Path: req.Path, MaxSize: req.MaxSize,
 		InstallID: cctx.InstallID, IsOAuth: cctx.IsOAuth,
 	})
 	if err != nil {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -8928,6 +8928,80 @@
                 }
             }
         },
+        "/api/v1/users/projects/{id}/tree/media": {
+            "get": {
+                "security": [
+                    {
+                        "MonkeyCodeAIAuth": []
+                    }
+                ],
+                "description": "获取项目中的栅格图片原始内容，用于 README 等页面内联展示",
+                "produces": [
+                    "image/png",
+                    "image/jpeg",
+                    "image/gif",
+                    "image/webp"
+                ],
+                "tags": [
+                    "【用户】项目管理"
+                ],
+                "summary": "获取项目图片",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "项目ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "图片路径",
+                        "name": "path",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "分支",
+                        "name": "ref",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "成功",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "无效路径",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "未授权",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "413": {
+                        "description": "图片过大",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "415": {
+                        "description": "不支持的媒体类型",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/users/status": {
             "get": {
                 "description": "检查当前用户是否已登录，返回认证状态和用户信息",

--- a/backend/domain/git.go
+++ b/backend/domain/git.go
@@ -172,6 +172,7 @@ type BlobOptions struct {
 	Repo      string
 	Ref       string
 	Path      string
+	MaxSize   int64
 	InstallID int64
 	IsOAuth   bool
 }

--- a/backend/domain/project.go
+++ b/backend/domain/project.go
@@ -225,9 +225,10 @@ type GetProjectTreeReq struct {
 
 // GetProjectBlobReq 获取项目文件内容请求
 type GetProjectBlobReq struct {
-	ID   uuid.UUID `param:"id" validate:"required" json:"-" swaggerignore:"true"`
-	Path string    `query:"path" validate:"required"`
-	Ref  string    `query:"ref" validate:"omitempty"`
+	ID      uuid.UUID `param:"id" validate:"required" json:"-" swaggerignore:"true"`
+	Path    string    `query:"path" validate:"required"`
+	Ref     string    `query:"ref" validate:"omitempty"`
+	MaxSize int64     `json:"-" swaggerignore:"true"`
 }
 
 // GetProjectLogsReq 获取项目提交历史请求

--- a/backend/pkg/git/github/operation.go
+++ b/backend/pkg/git/github/operation.go
@@ -259,6 +259,34 @@ func (g *Github) GetBlob(ctx context.Context, installID int64, token, owner, rep
 }
 
 func getBlobWithClient(ctx context.Context, client *github.Client, owner, repo, ref, path string, maxSize int64) (*GetBlobResp, error) {
+	if maxSize <= 0 {
+		opts := &github.RepositoryContentGetOptions{}
+		if ref != "" {
+			opts.Ref = ref
+		}
+		fileContent, _, _, err := client.Repositories.GetContents(ctx, owner, repo, path, opts)
+		if err != nil {
+			return nil, fmt.Errorf("get file content: %w", err)
+		}
+		if fileContent == nil {
+			return nil, fmt.Errorf("path %s is a directory, not a file", path)
+		}
+		decoded, err := fileContent.GetContent()
+		if err != nil {
+			return nil, fmt.Errorf("decode file content: %w", err)
+		}
+		content := []byte(decoded)
+		return &GetBlobResp{
+			Content:  content,
+			IsBinary: isBinaryContent(content),
+			Sha:      fileContent.GetSHA(),
+			Size:     fileContent.GetSize(),
+		}, nil
+	}
+	return getLimitedBlobWithClient(ctx, client, owner, repo, ref, path, maxSize)
+}
+
+func getLimitedBlobWithClient(ctx context.Context, client *github.Client, owner, repo, ref, path string, maxSize int64) (*GetBlobResp, error) {
 	opts := &github.RepositoryContentGetOptions{}
 	if ref != "" {
 		opts.Ref = ref
@@ -266,6 +294,9 @@ func getBlobWithClient(ctx context.Context, client *github.Client, owner, repo, 
 	reader, fileContent, response, err := client.Repositories.DownloadContentsWithMeta(ctx, owner, repo, path, opts)
 	if err != nil {
 		return nil, fmt.Errorf("download file content: %w", err)
+	}
+	if reader == nil {
+		return nil, fmt.Errorf("download file content: empty response body")
 	}
 	defer reader.Close()
 	if response != nil && response.Response != nil && (response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices) {

--- a/backend/pkg/git/github/operation.go
+++ b/backend/pkg/git/github/operation.go
@@ -250,33 +250,47 @@ func parseTreeCommitInfoDate(e *treeCommitInfoEntryRaw) int64 {
 }
 
 // GetBlob 获取单文件内容（PAT 模式）
-func (g *Github) GetBlob(ctx context.Context, installID int64, token, owner, repo, ref, path string) (*GetBlobResp, error) {
+func (g *Github) GetBlob(ctx context.Context, installID int64, token, owner, repo, ref, path string, maxSize int64) (*GetBlobResp, error) {
 	client, err := g.GetClient(ctx, token, installID)
 	if err != nil {
 		return nil, err
 	}
+	return getBlobWithClient(ctx, client, owner, repo, ref, path, maxSize)
+}
 
+func getBlobWithClient(ctx context.Context, client *github.Client, owner, repo, ref, path string, maxSize int64) (*GetBlobResp, error) {
 	opts := &github.RepositoryContentGetOptions{}
 	if ref != "" {
 		opts.Ref = ref
 	}
-	fileContent, _, _, err := client.Repositories.GetContents(ctx, owner, repo, path, opts)
+	reader, fileContent, response, err := client.Repositories.DownloadContentsWithMeta(ctx, owner, repo, path, opts)
 	if err != nil {
-		return nil, fmt.Errorf("get file content: %w", err)
+		return nil, fmt.Errorf("download file content: %w", err)
+	}
+	defer reader.Close()
+	if response != nil && response.Response != nil && (response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices) {
+		return nil, fmt.Errorf("download file content: unexpected status %s", response.Status)
 	}
 	if fileContent == nil {
-		return nil, fmt.Errorf("path %s is a directory, not a file", path)
+		return nil, fmt.Errorf("download file content: missing metadata for %s", path)
 	}
-	decoded, err := fileContent.GetContent()
+	size := fileContent.GetSize()
+	if maxSize > 0 && int64(size) > maxSize {
+		return &GetBlobResp{Sha: fileContent.GetSHA(), Size: size}, nil
+	}
+	contentReader := io.Reader(reader)
+	if maxSize > 0 {
+		contentReader = io.LimitReader(reader, maxSize+1)
+	}
+	content, err := io.ReadAll(contentReader)
 	if err != nil {
-		return nil, fmt.Errorf("decode file content: %w", err)
+		return nil, fmt.Errorf("read file content: %w", err)
 	}
-	content := []byte(decoded)
 	return &GetBlobResp{
 		Content:  content,
 		IsBinary: isBinaryContent(content),
 		Sha:      fileContent.GetSHA(),
-		Size:     fileContent.GetSize(),
+		Size:     size,
 	}, nil
 }
 
@@ -438,7 +452,7 @@ func (g *Github) Tree(ctx context.Context, opts *domain.TreeOptions) (*domain.Ge
 
 // Blob 实现 GitPlatformClient 接口
 func (g *Github) Blob(ctx context.Context, opts *domain.BlobOptions) (*domain.GetBlobResp, error) {
-	resp, err := g.GetBlob(ctx, opts.InstallID, opts.Token, opts.Owner, opts.Repo, opts.Ref, opts.Path)
+	resp, err := g.GetBlob(ctx, opts.InstallID, opts.Token, opts.Owner, opts.Repo, opts.Ref, opts.Path, opts.MaxSize)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/git/github/operation_blob_test.go
+++ b/backend/pkg/git/github/operation_blob_test.go
@@ -1,0 +1,97 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	gh "github.com/google/go-github/v74/github"
+)
+
+func TestGetBlobWithClientDownloadsGitHubContentLargerThanOneMiB(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xab}, (1<<20)+1024)
+	server := newBlobServer(t, payload)
+	defer server.Close()
+
+	client := gh.NewClient(server.Client())
+	client.BaseURL = mustParseURL(t, server.URL+"/")
+
+	got, err := getBlobWithClient(context.Background(), client, "owner", "repo", "main", "docs/demo.png", 10<<20)
+	if err != nil {
+		t.Fatalf("getBlobWithClient() error = %v", err)
+	}
+	if !bytes.Equal(got.Content, payload) {
+		t.Fatalf("content length = %d, want %d", len(got.Content), len(payload))
+	}
+	if got.Sha != "large-sha" || got.Size != len(payload) {
+		t.Fatalf("blob metadata = %#v", got)
+	}
+}
+
+func TestGetBlobWithClientDoesNotBufferContentOverLimit(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xcd}, (2<<20)+1)
+	server := newBlobServer(t, payload)
+	defer server.Close()
+
+	client := gh.NewClient(server.Client())
+	client.BaseURL = mustParseURL(t, server.URL+"/")
+
+	got, err := getBlobWithClient(context.Background(), client, "owner", "repo", "main", "docs/demo.png", 1<<20)
+	if err != nil {
+		t.Fatalf("getBlobWithClient() error = %v", err)
+	}
+	if len(got.Content) != 0 {
+		t.Fatalf("content length = %d, want 0 for known oversized content", len(got.Content))
+	}
+	if got.Size != len(payload) {
+		t.Fatalf("size = %d, want %d", got.Size, len(payload))
+	}
+}
+
+func newBlobServer(t *testing.T, payload []byte) *httptest.Server {
+	t.Helper()
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/contents/docs/demo.png":
+			writeJSON(t, w, map[string]any{
+				"type": "file", "name": "demo.png", "path": "docs/demo.png",
+				"sha": "large-sha", "size": len(payload), "encoding": "none",
+				"download_url": server.URL + "/raw/demo.png",
+			})
+		case "/repos/owner/repo/contents/docs":
+			writeJSON(t, w, []map[string]any{{
+				"type": "file", "name": "demo.png", "path": "docs/demo.png",
+				"sha": "large-sha", "size": len(payload), "encoding": "none",
+				"download_url": server.URL + "/raw/demo.png",
+			}})
+		case "/raw/demo.png":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(payload)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return server
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse URL: %v", err)
+	}
+	return parsed
+}

--- a/backend/pkg/git/github/operation_blob_test.go
+++ b/backend/pkg/git/github/operation_blob_test.go
@@ -7,10 +7,25 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	gh "github.com/google/go-github/v74/github"
 )
+
+func TestGetBlobWithClientPreservesExistingLimitWithoutExplicitMaxSize(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xef}, (1<<20)+1)
+	server := newBlobServer(t, payload)
+	defer server.Close()
+
+	client := gh.NewClient(server.Client())
+	client.BaseURL = mustParseURL(t, server.URL+"/")
+
+	_, err := getBlobWithClient(context.Background(), client, "owner", "repo", "main", "docs/demo.png", 0)
+	if err == nil || !strings.Contains(err.Error(), "unsupported content encoding: none") {
+		t.Fatalf("error = %v, want existing GitHub content limit error", err)
+	}
+}
 
 func TestGetBlobWithClientDownloadsGitHubContentLargerThanOneMiB(t *testing.T) {
 	payload := bytes.Repeat([]byte{0xab}, (1<<20)+1024)

--- a/frontend/src/api/Api.ts
+++ b/frontend/src/api/Api.ts
@@ -7423,6 +7423,34 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
+     * @description 获取项目中的栅格图片原始内容，用于 README 等页面内联展示
+     *
+     * @tags 【用户】项目管理
+     * @name V1UsersProjectsTreeMediaDetail
+     * @summary 获取项目图片
+     * @request GET:/api/v1/users/projects/{id}/tree/media
+     * @secure
+     */
+    v1UsersProjectsTreeMediaDetail: (
+      id: string,
+      query: {
+        /** 图片路径 */
+        path: string;
+        /** 分支 */
+        ref?: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<File, string>({
+        path: `/api/v1/users/projects/${id}/tree/media`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "blob",
+        ...params,
+      }),
+
+    /**
      * @description 获取项目仓库日志
      *
      * @tags 【用户】项目管理

--- a/frontend/src/components/common/markdown.tsx
+++ b/frontend/src/components/common/markdown.tsx
@@ -151,6 +151,8 @@ interface MarkdownProps {
   fileLinkEnvid?: string
   /** Opens workspace file links in the current task context. */
   onWorkspaceFileClick?: (path: string) => void
+  /** Resolves image sources for context-specific content such as repository READMEs. */
+  resolveImageUrl?: (src: string) => string | undefined
   className?: string
 }
 
@@ -220,7 +222,7 @@ function resolveWorkspaceFileLink(href: string | undefined, envid: string | unde
   }
 }
 
-export const Markdown = memo(function Markdown({ children, allowHtml = false, allowInternalLink = true, fileLinkEnvid, onWorkspaceFileClick, className }: MarkdownProps) {
+export const Markdown = memo(function Markdown({ children, allowHtml = false, allowInternalLink = true, fileLinkEnvid, onWorkspaceFileClick, resolveImageUrl, className }: MarkdownProps) {
   const location = useLocation()
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === "dark"
@@ -255,9 +257,23 @@ export const Markdown = memo(function Markdown({ children, allowHtml = false, al
         </a>
       )
     },
+    img({ src, alt, ...props }) {
+      const resolvedSrc = resolveImageUrl ? resolveImageUrl(src ?? "") : src
+      if (!resolvedSrc) return alt ? <span>{alt}</span> : null
+
+      return (
+        <img
+          {...props}
+          src={resolvedSrc}
+          alt={alt ?? ""}
+          loading="lazy"
+          decoding="async"
+        />
+      )
+    },
     p: MarkdownParagraph,
     pre: ({ children }) => <MarkdownCodeBlock isDark={isDark}>{children}</MarkdownCodeBlock>,
-  }), [allowInternalLink, fileLinkEnvid, isDark, location.pathname, onWorkspaceFileClick])
+  }), [allowInternalLink, fileLinkEnvid, isDark, location.pathname, onWorkspaceFileClick, resolveImageUrl])
 
   return (
     <div className={cn("markdown-body pb-2", isDark ? "markdown-body-dark" : "markdown-body-light", className)}>

--- a/frontend/src/pages/console/user/project/overview/info-tab.tsx
+++ b/frontend/src/pages/console/user/project/overview/info-tab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { ProjectFileManager } from "@/components/console/project/files"
 import { Markdown } from "@/components/common/markdown"
 import { type DomainBranch, type DomainProject } from "@/api/Api"
@@ -14,6 +14,7 @@ import { Label } from "@/components/ui/label"
 import { IconFileText, IconLoader } from "@tabler/icons-react"
 import { cn } from "@/lib/utils"
 import { useTranslation } from "react-i18next"
+import { resolveReadmeMediaUrl } from "@/utils/readme-media"
 
 interface ProjectOverviewInfoTabProps {
   projectId: string
@@ -152,6 +153,17 @@ export default function ProjectOverviewInfoTab({ projectId, project }: ProjectOv
     }
   }, [project?.id, project?.git_identity_id, project?.full_name, readmeRef, readmeRefProjectId, readmeRefResolved])
 
+  const resolveReadmeImageUrl = useCallback((src: string) => {
+    if (!project?.id) return undefined
+
+    return resolveReadmeMediaUrl({
+      src,
+      readmePath,
+      projectId: project.id,
+      ref: readmeRef || undefined,
+    })
+  }, [project?.id, readmePath, readmeRef])
+
   const ReadmeHeader = (
     <div className="px-4 py-2 flex items-center border-b bg-muted/50">
       <Label className="flex items-center h-6">
@@ -196,7 +208,7 @@ export default function ProjectOverviewInfoTab({ projectId, project }: ProjectOv
       <div className={cn("flex flex-1 flex-col border rounded-md w-full max-w-full")}>
         {ReadmeHeader}
         <div className="p-4">
-          <Markdown>{readmeContent}</Markdown>
+          <Markdown allowHtml resolveImageUrl={resolveReadmeImageUrl}>{readmeContent}</Markdown>
         </div>
       </div>
     )

--- a/frontend/src/utils/readme-media.ts
+++ b/frontend/src/utils/readme-media.ts
@@ -1,0 +1,61 @@
+interface ResolveReadmeMediaOptions {
+  src: string
+  readmePath: string
+  projectId: string
+  ref?: string
+}
+
+const absoluteScheme = /^([a-z][a-z\d+.-]*):/i
+
+export function resolveReadmeMediaUrl({
+  src,
+  readmePath,
+  projectId,
+  ref,
+}: ResolveReadmeMediaOptions): string | undefined {
+  const trimmedSrc = src.trim()
+  if (!trimmedSrc || !projectId) return undefined
+
+  const scheme = absoluteScheme.exec(trimmedSrc)?.[1]?.toLowerCase()
+  if (scheme) {
+    return scheme === "http" || scheme === "https" ? trimmedSrc : undefined
+  }
+  if (trimmedSrc.startsWith("//")) return trimmedSrc
+  if (trimmedSrc.includes("\\")) return undefined
+
+  const rawPath = trimmedSrc.split(/[?#]/, 1)[0]
+  if (!rawPath) return undefined
+
+  let decodedPath: string
+  try {
+    decodedPath = decodeURIComponent(rawPath)
+  } catch {
+    return undefined
+  }
+
+  const repositoryPath = resolveRepositoryPath(decodedPath, readmePath)
+  if (!repositoryPath) return undefined
+
+  const params = new URLSearchParams({ path: repositoryPath })
+  if (ref) params.set("ref", ref)
+
+  return `/api/v1/users/projects/${encodeURIComponent(projectId)}/tree/media?${params.toString()}`
+}
+
+function resolveRepositoryPath(srcPath: string, readmePath: string): string | undefined {
+  const segments = srcPath.startsWith("/")
+    ? []
+    : readmePath.split("/").slice(0, -1).filter(Boolean)
+
+  for (const segment of srcPath.split("/")) {
+    if (!segment || segment === ".") continue
+    if (segment === "..") {
+      if (segments.length === 0) return undefined
+      segments.pop()
+      continue
+    }
+    segments.push(segment)
+  }
+
+  return segments.length > 0 ? segments.join("/") : undefined
+}

--- a/frontend/test/readme-media.test.ts
+++ b/frontend/test/readme-media.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
 import test from "node:test"
 
 import { resolveReadmeMediaUrl } from "../src/utils/readme-media.ts"
@@ -51,4 +52,17 @@ test("拒绝主动协议、空地址和越出仓库根目录的路径", () => {
   assert.equal(resolveReadmeMediaUrl({ ...options, src: "data:image/png;base64,AAAA" }), undefined)
   assert.equal(resolveReadmeMediaUrl({ ...options, src: "" }), undefined)
   assert.equal(resolveReadmeMediaUrl({ ...options, src: "../../../secret.png" }), undefined)
+})
+
+test("项目 README 启用安全 HTML 图片解析并保留生成的媒体 API 契约", () => {
+  const markdownSource = readFileSync(new URL("../src/components/common/markdown.tsx", import.meta.url), "utf8")
+  const infoTabSource = readFileSync(new URL("../src/pages/console/user/project/overview/info-tab.tsx", import.meta.url), "utf8")
+  const apiSource = readFileSync(new URL("../src/api/Api.ts", import.meta.url), "utf8")
+
+  assert.match(markdownSource, /rehypePlugins=\{allowHtml \? \[rehypeRaw, rehypeSanitize\] : \[\]\}/)
+  assert.match(markdownSource, /const resolvedSrc = resolveImageUrl \? resolveImageUrl\(src \?\? ""\) : src/)
+  assert.match(infoTabSource, /<Markdown allowHtml resolveImageUrl=\{resolveReadmeImageUrl\}>/)
+  assert.match(apiSource, /v1UsersProjectsTreeMediaDetail/)
+  assert.match(apiSource, /path: `\/api\/v1\/users\/projects\/\$\{id\}\/tree\/media`/)
+  assert.match(apiSource, /format: "blob"/)
 })

--- a/frontend/test/readme-media.test.ts
+++ b/frontend/test/readme-media.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { resolveReadmeMediaUrl } from "../src/utils/readme-media.ts"
+
+const options = {
+  projectId: "project/id",
+  readmePath: "docs/README.md",
+  ref: "feature/readme",
+}
+
+test("README 图片相对 README 所在目录解析，并保留项目和分支", () => {
+  const result = resolveReadmeMediaUrl({ ...options, src: "./images/demo.png" })
+
+  assert.equal(
+    result,
+    "/api/v1/users/projects/project%2Fid/tree/media?path=docs%2Fimages%2Fdemo.png&ref=feature%2Freadme",
+  )
+})
+
+test("README 图片支持父目录和仓库根目录路径", () => {
+  assert.match(
+    resolveReadmeMediaUrl({ ...options, src: "../assets/demo.png" }) ?? "",
+    /path=assets%2Fdemo\.png/,
+  )
+  assert.match(
+    resolveReadmeMediaUrl({ ...options, src: "/assets/demo.png" }) ?? "",
+    /path=assets%2Fdemo\.png/,
+  )
+})
+
+test("README 图片正确编码中文、空格和特殊文件名", () => {
+  const result = resolveReadmeMediaUrl({
+    ...options,
+    readmePath: "中文目录/README.md",
+    src: "图片/a%3Fb c.png#preview",
+  })
+
+  const url = new URL(result ?? "", "https://monkeycode.invalid")
+  assert.equal(url.searchParams.get("path"), "中文目录/图片/a?b c.png")
+})
+
+test("外部 HTTP(S) 和协议相对图片保持原地址", () => {
+  assert.equal(resolveReadmeMediaUrl({ ...options, src: "https://example.com/a.png" }), "https://example.com/a.png")
+  assert.equal(resolveReadmeMediaUrl({ ...options, src: "http://example.com/a.png" }), "http://example.com/a.png")
+  assert.equal(resolveReadmeMediaUrl({ ...options, src: "//example.com/a.png" }), "//example.com/a.png")
+})
+
+test("拒绝主动协议、空地址和越出仓库根目录的路径", () => {
+  assert.equal(resolveReadmeMediaUrl({ ...options, src: "javascript:alert(1)" }), undefined)
+  assert.equal(resolveReadmeMediaUrl({ ...options, src: "data:image/png;base64,AAAA" }), undefined)
+  assert.equal(resolveReadmeMediaUrl({ ...options, src: "" }), undefined)
+  assert.equal(resolveReadmeMediaUrl({ ...options, src: "../../../secret.png" }), undefined)
+})


### PR DESCRIPTION
## 问题

项目「信息」页中的 README 无法展示仓库内相对路径图片：Markdown 图片显示为破图，原生 HTML 图片语法显示为文本。

Closes #957

## 修改范围

### 后端

- 新增受现有项目鉴权保护的 `GET /api/v1/users/projects/{id}/tree/media` 接口。
- 复用项目 blob 读取逻辑，支持按 `path` 和 `ref` 获取 README 图片。
- 仅允许 PNG、JPEG、GIF、WebP，并依据文件内容嗅探真实 `Content-Type`。
- 支持读取超过 GitHub Contents API 1 MiB 内联限制的仓库图片。
- 媒体读取上限为 10 MiB：已知大小时提前拒绝，未知大小时使用有界读取，避免无上限缓冲。
- 普通 blob 请求继续沿用原有读取路径，避免扩大既有接口的读取范围。
- 增加 `ETag`、`private, no-cache`、inline disposition 与 `nosniff` 响应头。

### 前端

- 为通用 Markdown 组件增加可选 `resolveImageUrl` 扩展点，不改变其他调用方的默认行为。
- 项目 README 基于 README 所在目录解析相对图片，并保留项目 ID 与当前分支。
- 支持父目录、仓库根路径、中文、空格和外部 HTTP(S) 图片。
- 拒绝 `data:`、`javascript:`、反斜杠和越出仓库根目录的路径。
- 在项目 README 场景启用经现有 `rehype-sanitize` 净化后的原生 HTML，以支持 `<details>` / `<img>`。
- 同步 Swagger 文档与生成的前端 Blob API 契约（`format: "blob"`）。

## 测试证据

- `go test ./pkg/git/github ./biz/project/handler/v1` ✅
- `go test -race ./pkg/git/... ./biz/project/...` ✅
- `npx --yes tsx --test test/readme-media.test.ts` ✅（6/6）
- `npm run lint` ✅
- `npm run build` ✅
- `jq empty backend/docs/swagger.json` ✅
- Chrome 端到端验证 ✅
  - 两张 Markdown 相对图片均解码为 `1440 × 1000`
  - 一张原生 HTML 图片解码为 `390 × 3390`
  - 测试样本扩展名为 `.png`、实际内容为 JPEG，服务端正确返回 `image/jpeg`

> 构建仍会显示仓库环境已有的 Node.js 版本建议及大 chunk 提示，构建退出码为 0，与本次修改无关。

## 截图

修复后：Markdown 相对图片正常展示：
<img width="1920" height="872" alt="clipboard" src="https://github.com/user-attachments/assets/f1fc2731-8737-411e-af12-f37dcbafc56a" />

修复后：经安全净化的原生 HTML `<img>` 正常展示：

<img width="1920" height="872" alt="clipboard" src="https://github.com/user-attachments/assets/77ca0091-461a-4fc3-a10b-3dca169e3516" />
