### PR TITLE
feat(desktop): 任务提示音开关(设置页 + 托盘)

### DIFF
--- a/desktop/ARCHITECTURE.md
+++ b/desktop/ARCHITECTURE.md
@@ -127,8 +127,12 @@ folded.jsonl",TS 钉住 `reduceBatch(raw) ≡ reduceBatch(folded)`
 ~/.ohmyagent;WSL 模式下引擎数据仍留宿主侧,该路径经 wslpath 翻成 guest
 形态注入;扩展完成配对后 mcp.json 才注入 mc-browser 内置条目,URL/Bearer
 进程级新发,WSL 下另要求 networking-mode=mirrored;首次配对/重置配对在
-所有前台/后台任务空闲后自动重启 Agent 刷新工具集)。壳自有偏好(桌宠)走
-原子 read-modify-write,只写权威、不触发物化。
+所有前台/后台任务空闲后自动重启 Agent 刷新工具集)。壳自有偏好(桌宠、
+提示音)走原子 read-modify-write,只写权威、不触发物化——它们不在设置页
+表单里,表单保存必须从磁盘合并这几个字段,否则被 serde 默认值打回。
+提示音 `sound_enabled` 有设置页与托盘两个入口,壳持运行时真值并经
+`sound-enabled` 事件广播,音效本身由桌宠页 pet.html 播放(桌宠隐藏后
+webview 仍在跑,所以"关桌宠"不等于"静音",两个开关独立)。
 
 模型物化按**别名**作键,每条恒写 8 键:`type/model/base_url/api_key/
 context_window/supports_images/max_output/thinking`。桌面缺省显式压过

--- a/desktop/src/config.rs
+++ b/desktop/src/config.rs
@@ -3,8 +3,9 @@
 // DesktopConfig 是应用权威配置；引擎 settings.json/mcp.json 只是可重建的
 // 派生物。所有权威配置读改写经 ConfigStore 串行，并使用同目录临时文件
 // 原子替换；损坏的主文件只允许从有效备份恢复，绝不能静默退成默认配置后
-// 覆盖用户的模型/API Key。pet_*(托盘切换)与 telemetry_enabled(仅改文件)
-// 都不在设置页表单里，设置页保存时必须从磁盘合并，否则会被默认值打回。
+// 覆盖用户的模型/API Key。pet_*(托盘切换)、sound_enabled(设置页/托盘即时
+// 开关)与 telemetry_enabled(仅改文件)都不在设置页表单里，设置页保存时必须
+// 从磁盘合并，否则会被默认值打回。
 
 use std::ffi::OsString;
 use std::fs;
