### PR TITLE
fix(desktop): 修复百智云登录后模型与 MCP 未同步

### DIFF
--- a/desktop/ui/src/baizhi.tsx
+++ b/desktop/ui/src/baizhi.tsx
@@ -6,11 +6,10 @@ import {
   baizhiLogin,
   baizhiLogout,
   baizhiSendCode,
-  baizhiSync,
   baizhiWechatPoll,
   baizhiWechatStart,
 } from "./baizhiapi";
-import type { BaizhiStatus, BaizhiSyncResult, SyncApplyResult } from "./types";
+import type { BaizhiStatus } from "./types";
 import { MONO } from "./components";
 import { Field, input, whiteBtn } from "./settings-ui";
 import baizhiLogoUrl from "./baizhi-logo.png";
@@ -45,9 +44,10 @@ export function BaizhiCard({
   status,
   statusErr,
   refreshStatus,
-  onSynced,
+  syncing,
+  syncMsg,
+  onSync,
   onLoggedIn,
-  knownKeys,
 }: {
   /** 登录态(宿主查询并持有;null=读取中) */
   status: BaizhiStatus | null;
@@ -55,12 +55,16 @@ export function BaizhiCard({
   statusErr: string;
   /** 让宿主重新查询登录态(登录/登出/扫码成功后调用) */
   refreshStatus: () => Promise<void>;
-  /** 同步结果并入设置表单;返回跨组撞名被跳过的名字(外显提示用) */
-  onSynced: (r: BaizhiSyncResult) => SyncApplyResult;
+  /** 同步的进行态与结果文案。同步流水线(拉取→并入表单→自动保存)整体在
+   * SettingsView:登录会同时起百智云与 MonkeyCode 两路同步,任一路先落地都会
+   * 把分区切到模型页(mergeSyncedModels),本卡随之卸载——挂在卡里的收尾会把
+   * 这一路已经拉到的模型与 MCP 一起丢掉,只剩先到的那一组 */
+  syncing: boolean;
+  syncMsg: { text: string; color: string } | null;
+  onSync: () => void;
   /** 真实登录事件(短信/扫码成功各一次)。宿主据此顺带连上 MonkeyCode
    * ——只报边沿,不报 status 快照:后者每次打开设置都会翻转 */
   onLoggedIn?: () => void;
-  knownKeys: () => string[];
 }) {
   const [mode, setMode] = useState<"wechat" | "phone">("wechat");
   const [phone, setPhone] = useState("");
@@ -71,8 +75,6 @@ export function BaizhiCard({
   const [err, setErr] = useState("");
   const [qr, setQr] = useState("");
   const [wxState, setWxState] = useState<WxState>("loading");
-  const [syncing, setSyncing] = useState(false);
-  const [syncMsg, setSyncMsg] = useState<{ text: string; color: string } | null>(null);
   const mounted = useRef(true);
   const wxGen = useRef(0); // 代号:模式切换/重新获取/卸载时作废旧轮询循环
 
@@ -105,13 +107,13 @@ export function BaizhiCard({
         }
         if (res.status === "ok") {
           await refreshStatus();
-          // 登录成功即自动同步(用户拍板,免手动点)。不能用 live() 甄别:
-          // loggedIn 翻转会触发拉码 effect 的 cleanup 使 gen 作废,而这里
-          // 恰恰是登录成功之后
-          if (mounted.current) {
-            onLoggedIn?.();
-            void doSync();
-          }
+          // 登录成功即自动同步(用户拍板,免手动点)。两个回调都在宿主
+          // (SettingsView),这里不再补 mounted 判据:refreshStatus 期间另一路
+          // 同步可能落地并切分区把本卡卸载,漏掉就等于登录了却什么都不同步。
+          // 也不能用 live() 甄别——loggedIn 翻转会触发拉码 effect 的 cleanup
+          // 使 gen 作废,而这里恰恰是登录成功之后
+          onLoggedIn?.();
+          onSync();
           return;
         }
         setWxState(res.status); // expired / canceled → 引导重新获取
@@ -172,11 +174,10 @@ export function BaizhiCard({
     try {
       await baizhiLogin(phone.trim(), code.trim());
       await refreshStatus();
-      if (mounted.current) {
-        setCode("");
-        onLoggedIn?.();
-        void doSync(); // 登录成功即自动同步(用户拍板,免手动点)
-      }
+      if (mounted.current) setCode("");
+      // 同上:登录成功即自动同步,两个回调在宿主,卡是否还挂着都要走
+      onLoggedIn?.();
+      onSync();
     } catch (e) {
       if (mounted.current) setErr(e instanceof Error ? e.message : String(e));
     } finally {
@@ -191,41 +192,6 @@ export function BaizhiCard({
       await refreshStatus();
     } catch (e) {
       if (mounted.current) setErr(e instanceof Error ? e.message : String(e));
-    }
-  };
-
-  // 同步即全量导入(用户拍板,不再逐条挑选):结果整组并入设置表单,
-  // 交保存条落盘重启;不想要的条目可在模型页删除(重同步会恢复)
-  const doSync = async () => {
-    setSyncMsg(null);
-    setSyncing(true);
-    try {
-      const r = await baizhiSync(knownKeys());
-      if (!mounted.current) return;
-      if (!r.models.length && !Object.keys(r.mcp_servers ?? {}).length) {
-        setSyncMsg({ text: "没有拉取到可用的模型" + (r.notes?.length ? `(${r.notes.join(";")})` : ""), color: "var(--err)" });
-        return;
-      }
-      const applied = onSynced(r);
-      const parts = [`已同步 ${r.models.length - applied.skipped.length} 个模型`];
-      if (Object.keys(r.mcp_servers ?? {}).length) parts.push("MCP 条目");
-      if (r.key_created) parts.push(`已在网关新建密钥「${r.key_name || "MonkeyCode"}」`);
-      parts.push(
-        applied.autoSaved
-          ? "正在保存并重启内核…"
-          : applied.blocked === "busy"
-            ? "有任务正在执行,空闲后请手动保存(保存会重启内核)"
-            : applied.blocked === "dirty"
-              ? "表单有未保存的修改,请核对后手动保存"
-              : "已切到模型页,核对后保存",
-      );
-      // 跨组撞名先到先得:跳过必须外显,否则"少了几个模型"查无对证
-      if (applied.skipped.length) parts.push(`与现有条目同名已跳过: ${applied.skipped.join("、")}(想改用百智云通道请删除原条目后重新同步)`);
-      setSyncMsg({ text: parts.join("、"), color: "var(--ok)" });
-    } catch (e) {
-      if (mounted.current) setSyncMsg({ text: e instanceof Error ? e.message : String(e), color: "var(--err)" });
-    } finally {
-      if (mounted.current) setSyncing(false);
     }
   };
 
@@ -253,7 +219,7 @@ export function BaizhiCard({
           {err && <span style={{ fontSize: 12, color: "var(--err)", flex: "none" }}>{err}</span>}
           <button
             className="hv-acc"
-            onClick={() => !syncing && void doSync()}
+            onClick={() => !syncing && onSync()}
             style={{ ...whiteBtn, flex: "none", gap: 6, background: "var(--acc)", borderColor: "var(--acc)", color: "var(--onAcc)", opacity: syncing ? 0.7 : 1, cursor: syncing ? "default" : "pointer" }}
           >
             {syncing && (

--- a/desktop/ui/src/baizhiCard.test.tsx
+++ b/desktop/ui/src/baizhiCard.test.tsx
@@ -1,0 +1,40 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { BaizhiCard } from "./baizhi";
+import type { BaizhiStatus } from "./types";
+
+const loggedIn: BaizhiStatus = { logged_in: true, host: "baizhi.cloud", profile: { name: "阿茂" } };
+const noop = async () => {};
+
+/** 回归:同步流水线(拉取→并入表单→自动保存)必须整体在宿主(SettingsView),
+ * 卡只做受控展示。曾经它挂在卡内,而登录会同时起百智云与 MonkeyCode 两路同步
+ * ——先落地的那路把分区切到模型页并卸载账号卡,晚到的一路回来只看到自己已被
+ * 卸载,整份 {models, mcp_servers} 连同报错一起被丢弃(表现为"登录百智云后只
+ * 同步到会员模型,百智云的模型和 MCP 都没有")。 */
+describe("BaizhiCard(同步态由宿主持有)", () => {
+  it("进行态与结果文案完全来自 props(卡内不再有同步 state)", () => {
+    const html = renderToStaticMarkup(
+      <BaizhiCard
+        status={loggedIn}
+        statusErr=""
+        refreshStatus={noop}
+        syncing
+        syncMsg={{ text: "已同步 3 个模型、MCP 条目", color: "var(--ok)" }}
+        onSync={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("同步中…");
+    expect(html).toContain("已同步 3 个模型、MCP 条目");
+  });
+
+  it("空闲态给出同步入口,不残留上一轮文案", () => {
+    const html = renderToStaticMarkup(
+      <BaizhiCard status={loggedIn} statusErr="" refreshStatus={noop} syncing={false} syncMsg={null} onSync={vi.fn()} />,
+    );
+
+    expect(html).toContain("同步模型与 MCP");
+    expect(html).not.toContain("同步中…");
+  });
+});

--- a/desktop/ui/src/settings.tsx
+++ b/desktop/ui/src/settings.tsx
@@ -6,7 +6,7 @@
 // 整个页面导航到新内核 URL(本组件随之卸载)。
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { BaizhiCard } from "./baizhi";
-import { baizhiStatus } from "./baizhiapi";
+import { baizhiStatus, baizhiSync } from "./baizhiapi";
 import {
   getBrowserExtStatus,
   getHostConfig,
@@ -881,6 +881,60 @@ export function SettingsView({
     return { skipped: merged?.skipped ?? [], autoSaved: !blocked, blocked };
   };
 
+  // ---- 百智云同步流水线(拉取 → 并入表单 → 自动保存)----
+  // 与会员模型同款放在 SettingsView 而非账号卡内:登录会同时起两路同步,
+  // 谁先落地谁就把分区切到模型页(mergeSyncedModels)并卸载账号卡——挂在卡里
+  // 时,晚到的这一路回来只看到自己已被卸载,整份 {models, mcp_servers} 连同
+  // 报错一起被丢掉(表现为"登录后只同步到会员模型")。
+  const [bzSyncing, setBzSyncing] = useState(false);
+  const [bzSyncMsg, setBzSyncMsg] = useState<{ text: string; color: string } | null>(null);
+  // 同步即全量导入(用户拍板,不再逐条挑选):结果整组并入设置表单,
+  // 交保存条落盘重启;不想要的条目可在模型页删除(重同步会恢复)
+  const syncBaizhi = async () => {
+    if (bzSyncing) return;
+    setBzSyncMsg(null);
+    setBzSyncing(true);
+    try {
+      // 已持有的明文密钥交给内核复用(免在网关重复建 key);基准取此刻的表单
+      const knownKeys = formRef.current.models.map((m) => m.api_key.trim()).filter((k) => k.startsWith("sk-"));
+      const r = await baizhiSync(knownKeys);
+      const hasMcp = !!Object.keys(r.mcp_servers ?? {}).length;
+      if (!r.models.length && !hasMcp) {
+        setBzSyncMsg({
+          text: "没有拉取到可用的模型" + (r.notes?.length ? `(${r.notes.join(";")})` : ""),
+          color: "var(--err)",
+        });
+        return;
+      }
+      const applied = applySynced(r);
+      const parts = [`已同步 ${r.models.length - applied.skipped.length} 个模型`];
+      if (hasMcp) parts.push("MCP 条目");
+      if (r.key_created) parts.push(`已在网关新建密钥「${r.key_name || "MonkeyCode"}」`);
+      // 内核的诊断信息必须外显(与会员模型同步一致)。MCP 那半边的失败原因
+      // 全在 notes 里(未开通 Agent 工具包/没有可用服务/密钥取不到),此前只在
+      // "模型和 MCP 都为空"时才展示 —— 模型拉到了而 MCP 没有时静默无声,
+      // 用户只看到"MCP 没同步过来"却查无对证
+      if (r.notes?.length) parts.push(...r.notes);
+      parts.push(
+        applied.autoSaved
+          ? "正在保存并重启内核…"
+          : applied.blocked === "busy"
+            ? "有任务正在执行,空闲后请手动保存(保存会重启内核)"
+            : applied.blocked === "dirty"
+              ? "表单有未保存的修改,请核对后手动保存"
+              : "已切到模型页,核对后保存",
+      );
+      // 跨组撞名先到先得:跳过必须外显,否则"少了几个模型"查无对证
+      if (applied.skipped.length)
+        parts.push(`与现有条目同名已跳过: ${applied.skipped.join("、")}(想改用百智云通道请删除原条目后重新同步)`);
+      setBzSyncMsg({ text: parts.join("、"), color: "var(--ok)" });
+    } catch (e) {
+      setBzSyncMsg({ text: e instanceof Error ? e.message : String(e), color: "var(--err)" });
+    } finally {
+      setBzSyncing(false);
+    }
+  };
+
   // ---- MonkeyCode 会员模型同步流水线(拉取 → 并入表单 → 自动保存)----
   // 放在 SettingsView 而非账号卡内:百智云同步成功会把分区切到模型页,
   // 账号卡随之卸载,挂在卡里的"连上就自动同步"会在最关键的一步失效。
@@ -1650,9 +1704,10 @@ export function SettingsView({
           status={bzStatus}
           statusErr={bzErr}
           refreshStatus={refreshBz}
-          onSynced={applySynced}
+          syncing={bzSyncing}
+          syncMsg={bzSyncMsg}
+          onSync={() => void syncBaizhi()}
           onLoggedIn={onBaizhiLoggedIn}
-          knownKeys={() => models.map((m) => m.api_key.trim()).filter((k) => k.startsWith("sk-"))}
         />
       </Section>
       <Section label="MonkeyCode">


### PR DESCRIPTION
登录会同时起百智云与 MonkeyCode 两路同步,而百智云的同步流水线挂在账号卡
内:先落地的一路会把分区切到模型页(mergeSyncedModels)并卸载账号卡,晚到的
一路回来撞上 mounted 判据,整份 {models, mcp_servers} 连同报错一起被丢弃, 表现为登录后只同步到会员模型。

- 同步流水线整体上提到 SettingsView(与会员模型同款),账号卡只做受控展示
- 登录后的 onLoggedIn/onSync 不再受卡的 mounted 约束:两者都在宿主,卡被 另一路同步卸载时漏掉就等于登录了却什么都不同步
- 成功路径外显内核 notes。MCP 那半边的失败原因(未开通 Agent 工具包/没有 可用服务等)全在 notes 里,此前只在模型与 MCP 都为空时才展示,模型拉到了 而 MCP 没有时静默无声,用户查无对证