@@ -88,6 +89,11 @@ pub struct DesktopConfig {
     /// 桌宠开关(托盘菜单切换)
     #[serde(default = "default_true")]
     pub pet_enabled: bool,
+    /// 事件提示音开关(设置页与托盘菜单切换)。关掉后桌宠页的五种音效
+    /// (启动/轮次完成/出错/请求审批/空闲提醒)全部静音;桌宠是否显示不影响
+    /// 音效(pet.html 隐藏后仍在跑),两个开关彼此独立。
+    #[serde(default = "default_true")]
+    pub sound_enabled: bool,
     /// 桌宠窗口位置(物理像素;拖动后记忆)
     #[serde(default)]
     pub pet_pos: Option<(i32, i32)>,
@@ -110,6 +116,7 @@ impl Default for DesktopConfig {
             mc_llm_base_url: String::new(),
             agent_engine: default_engine(),
             pet_enabled: true,
+            sound_enabled: true,
             pet_pos: None,
             telemetry_enabled: true,
         }
@@ -370,12 +377,14 @@ pub fn save_ui_config_files(
     Ok(cfg)
 }
 
-/// 设置页表单只覆盖它自己呈现的字段。桌宠偏好由托盘切换、统计开关只由改文件
-/// 关闭,两者都不在表单里——incoming 携带的是 serde 默认值(全为"开")。不从
+/// 设置页表单只覆盖它自己呈现的字段。桌宠偏好由托盘切换、提示音开关走自己的
+/// 即时命令(set_sound_enabled,点一下就落盘,不进保存条)、统计开关只由改文件
+/// 关闭,三者都不在表单里——incoming 携带的是 serde 默认值(全为"开")。不从
 /// 磁盘捞回来,用户关掉的东西会被下一次"保存设置"静默打开。
 fn merge_shell_prefs(incoming: DesktopConfig, disk: &DesktopConfig) -> DesktopConfig {
     DesktopConfig {
         pet_enabled: disk.pet_enabled,
+        sound_enabled: disk.sound_enabled,
         pet_pos: disk.pet_pos,
         telemetry_enabled: disk.telemetry_enabled,
         ..incoming
@@ -810,6 +819,7 @@ mod tests {
     fn saving_ui_settings_preserves_preferences_outside_the_form() {
         let disk = DesktopConfig {
             pet_enabled: false,
+            sound_enabled: false,
             pet_pos: Some((12, 34)),
             telemetry_enabled: false,
             ..Default::default()
@@ -825,6 +835,7 @@ mod tests {
 
         assert!(!merged.telemetry_enabled, "统计开关必须保留磁盘上的关闭态");
         assert!(!merged.pet_enabled);
+        assert!(!merged.sound_enabled, "提示音开关同样不在表单里,必须保留关闭态");
         assert_eq!(merged.pet_pos, Some((12, 34)));
         assert_eq!(merged.kernel_env, "wsl:Ubuntu", "表单字段仍应生效");
     }
@@ -834,6 +845,7 @@ mod tests {
     fn config_without_telemetry_field_defaults_to_enabled() {
         let cfg: DesktopConfig = serde_json::from_str(r#"{"models":[],"pet_enabled":false}"#).unwrap();
         assert!(cfg.telemetry_enabled);
+        assert!(cfg.sound_enabled, "升级到带提示音开关的版本不该静音");
         assert!(!cfg.pet_enabled, "同一份 JSON 里显式给出的字段不受影响");
     }
 

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -68,6 +68,15 @@ struct UiIntent(Mutex<Option<String>>);
 /// 桌宠开关的运行时缓存(真值落 config.json)。
 struct PetEnabled(AtomicBool);
 
+/// 事件提示音开关的运行时缓存(真值落 config.json)。音效由桌宠页 pet.html
+/// 播放,开关由设置页与托盘两处切换,故运行时真值收在壳里,变更经
+/// `sound-enabled` 事件广播给两个 webview。
+struct SoundEnabled(AtomicBool);
+
+/// 托盘的提示音勾选项。设置页切换时要把托盘勾选态改过来,否则两处显示会打架;
+/// 托盘创建失败(无托盘宿主)时为 None,设置页照常工作。
+struct TraySoundItem(Mutex<Option<CheckMenuItem<tauri::Wry>>>);
+
 /// 桌宠位置暂存:Moved 事件在拖动中高频触发,不能逐次写盘;
 /// 退出与托盘开关切换时经 persist_pet_prefs 落盘。
 struct PetPos(Mutex<Option<(i32, i32)>>);
@@ -1081,6 +1090,34 @@ fn persist_pet_prefs(app: &AppHandle) {
     }
 }
 
+/// 提示音开关当前值(桌宠页启动时读一次;设置页渲染开关用)。
+#[tauri::command]
+fn sound_enabled(app: AppHandle) -> bool {
+    app.state::<SoundEnabled>().0.load(Ordering::Relaxed)
+}
+
+/// 设置页切换提示音。与主题一样点一下即生效:不进保存条、不重启引擎。
+#[tauri::command]
+fn set_sound_enabled(app: AppHandle, enabled: bool) {
+    apply_sound_enabled(&app, enabled);
+}
+
+/// 提示音开关的唯一落点(设置页命令与托盘勾选项共用):更新运行时真值 →
+/// 同步托盘勾选态 → 广播给桌宠页与设置页 → 落盘。
+///
+/// 广播先于落盘:静音是用户此刻就要的效果,写盘失败(磁盘满/权限)不该让
+/// 本次静音也失效——下次启动回到旧值即可,而不是"点了没反应"。
+fn apply_sound_enabled(app: &AppHandle, enabled: bool) {
+    app.state::<SoundEnabled>().0.store(enabled, Ordering::Relaxed);
+    if let Some(item) = app.state::<TraySoundItem>().0.lock_ok().as_ref() {
+        let _ = item.set_checked(enabled);
+    }
+    let _ = app.emit("sound-enabled", enabled);
+    if let Err(e) = config::update_config_json(app, |cfg| cfg.sound_enabled = enabled) {
+        eprintln!("[desktop] 提示音开关保存失败: {e}");
+    }
+}
+
 fn main() {
     eprintln!("[desktop] main 进入");
     // Linux:桌宠依赖 set_position / always_on_top / skip_taskbar,这些在
@@ -1108,6 +1145,8 @@ fn main() {
         .manage(TrayReady(AtomicBool::new(true)))
         .manage(UiIntent(Mutex::new(None)))
         .manage(PetEnabled(AtomicBool::new(true)))
+        .manage(SoundEnabled(AtomicBool::new(true)))
+        .manage(TraySoundItem(Mutex::new(None)))
         .manage(PetPos(Mutex::new(None)))
         .manage(EngineApply(Mutex::new(())))
         .manage(BrowserMcpRefresh(AtomicU64::new(0)))
@@ -1122,6 +1161,8 @@ fn main() {
             show_main,
             open_devtools,
             pet_native_render,
+            sound_enabled,
+            set_sound_enabled,
             update_check,
             update_install,
             open_extension_dir,
@@ -1203,12 +1244,15 @@ fn main() {
             app.state::<PetEnabled>()
                 .0
                 .store(cfg.pet_enabled, Ordering::Relaxed);
+            app.state::<SoundEnabled>()
+                .0
+                .store(cfg.sound_enabled, Ordering::Relaxed);
             *app.state::<PetPos>()
                 .0
                 .lock_ok() = cfg.pet_pos;
 
             // 托盘失败只降级(无托盘宿主的桌面环境),不阻塞
-            if let Err(e) = setup_tray(app.handle(), cfg.pet_enabled) {
+            if let Err(e) = setup_tray(app.handle(), cfg.pet_enabled, cfg.sound_enabled) {
                 eprintln!("[desktop] 托盘创建失败(关窗将直接退出): {e}");
                 app.state::<TrayReady>().0.store(false, Ordering::Relaxed);
             }
@@ -1335,7 +1379,7 @@ fn main() {
 }
 
 /// 创建托盘:菜单(显示窗口/设置/退出)+ 左键单击恢复窗口。
-fn setup_tray(app: &AppHandle, pet_enabled: bool) -> tauri::Result<()> {
+fn setup_tray(app: &AppHandle, pet_enabled: bool, sound_enabled: bool) -> tauri::Result<()> {
     let show = MenuItem::with_id(app, "show", "显示窗口", true, None::<&str>)?;
     let settings = MenuItem::with_id(app, "settings", "设置", true, None::<&str>)?;
     let pet = CheckMenuItem::with_id(
@@ -1346,9 +1390,19 @@ fn setup_tray(app: &AppHandle, pet_enabled: bool) -> tauri::Result<()> {
         pet_enabled,
         None::<&str>,
     )?;
+    let sound = CheckMenuItem::with_id(
+        app,
+        "toggle-sound",
+        "任务提示音",
+        true,
+        sound_enabled,
+        None::<&str>,
+    )?;
+    // 设置页切换时要回改这个勾选项(见 apply_sound_enabled)
+    *app.state::<TraySoundItem>().0.lock_ok() = Some(sound.clone());
     let update = MenuItem::with_id(app, "check-update", "检查更新", true, None::<&str>)?;
     let quit = MenuItem::with_id(app, "quit", "退出 MonkeyCode", true, None::<&str>)?;
-    let menu = Menu::with_items(app, &[&show, &settings, &pet, &update, &quit])?;
+    let menu = Menu::with_items(app, &[&show, &settings, &pet, &sound, &update, &quit])?;
     let tray = TrayIconBuilder::new()
         .icon(tray_icon())
         .tooltip("MonkeyCode")
@@ -1375,6 +1429,12 @@ fn setup_tray(app: &AppHandle, pet_enabled: bool) -> tauri::Result<()> {
                     .store(enabled, Ordering::Relaxed);
                 persist_pet_prefs(app);
                 set_pet_visible(app, enabled);
+            }
+            // 提示音开关:CheckMenuItem 已自翻勾选态,apply 里的 set_checked 是
+            // 幂等回写(设置页那条路径才真正需要它)
+            "toggle-sound" => {
+                let enabled = !app.state::<SoundEnabled>().0.load(Ordering::Relaxed);
+                apply_sound_enabled(app, enabled);
             }
             "check-update" => {
                 let app = app.clone();

--- a/desktop/ui/public/pet.html
+++ b/desktop/ui/public/pet.html
@@ -87,8 +87,15 @@
     }).catch(() => {});
   }
 
-  // 事件音效:桌宠被用户隐藏时 webview 仍在运行,所以音效仍会响。
+  // 事件音效:桌宠被用户隐藏时 webview 仍在运行,所以音效仍会响——想要安静
+  // 得关提示音开关(设置页「通用与更新 → 提示音」或托盘「任务提示音」),
+  // 它与桌宠显示开关彼此独立。真值在壳(config.json 的 sound_enabled),
+  // 这里启动读一次、之后跟 sound-enabled 事件走。
   // 同一音效 2s 内只响一次,避免并发叠音。
+  let soundEnabled = true;
+  window.__TAURI__.event.listen('sound-enabled', (evt) => {
+    soundEnabled = evt.payload !== false;
+  });
   const sounds = {
     start: new Audio('sound-app-start.mp3'),      // 应用启动(首次连上内核)
     end: new Audio('sound-task-end.mp3'),         // 轮次完成
@@ -99,6 +106,7 @@
   for (const a of Object.values(sounds)) a.volume = 0.7;
   const lastPlay = {};
   function play(key) {
+    if (!soundEnabled) return;
     const now = Date.now();
     if (now - (lastPlay[key] || 0) < 2000) return;
     lastPlay[key] = now;
@@ -243,7 +251,12 @@
 
   // 周期性快照兜底:探活(引擎停了没有任何事件外显)+ 收敛漏掉的状态
   setInterval(() => { if (online) snapshot(); }, 10000);
-  snapshot();
+  // 首次快照会放启动音,所以先把开关取回来再快照:否则关掉提示音的用户
+  // 每次启动仍要挨一声。取不到(命令异常)按默认"开"继续,不拖住状态渲染。
+  invoke('sound_enabled')
+    .then((on) => { soundEnabled = on !== false; })
+    .catch(() => {})
+    .then(snapshot);
 
   // ---- 交互:拖动(位移阈值)与点击(唤回主窗口) ----
   // macOS 不能走原生 startDragging:tao 在 mac 上用 performWindowDragWithEvent,

--- a/desktop/ui/src/host.ts
+++ b/desktop/ui/src/host.ts
@@ -108,6 +108,20 @@ export async function saveHostConfig(config: HostConfig): Promise<void> {
   await invoke("save_config", { config });
 }
 
+/** 事件提示音开关(桌宠页那五种音效的总闸)。真值在壳的 config.json,与
+ * 托盘「任务提示音」同源;非壳环境(浏览器模式没有桌宠也就没有音效)返回
+ * 开,设置页不渲染这一项。 */
+export async function getSoundEnabled(): Promise<boolean> {
+  if (!tauri()?.core?.invoke) return true;
+  return invoke<boolean>("sound_enabled");
+}
+
+/** 切换提示音:与主题一样点一下即生效并落盘,不进保存条、不重启引擎。
+ * 壳会广播 sound-enabled 让桌宠页与托盘勾选态一起跟上。 */
+export async function setSoundEnabled(enabled: boolean): Promise<void> {
+  await invoke("set_sound_enabled", { enabled });
+}
+
 /** 在文件管理器中定位随桌面包分发的浏览器扩展目录(用户在扩展管理页
  * 「加载已解压的扩展程序」时选它)。返回目录路径;非壳环境返回 null。 */
 export async function openExtensionDir(): Promise<string | null> {

--- a/desktop/ui/src/settings.tsx
+++ b/desktop/ui/src/settings.tsx
@@ -10,14 +10,17 @@ import { baizhiStatus } from "./baizhiapi";
 import {
   getBrowserExtStatus,
   getHostConfig,
+  getSoundEnabled,
   inDesktopShell,
   isMacShell,
   isWindowsShell,
   listWslDistros,
   exportEngineLog,
+  onHostEvent,
   openExtensionDir,
   repairBrowserExt,
   saveHostConfig,
+  setSoundEnabled,
   updateCheck,
   updateInstall,
 } from "./host";
@@ -671,6 +674,25 @@ export function SettingsView({
   const pickAccent = (next: AccentKey) => {
     setAccent(next);
     setAccentState(next);
+  };
+  // 提示音也不进保存条(壳侧即时落盘,不重启内核),但真值在 config.json 而非
+  // localStorage:桌宠是另一个 webview,得由壳广播才能一起静音。托盘那个勾选项
+  // 是同一开关的另一入口,订阅 sound-enabled 让两处显示不打架。
+  const [soundOn, setSoundOn] = useState(true);
+  useEffect(() => {
+    let alive = true;
+    void getSoundEnabled().then((on) => {
+      if (alive) setSoundOn(on);
+    }).catch(() => {});
+    const off = onHostEvent<boolean>("sound-enabled", (on) => setSoundOn(on !== false));
+    return () => {
+      alive = false;
+      off();
+    };
+  }, []);
+  const pickSound = (next: boolean) => {
+    setSoundOn(next); // 乐观置位:壳广播会回来盖一次,失败则由它纠回
+    void setSoundEnabled(next).catch(() => void getSoundEnabled().then(setSoundOn).catch(() => {}));
   };
 
   // 登录态由 Shell 持有:账号页 BaizhiCard 与模型/MCP 页的引导条共用
@@ -1531,12 +1553,11 @@ export function SettingsView({
 
   // ---- 通用 ----
 
-  /** 主题分段控件的一格(选中格用卡面+投影浮起,未选中格只留弱文字) */
-  const themeBtn = (value: Theme, label: string) => {
-    const on = theme === value;
+  /** 分段控件的一格(选中格用卡面+投影浮起,未选中格只留弱文字) */
+  const segBtn = (label: string, on: boolean, onClick: () => void) => {
     return (
       <button
-        onClick={() => pickTheme(value)}
+        onClick={onClick}
         style={{
           border: "none",
           borderRadius: 6,
@@ -1554,6 +1575,8 @@ export function SettingsView({
       </button>
     );
   };
+
+  const themeBtn = (value: Theme, label: string) => segBtn(label, theme === value, () => pickTheme(value));
 
   /** 主题色色板一枚。圆点用该色**自己**的 --acc(gen/accents.ts 里生成的
    *  swatch),不能写 var(--acc)——那是"当前选中的色",四枚会长得一模一样。 */
@@ -1604,6 +1627,22 @@ export function SettingsView({
           </div>
         </div>
       </Section>
+      {/* 提示音:音效由桌宠页播放(隐藏桌宠不等于静音),故仅桌面壳有此项。
+          与主题同为"点一下即生效"的偏好,不进保存条也不重启内核 */}
+      {desktop && (
+        <Section label="提示音">
+          <div className="card card-lg" style={{ padding: "14px 16px", display: "flex", alignItems: "center", gap: 14 }}>
+            <div style={{ display: "flex", background: "var(--segBg)", borderRadius: 8, padding: 3, gap: 2 }}>
+              {segBtn("开", soundOn, () => pickSound(true))}
+              {segBtn("关", !soundOn, () => pickSound(false))}
+            </div>
+            <span style={{ fontSize: 12, color: "var(--t5)", lineHeight: 1.7 }}>
+              任务完成、出错、请求审批、长时间空闲提醒与应用启动的音效。切换立即生效;
+              托盘菜单的「任务提示音」是同一个开关。
+            </span>
+          </div>
+        </Section>
+      )}
       {/* 内核运行环境:Windows 本机 / WSL 发行版(仅 Windows 壳显示)。
           发行版列表读注册表(list_wsl_distros),未装 WSL 即空列表只留本机;
           当前值不在列表(发行版被删)时保留一个标注项,用户能看到现状并切走。 */}


### PR DESCRIPTION
桌宠页的五种音效(启动/轮次完成/出错/请求审批/空闲提醒)此前无开关,
且桌宠隐藏后 webview 仍在跑,"关桌宠"并不等于静音,只能忍。

config.json 加 sound_enabled(默认 true,老配置升级不静音),壳持运行时 真值并经 sound-enabled 事件广播;设置页「通用与更新 → 提示音」与托盘
「任务提示音」是同一个开关,任一处切换另一处跟上。与主题同为点一下即
生效的偏好:不进保存条、不重启内核。广播先于落盘——写盘失败不该让本次
静音也失效。

pet.html 首次快照前先取回开关,否则关掉提示音的用户每次启动仍要挨一声
启动音。sound_enabled 不在设置页表单里,故 merge_shell_prefs 必须从磁盘 捞回,防被 serde 默认值打回(与 pet_*/telemetry_enabled 同款陷阱)。