### PR TITLE
feat(desktop): 云端任务支持斜杠指令,并重做启动页

### DIFF
--- a/desktop/ui/src/cloudStartup.test.tsx
+++ b/desktop/ui/src/cloudStartup.test.tsx
@@ -1,0 +1,113 @@
+// 云端任务启动页:conditions → 阶段时间线的推导,以及卡片渲染的关键外显。
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { CloudStartupCard, startupSteps, startupTitle } from "./cloudStartup";
+import type { CloudTaskDetail } from "./types";
+
+type Cond = NonNullable<NonNullable<CloudTaskDetail["virtualmachine"]>["conditions"]>[number];
+
+const meta = (conditions: Cond[]): CloudTaskDetail => ({ id: "t1", virtualmachine: { conditions } });
+
+describe("startupSteps", () => {
+  it("没有 conditions 时给空列表(由卡片兜底成「排队等待调度」)", () => {
+    expect(startupSteps(null)).toEqual([]);
+    expect(startupSteps(meta([]))).toEqual([]);
+  });
+
+  it("末项之外一律算已完成,末项按 status 判定进行中", () => {
+    const steps = startupSteps(
+      meta([
+        { type: "Scheduled", status: 2 },
+        { type: "ImagePulled", status: 1, progress: 42 },
+      ]),
+    );
+    expect(steps).toEqual([
+      { type: "Scheduled", label: "调度到宿主机", state: "done" },
+      { type: "ImagePulled", label: "拉取系统镜像", state: "active", progress: 42 },
+    ]);
+  });
+
+  it("同一阶段重复下发(进度刷新)按最后一次取值,顺序不跳位", () => {
+    const steps = startupSteps(
+      meta([
+        { type: "ImagePulled", status: 1, progress: 10 },
+        { type: "Scheduled", status: 2 },
+        { type: "ImagePulled", status: 1, progress: 88 },
+      ]),
+    );
+    expect(steps.map((s) => s.type)).toEqual(["ImagePulled", "Scheduled"]);
+    // 末项是 Scheduled,ImagePulled 退回 done —— 但取的是最后一次的载荷
+    expect(steps[0].state).toBe("done");
+    expect(steps[1].state).toBe("done");
+  });
+
+  it("失败项恒为 failed,前序步骤保持已完成", () => {
+    const steps = startupSteps(
+      meta([
+        { type: "Scheduled", status: 2 },
+        { type: "Failed", status: 3, message: "宿主机资源不足" },
+      ]),
+    );
+    expect(steps[0].state).toBe("done");
+    expect(steps[1]).toEqual({ type: "Failed", label: "环境启动失败", state: "failed", message: "宿主机资源不足" });
+  });
+
+  it("末项 status=2(Ready)算已完成,不再转圈", () => {
+    const steps = startupSteps(meta([{ type: "Ready", status: 2 }]));
+    expect(steps[0].state).toBe("done");
+  });
+
+  it("进度只在当前项且 >0 时保留(0/缺省不画进度条)", () => {
+    expect(startupSteps(meta([{ type: "ImagePulled", status: 1, progress: 0 }]))[0].progress).toBeUndefined();
+    expect(startupSteps(meta([{ type: "ImagePulled", status: 1 }]))[0].progress).toBeUndefined();
+  });
+});
+
+describe("startupTitle", () => {
+  it("以当前步骤说明正在做什么", () => {
+    expect(startupTitle(startupSteps(meta([{ type: "ProjectCloned", status: 1 }])))).toBe("正在克隆代码仓库…");
+  });
+
+  it("失败优先外显", () => {
+    expect(
+      startupTitle(startupSteps(meta([{ type: "Scheduled", status: 2 }, { type: "Failed", status: 3 }]))),
+    ).toBe("云端开发环境启动失败");
+  });
+
+  it("无步骤时给通用文案", () => {
+    expect(startupTitle([])).toBe("正在准备云端开发环境…");
+  });
+});
+
+describe("CloudStartupCard", () => {
+  it("展开阶段时间线,当前步骤带进度百分比", () => {
+    const html = renderToStaticMarkup(
+      <CloudStartupCard meta={meta([{ type: "Scheduled", status: 2 }, { type: "ImagePulled", status: 1, progress: 42 }])} />,
+    );
+    expect(html).toContain("调度到宿主机");
+    expect(html).toContain("拉取系统镜像");
+    expect(html).toContain("42%");
+    // 启动期 composer 仍可用:页面要说清排队语义
+    expect(html).toContain("环境就绪后自动送达");
+  });
+
+  it("已排队时改说排队文案", () => {
+    const html = renderToStaticMarkup(<CloudStartupCard meta={meta([{ type: "Scheduled", status: 1 }])} queued />);
+    expect(html).toContain("已排队的内容会在环境就绪后自动送达");
+  });
+
+  it("失败态外显原因与补救路径,不再提排队", () => {
+    const html = renderToStaticMarkup(
+      <CloudStartupCard meta={meta([{ type: "Failed", status: 3, message: "镜像拉取超时" }])} />,
+    );
+    expect(html).toContain("云端开发环境启动失败");
+    expect(html).toContain("镜像拉取超时");
+    expect(html).toContain("终止任务后重新创建");
+    expect(html).not.toContain("自动送达");
+  });
+
+  it("尚无 conditions 时兜底一行「排队等待调度」", () => {
+    const html = renderToStaticMarkup(<CloudStartupCard meta={null} />);
+    expect(html).toContain("排队等待调度");
+  });
+});

--- a/desktop/ui/src/cloudStartup.tsx
+++ b/desktop/ui/src/cloudStartup.tsx
@@ -1,0 +1,164 @@
+// 云端任务启动页(task.status = pending):虚拟机准备是以分钟计的过程,
+// 原先只有一条"云端开发环境:拉取镜像 42%"的黄条,用户看不出还要多久、
+// 卡在哪一步、失败了能不能救。这里按 virtualmachine.conditions 展开成
+// 一条时间线:已完成的打勾、当前项转圈带进度条、失败项红色带原因。
+//
+// 与移动端(mobile/app/task/[id].tsx 的 starting 分支)同一份状态语义,
+// 但桌面不退化成只读等待页——composer 保持可用,启动期输入自动排队,
+// 环境就绪即送达(这是桌面侧独有的能力,页面上要说清楚)。
+import { MONO } from "./fonts";
+import { IconCheck, IconCloud } from "./icons";
+import type { CloudTaskDetail } from "./types";
+
+/** conditions[].status:0 未知 / 1 进行中 / 2 完成 / 3 失败 */
+const DONE = 2;
+const FAILED = 3;
+
+/** 准备阶段 → 短标签(对齐 web getConditionTypeText / mobile CONDITION_LABELS) */
+const STEP_LABEL: Record<string, string> = {
+  Scheduled: "调度到宿主机",
+  ImagePulled: "拉取系统镜像",
+  ProjectCloned: "克隆代码仓库",
+  ImageBuilt: "构建系统镜像",
+  ContainerCreated: "创建开发环境",
+  ContainerStarted: "启动开发环境",
+  Ready: "环境就绪",
+  Failed: "环境启动失败",
+};
+
+export interface StartupStep {
+  type: string;
+  label: string;
+  state: "done" | "active" | "failed";
+  /** 0-100;仅当前项且服务端给了才画进度条 */
+  progress?: number;
+  message?: string;
+}
+
+/**
+ * conditions → 时间线。服务端按阶段追加(同一阶段可能带着进度重复下发),
+ * 故按 type 去重保留最后一次,顺序以首次出现为准:进度刷新不会让步骤跳位。
+ *
+ * 除最后一项外都算已完成(服务端进入下一阶段就意味着上一阶段过了);
+ * 最后一项按 status 判定 完成/进行中/失败。
+ */
+export function startupSteps(meta: CloudTaskDetail | null): StartupStep[] {
+  const conds = meta?.virtualmachine?.conditions ?? [];
+  const order: string[] = [];
+  const last = new Map<string, { status?: number; message?: string; progress?: number }>();
+  for (const c of conds) {
+    const type = c.type ?? "";
+    if (!type) continue;
+    if (!last.has(type)) order.push(type);
+    last.set(type, c);
+  }
+  return order.map((type, i) => {
+    const c = last.get(type)!;
+    const tail = i === order.length - 1;
+    const failed = c.status === FAILED || type === "Failed";
+    const state: StartupStep["state"] = failed ? "failed" : !tail || c.status === DONE ? "done" : "active";
+    return {
+      type,
+      label: STEP_LABEL[type] ?? type,
+      state,
+      ...(state === "active" && typeof c.progress === "number" && c.progress > 0 ? { progress: c.progress } : {}),
+      ...(c.message ? { message: c.message } : {}),
+    };
+  });
+}
+
+/** 标题:失败外显失败,否则以当前步骤说明"正在做什么" */
+export function startupTitle(steps: StartupStep[]): string {
+  const failed = steps.find((s) => s.state === "failed");
+  if (failed) return "云端开发环境启动失败";
+  const active = steps.find((s) => s.state === "active");
+  return active ? `正在${active.label}…` : "正在准备云端开发环境…";
+}
+
+function StepRow({ step }: { step: StartupStep }) {
+  const color = step.state === "failed" ? "var(--err)" : step.state === "active" ? "var(--t2)" : "var(--t5)";
+  return (
+    <div style={{ display: "flex", gap: 9, alignItems: "flex-start" }}>
+      <span style={{ flex: "none", width: 14, height: 18, display: "flex", alignItems: "center", justifyContent: "center" }}>
+        {step.state === "done" && <IconCheck size={11} strokeWidth={1.8} />}
+        {step.state === "active" && (
+          <span className="spinner" style={{ width: 11, height: 11, borderWidth: 1.5 }} />
+        )}
+        {step.state === "failed" && <span style={{ width: 7, height: 7, borderRadius: "50%", background: "var(--err)" }} />}
+      </span>
+      <span style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 4, paddingBottom: 2 }}>
+        <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ fontSize: 12.5, fontWeight: step.state === "done" ? 400 : 600, color }}>{step.label}</span>
+          {step.progress !== undefined && (
+            <span style={{ fontSize: 11, color: "var(--t5)", fontFamily: MONO, fontVariantNumeric: "tabular-nums" }}>
+              {step.progress}%
+            </span>
+          )}
+        </span>
+        {step.progress !== undefined && (
+          // 限宽:满宽的细线会被当成分隔线,收窄后才读得出是进度条
+          <span style={{ height: 3, maxWidth: 200, borderRadius: 2, background: "var(--line2)", overflow: "hidden" }}>
+            <span style={{ display: "block", height: "100%", width: `${Math.min(100, step.progress)}%`, background: "var(--acc)", transition: "width .3s ease" }} />
+          </span>
+        )}
+        {/* 详情只在当前/失败步骤展开:已完成步骤的 message 是噪音 */}
+        {step.message && step.state !== "done" && (
+          <span style={{ fontSize: 11.5, lineHeight: 1.5, color: step.state === "failed" ? "var(--err)" : "var(--t5)", wordBreak: "break-word" }}>
+            {step.message}
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}
+
+/** 启动卡:标题 + 阶段时间线 + 排队说明(composer 仍可用) */
+export function CloudStartupCard({ meta, queued }: { meta: CloudTaskDetail | null; queued?: boolean }) {
+  const steps = startupSteps(meta);
+  const failed = steps.some((s) => s.state === "failed");
+  const title = startupTitle(steps);
+  return (
+    <div className="card" style={{ width: "100%", maxWidth: 460, padding: "18px 20px 16px", display: "flex", flexDirection: "column", gap: 14 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+        <span
+          style={{
+            flex: "none",
+            width: 30,
+            height: 30,
+            borderRadius: 9,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: failed ? "var(--errBg)" : "var(--accBgSoft)",
+          }}
+        >
+          <IconCloud size={15} color={failed ? "var(--err)" : "var(--accTx)"} />
+        </span>
+        <span style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 2 }}>
+          <span style={{ fontSize: 13.5, fontWeight: 700, color: failed ? "var(--err)" : "var(--t1)" }}>{title}</span>
+          <span style={{ fontSize: 11.5, color: "var(--t5)" }}>
+            {failed ? "可在 ⋯ 菜单终止任务后重新创建" : "云端虚拟机首次准备通常需要 1–3 分钟"}
+          </span>
+        </span>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 9 }}>
+        {steps.length === 0 ? (
+          <StepRow step={{ type: "Scheduled", label: "排队等待调度", state: "active" }} />
+        ) : (
+          steps.map((s) => <StepRow key={s.type} step={s} />)
+        )}
+      </div>
+
+      {!failed && (
+        <div style={{ borderTop: "1px solid var(--line2)", paddingTop: 11, fontSize: 11.5, lineHeight: 1.6, color: "var(--t5)" }}>
+          {queued
+            ? "已排队的内容会在环境就绪后自动送达,可以先去忙别的。"
+            : "现在就能在下方输入——内容会先排队,环境就绪后自动送达。"}
+          <br />
+          任务跑在云端服务器上,关掉客户端也会继续。
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/ui/src/cloudtask.tsx
+++ b/desktop/ui/src/cloudtask.tsx
@@ -4,13 +4,15 @@
 // 渲染复用本地会话的帧归约链(reduceBatch → LogList):云端帧与本地 Frame 同构。
 import { useRef, useState, type ClipboardEvent, type DragEvent } from "react";
 import { openExternal } from "./host";
-import type { CloudTask, CloudTaskDetail } from "./types";
+import type { CloudTask } from "./types";
 import { cloudModelLabel, groupedCloudModelLabel } from "./cloud";
 import { CloudFilesDrawer } from "./cloudfiles";
 import { CloudTerminal } from "./cloudterm";
 import { MAX_CLOUD_ATTS } from "./cloudUpload";
 import { COL_MAX, ModelPickerTrigger } from "./chat";
 import { CloudModelGroups } from "./cloudModelMenu";
+import { CloudStartupCard } from "./cloudStartup";
+import { SlashCommandMenu, useSlashCommands } from "./commandMenu";
 import { HeaderFilesButton, HeaderMenu, LogList, TaskPanel, ViewHeader, type MenuState } from "./components";
 import { Composer, QueuedChip, RunningBar } from "./composer";
 import { IconCloud, IconFile, IconGlobe, IconMonitor, IconPaperclip, IconStop, IconX } from "./icons";
@@ -24,26 +26,6 @@ const STATUS_LABEL: Record<string, { text: string; color: string }> = {
   error: { text: "出错", color: "var(--err)" },
   finished: { text: "已完成", color: "var(--t4)" },
 };
-
-/** VM 准备进度:取 conditions 最后一项(对齐移动端 taskConditionInfo) */
-function vmCondition(meta: CloudTaskDetail | null): string {
-  const conds = meta?.virtualmachine?.conditions;
-  const last = conds?.[conds.length - 1];
-  if (!last) return "云端开发环境准备中…";
-  const label: Record<string, string> = {
-    Scheduled: "已调度",
-    ImagePulled: "拉取镜像",
-    ProjectCloned: "克隆代码",
-    ImageBuilt: "构建镜像",
-    ContainerCreated: "创建容器",
-    ContainerStarted: "启动容器",
-    Ready: "环境就绪",
-    Failed: "环境启动失败",
-  };
-  const name = label[last.type ?? ""] ?? last.type ?? "准备中";
-  const pct = typeof last.progress === "number" && last.progress > 0 ? ` ${last.progress}%` : "";
-  return `云端开发环境:${name}${pct}${last.message ? ` — ${last.message}` : ""}`;
-}
 
 export function CloudTaskView({
   task,
@@ -112,6 +94,16 @@ export function CloudTaskView({
     onDragging: setDragging,
     onFiles: (files) => h.addFiles(files),
     onError: (msg) => h.notify("⚠ 附件上传失败: " + msg),
+  });
+
+  // 斜杠指令(Agent 上报):composer 左侧 / 按钮,或在输入框直接敲 / 就地补全
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const slash = useSlashCommands({
+    commands: h.commands,
+    input: h.input,
+    setInput: h.setInput,
+    inputRef,
+    enabled: !ended,
   });
 
   // 云端模型下拉开合(列表加载/切换在 hook)
@@ -272,38 +264,40 @@ export function CloudTaskView({
         </HeaderMenu>
       </ViewHeader>
 
-      {/* ==== 对话流:列宽公式与滚动条预留同 ChatView;内距 36px 是本视图自己的
-              尺度,与下方 composer 对齐即可(ChatView 那边是 30px) ==== */}
-      <div
-        ref={h.scrollRef}
-        onWheel={h.onWheel}
-        onScroll={h.onScroll}
-        style={{ flex: 1, overflowY: "auto", overflowX: "hidden", minHeight: 0, scrollbarGutter: "stable both-edges" }}
-      >
-        <div style={{ maxWidth: COL_MAX, margin: "0 auto", padding: "26px 36px 16px", display: "flex", flexDirection: "column", gap: 18 }}>
-          {h.cursor && (
-            <button
-              className="hv"
-              onClick={() => void h.loadEarlier()}
-              style={{ alignSelf: "center", border: "1px solid var(--line)", background: "var(--card)", color: "var(--t3)", fontSize: 11.5, borderRadius: 8, padding: "4px 14px", cursor: "pointer", boxShadow: "var(--cardSh)" }}
-            >
-              {h.loadingEarlier ? "加载中…" : "加载更早的对话"}
-            </button>
-          )}
-          {taskStatus === "pending" && (
-            <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 13px", borderRadius: 9, background: "var(--warnBg)", border: "1px solid var(--warnBd2)", fontSize: 12.5, color: "var(--warnT)" }}>
-              <span className="spinner" style={{ width: 12, height: 12, borderColor: "var(--warn)", borderTopColor: "transparent" }} />
-              {vmCondition(meta)}
-            </div>
-          )}
-          {chat.items.length === 0 && taskStatus !== "pending" && (
-            <div style={{ padding: "40px 0", textAlign: "center", fontSize: 12.5, color: "var(--t5)" }}>
-              {ended ? "没有可回放的对话记录。" : h.status}
-            </div>
-          )}
-          <LogList items={chat.items} onPermAnswer={() => {}} onAskAnswer={ended ? undefined : h.answerAsk} workdir="/workspace" />
+      {/* ==== 启动页(pending):VM 准备是以分钟计的过程,给足过程感 ====
+          此时必然还没有任何对话(首轮要等环境就绪才开跑),整屏让给启动卡 */}
+      {taskStatus === "pending" ? (
+        <div style={{ flex: 1, overflowY: "auto", minHeight: 0, display: "flex", alignItems: "center", justifyContent: "center", padding: "24px 36px" }}>
+          <CloudStartupCard meta={meta} queued={!!queued} />
         </div>
-      </div>
+      ) : (
+        /* ==== 对话流:列宽公式与滚动条预留同 ChatView;内距 36px 是本视图自己的
+                尺度,与下方 composer 对齐即可(ChatView 那边是 30px) ==== */
+        <div
+          ref={h.scrollRef}
+          onWheel={h.onWheel}
+          onScroll={h.onScroll}
+          style={{ flex: 1, overflowY: "auto", overflowX: "hidden", minHeight: 0, scrollbarGutter: "stable both-edges" }}
+        >
+          <div style={{ maxWidth: COL_MAX, margin: "0 auto", padding: "26px 36px 16px", display: "flex", flexDirection: "column", gap: 18 }}>
+            {h.cursor && (
+              <button
+                className="hv"
+                onClick={() => void h.loadEarlier()}
+                style={{ alignSelf: "center", border: "1px solid var(--line)", background: "var(--card)", color: "var(--t3)", fontSize: 11.5, borderRadius: 8, padding: "4px 14px", cursor: "pointer", boxShadow: "var(--cardSh)" }}
+              >
+                {h.loadingEarlier ? "加载中…" : "加载更早的对话"}
+              </button>
+            )}
+            {chat.items.length === 0 && (
+              <div style={{ padding: "40px 0", textAlign: "center", fontSize: 12.5, color: "var(--t5)" }}>
+                {ended ? "没有可回放的对话记录。" : h.status}
+              </div>
+            )}
+            <LogList items={chat.items} onPermAnswer={() => {}} onAskAnswer={ended ? undefined : h.answerAsk} workdir="/workspace" />
+          </div>
+        </div>
+      )}
 
       {/* ==== 运行条 + 终端卡 + composer:与 ChatView 同列宽同出血 ==== */}
       <div style={{ flex: "none", maxWidth: COL_MAX, width: "calc(100% - 16px)", margin: "0 auto", padding: "0 36px 20px", display: "flex", flexDirection: "column", gap: 8 }}>
@@ -372,12 +366,16 @@ export function CloudTaskView({
                   ? "环境唤醒中…现在发送会排队,唤醒后自动送达"
                   : running
                     ? "补充说明…运行中发送会排队"
-                    : "继续对话…粘贴或拖入图片、文件可作为附件"
+                    : h.commands.length > 0
+                      ? "继续对话…输入 / 唤起指令,可粘贴或拖入附件"
+                      : "继续对话…粘贴或拖入图片、文件可作为附件"
             }
             sendActive={!!h.input.trim()}
             onChange={h.setInput}
             onSend={h.send}
             onPaste={onPaste}
+            onKeyDown={slash.onKeyDown}
+            inputRef={inputRef}
             above={
               (h.atts.length > 0 || h.uploading > 0) && (
                 <div style={{ display: "flex", flexWrap: "wrap", gap: 8, padding: "10px 12px 0" }}>
@@ -473,6 +471,8 @@ export function CloudTaskView({
                 >
                   <IconPaperclip size={13} color="var(--t3)" />
                 </button>
+                {/* 斜杠指令:点开浏览全部,或在输入框直接敲 / 就地补全 */}
+                <SlashCommandMenu h={slash} count={h.commands.length} />
                 <span
                   title={`${h.status} · 任务运行在云端服务器,关掉客户端也会继续`}
                   style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 11, color: "var(--t5)", minWidth: 0 }}

--- a/desktop/ui/src/commandMenu.test.tsx
+++ b/desktop/ui/src/commandMenu.test.tsx
@@ -1,0 +1,55 @@
+// 斜杠指令菜单的渲染契约(状态机的纯逻辑在 slashCommands.test.ts)。
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { SlashCommandMenu, type SlashCommandsHandle } from "./commandMenu";
+import type { SlashCommand } from "./types";
+
+const handle = (over: Partial<SlashCommandsHandle> = {}): SlashCommandsHandle => ({
+  open: true,
+  list: [],
+  active: 0,
+  setActive: vi.fn(),
+  pick: vi.fn(),
+  toggle: vi.fn(),
+  close: vi.fn(),
+  onKeyDown: () => false,
+  ...over,
+});
+
+const list: SlashCommand[] = [
+  { name: "compact", description: "压缩上下文,释放 token 空间" },
+  { name: "review", description: "代码审查", input: { hint: "<file>" } },
+];
+
+describe("SlashCommandMenu", () => {
+  it("列出 /指令、参数提示与描述,高亮当前项", () => {
+    const html = renderToStaticMarkup(<SlashCommandMenu h={handle({ list, active: 1 })} count={2} />);
+    expect(html).toContain("/compact");
+    expect(html).toContain("压缩上下文,释放 token 空间");
+    expect(html).toContain("&lt;file&gt;"); // 参数提示
+    // active=1 那项(review)拿到高亮底色,首项不带
+    const [, first, second] = html.split('class="menu-item"');
+    expect(first).toContain("background:transparent");
+    expect(second).toContain("background:var(--hov)");
+    // 键盘用法就地说明:桌面这条路径是主路径,不能只靠试
+    expect(html).toContain("↑↓ 选择");
+  });
+
+  it("过滤无命中时给空态而不是空菜单", () => {
+    const html = renderToStaticMarkup(<SlashCommandMenu h={handle({ list: [] })} count={3} />);
+    expect(html).toContain("无匹配指令");
+  });
+
+  it("关闭态只渲染触发按钮;有指令时 title 提示可直接敲 /", () => {
+    const html = renderToStaticMarkup(<SlashCommandMenu h={handle({ open: false, list })} count={2} />);
+    expect(html).not.toContain("↑↓ 选择");
+    expect(html).toContain("斜杠指令(2)");
+    expect(html).toContain("在输入框直接敲 / 也可唤起");
+  });
+
+  it("Agent 还没上报指令时按钮灰态并说明原因", () => {
+    const html = renderToStaticMarkup(<SlashCommandMenu h={handle({ open: false })} count={0} />);
+    expect(html).toContain("opacity:0.4");
+    expect(html).toContain("尚未上报可用指令");
+  });
+});

--- a/desktop/ui/src/commandMenu.tsx
+++ b/desktop/ui/src/commandMenu.tsx
@@ -1,0 +1,211 @@
+// 斜杠指令(Agent 上报的 available_commands)选择器:composer 上的 / 按钮
+// + 上弹菜单。移动端是底部「使用技能」面板,桌面遵循自己的交互语言——
+//   1. 直接在输入框敲 `/` 即就地补全(↑↓ 选择、↩/⇥ 填入、Esc 关掉),
+//   2. 不记得指令名时点 composer 左侧的 / 按钮浏览全部。
+// 两条路径共用同一份状态(useSlashCommands),菜单只有一个。
+import { useCallback, useEffect, useMemo, useState, type KeyboardEvent, type RefObject } from "react";
+import { isImeEnter } from "./composer";
+import { MONO } from "./fonts";
+import { IconSlash } from "./icons";
+import { useUpwardMenuHeight } from "./menuPosition";
+import { commandText, filterCommands, nextActive, slashQuery } from "./slashCommands";
+import type { SlashCommand } from "./types";
+
+export interface SlashCommandsHandle {
+  /** 菜单是否展开(按钮点开,或输入框正在敲 /xxx) */
+  open: boolean;
+  /** 当前过滤结果(前缀匹配优先) */
+  list: SlashCommand[];
+  active: number;
+  setActive(i: number): void;
+  pick(cmd: SlashCommand): void;
+  /** 按钮开合;有指令才响应 */
+  toggle(): void;
+  close(): void;
+  /** 输入区按键预处理:返回 true = 本次按键归菜单(Composer 不再当作发送) */
+  onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>): boolean;
+}
+
+export function useSlashCommands(opts: {
+  commands: SlashCommand[];
+  input: string;
+  setInput(v: string): void;
+  /** 选完指令把焦点还给输入框(桌面上丢焦点等于打断输入) */
+  inputRef?: RefObject<HTMLTextAreaElement | null>;
+  /** 结束态等场景整体关闭 */
+  enabled?: boolean;
+}): SlashCommandsHandle {
+  const { commands, input, setInput, inputRef, enabled = true } = opts;
+  const [buttonOpen, setButtonOpen] = useState(false);
+  // Esc / 已填入:压住当前这一段 `/xxx` 的自动补全,直到它被清掉
+  const [typingOff, setTypingOff] = useState(false);
+  const [active, setActive] = useState(0);
+
+  const query = enabled ? slashQuery(input) : null;
+  const has = enabled && commands.length > 0;
+  const open = has && (buttonOpen || (query !== null && !typingOff));
+  const list = useMemo(() => filterCommands(commands, query ?? ""), [commands, query]);
+
+  // 查询词/清单变了就回到第一项:高亮停在旧下标会选中看不见的条目
+  useEffect(() => setActive(0), [query, commands]);
+  // 输入框里的 `/` 段被清掉 → 解除压制,下次敲 / 照常补全
+  useEffect(() => {
+    if (query === null) setTypingOff(false);
+  }, [query]);
+
+  const close = useCallback(() => {
+    setButtonOpen(false);
+    if (query !== null) setTypingOff(true);
+  }, [query]);
+
+  // Esc 关闭必须在 window **capture** 阶段拦截(与 chat.tsx 的 ModelPicker 同源):
+  // 全局快捷键(appView)在云端视图里,Esc 落在输入态是 blur composer、落在
+  // 别处直接关掉整个任务视图——菜单开着时这一下只能归菜单。
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      e.stopImmediatePropagation();
+      e.preventDefault();
+      close();
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [open, close]);
+
+  const pick = (cmd: SlashCommand) => {
+    setInput(commandText(cmd));
+    setButtonOpen(false);
+    // 填入的文本自己就是一段 `/name`,不压住的话菜单会立刻回弹匹配自己
+    setTypingOff(true);
+    inputRef?.current?.focus();
+  };
+
+  // 高亮下标随时按列表长度收敛:过滤把列表缩短的那一帧,旧下标会越界
+  const act = Math.min(active, Math.max(0, list.length - 1));
+
+  // Esc 不在这里收(见上面的 window capture):那条路径同时覆盖"按钮点开、
+  // 焦点不在输入框"的情形,冒泡阶段的 textarea 处理器够不着。
+  const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): boolean => {
+    if (!open) return false;
+    switch (e.key) {
+      case "ArrowDown":
+      case "ArrowUp":
+        e.preventDefault();
+        setActive(nextActive(act, e.key === "ArrowDown" ? 1 : -1, list.length));
+        return true;
+      case "Enter":
+      case "Tab":
+        // 输入法组合态的 ↩ 是选字确认,不是选中指令(与 Composer 同一守卫)
+        if (e.key === "Enter" && isImeEnter(e)) return false;
+        if (!list.length) return false;
+        e.preventDefault();
+        pick(list[act]);
+        return true;
+      default:
+        return false;
+    }
+  };
+
+  return {
+    open,
+    list,
+    active: act,
+    setActive,
+    pick,
+    // 按 open 而非 buttonOpen 取反:输入框里正敲着 /xxx 时,菜单本就开着,
+    // 这一下应该是"关掉"(只翻 buttonOpen 会看起来点了没反应)
+    toggle: () => {
+      if (!has) return;
+      if (open) return close();
+      setTypingOff(false);
+      setButtonOpen(true);
+    },
+    close,
+    onKeyDown,
+  };
+}
+
+/** composer 左侧的 / 按钮 + 上弹指令菜单(整体自带定位锚点) */
+export function SlashCommandMenu({ h, count }: { h: SlashCommandsHandle; count: number }) {
+  const { anchorRef, menuMaxHeight } = useUpwardMenuHeight<HTMLSpanElement>(h.open, 320);
+  const disabled = count === 0;
+  return (
+    <span ref={anchorRef} style={{ position: "relative", display: "flex", flex: "none" }}>
+      <button
+        className="hv2 icon-btn"
+        title={disabled ? "Agent 尚未上报可用指令(环境就绪后自动同步)" : `斜杠指令(${count})· 在输入框直接敲 / 也可唤起`}
+        onClick={h.toggle}
+        style={{ width: 24, height: 24, borderRadius: 7, background: h.open ? "var(--hov)" : "transparent", opacity: disabled ? 0.4 : 1 }}
+      >
+        <IconSlash size={13} color="var(--t3)" />
+      </button>
+      {h.open && (
+        <>
+          <div className="backdrop" onClick={h.close} />
+          <div
+            className="pop"
+            style={{
+              position: "absolute",
+              bottom: 30,
+              left: 0,
+              width: 340,
+              maxHeight: menuMaxHeight,
+              overflow: "hidden",
+            }}
+          >
+            <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
+              {h.list.length === 0 && (
+                <div style={{ padding: "8px 10px", fontSize: 12, color: "var(--t5)" }}>无匹配指令</div>
+              )}
+              {h.list.map((c, i) => (
+                <button
+                  key={c.name}
+                  className="menu-item"
+                  onMouseEnter={() => h.setActive(i)}
+                  onClick={() => h.pick(c)}
+                  title={c.description || `/${c.name}`}
+                  style={{
+                    flexDirection: "column",
+                    alignItems: "stretch",
+                    gap: 2,
+                    whiteSpace: "normal",
+                    background: i === h.active ? "var(--hov)" : "transparent",
+                  }}
+                >
+                  <span style={{ display: "flex", alignItems: "baseline", gap: 6, minWidth: 0 }}>
+                    <span style={{ fontFamily: MONO, fontSize: 12.5, fontWeight: 700, color: "var(--accTx)", flex: "none" }}>
+                      /{c.name}
+                    </span>
+                    {c.input?.hint && (
+                      <span style={{ fontFamily: MONO, fontSize: 11, color: "var(--t6)", flex: "none" }}>
+                        {c.input.hint}
+                      </span>
+                    )}
+                  </span>
+                  {c.description && (
+                    <span className="ellipsis" style={{ fontSize: 11.5, color: "var(--t5)", lineHeight: 1.4 }}>
+                      {c.description}
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+            <div
+              style={{
+                flex: "none",
+                borderTop: "1px solid var(--line2)",
+                margin: "4px -4px -4px",
+                padding: "5px 10px",
+                fontSize: 10.5,
+                color: "var(--t6)",
+              }}
+            >
+              ↑↓ 选择 · ↩ 填入 · Esc 关闭
+            </div>
+          </div>
+        </>
+      )}
+    </span>
+  );
+}

--- a/desktop/ui/src/composer.tsx
+++ b/desktop/ui/src/composer.tsx
@@ -2,7 +2,7 @@
 // + 发送按钮)、运行条、排队 chip。原先 chat.tsx 与 cloudtask.tsx 各持一份
 // 逐字相同的样式、靠注释对表,现收敛于此;两侧的扩展位(本地:附件条/权限
 // pill/模型切换/ctx 环;云端:状态行/云端模型选择器)走 above/controls 槽位。
-import { useEffect, useRef, type ClipboardEvent, type ReactNode } from "react";
+import { useEffect, useRef, type ClipboardEvent, type KeyboardEvent, type MutableRefObject, type ReactNode } from "react";
 import { IconClock, IconSend, IconStop, IconX } from "./icons";
 
 // 输入法(IME)组合态的 Enter 只是确认候选词,不能当作提交。Chromium 上该 keydown
@@ -140,6 +140,8 @@ export function Composer({
   onChange,
   onSend,
   onPaste,
+  onKeyDown,
+  inputRef,
   above,
   controls,
 }: {
@@ -151,12 +153,17 @@ export function Composer({
   onSend: () => void;
   /** 粘贴处理(本地:剪贴板文件转附件;不给则默认文本粘贴) */
   onPaste?: (e: ClipboardEvent<HTMLTextAreaElement>) => void;
+  /** 按键预处理:返回 true = 已被上层消费(斜杠指令菜单的 ↑↓/↩/Esc),
+   * 本组件不再把这一下当作发送/换行 */
+  onKeyDown?: (e: KeyboardEvent<HTMLTextAreaElement>) => boolean;
+  /** 把 textarea 交给上层(选完指令后要把焦点还回来) */
+  inputRef?: MutableRefObject<HTMLTextAreaElement | null>;
   /** 卡片顶部扩展位(本地:附件条) */
   above?: ReactNode;
   /** 底部操作行(发送按钮左侧,含中缝 spacer 由调用方排布) */
   controls?: ReactNode;
 }) {
-  const taRef = useRef<HTMLTextAreaElement>(null);
+  const taRef = useRef<HTMLTextAreaElement | null>(null);
 
   // 输入框随内容自适应高度
   useEffect(() => {
@@ -182,13 +189,18 @@ export function Composer({
     >
       {above}
       <textarea
-        ref={taRef}
+        ref={(el) => {
+          taRef.current = el;
+          if (inputRef) inputRef.current = el;
+        }}
         rows={2}
         value={value}
         placeholder={placeholder}
         onChange={(e) => onChange(e.target.value)}
         onCompositionEnd={markImeEnd}
         onKeyDown={(e) => {
+          // 上层浮层(斜杠指令菜单)优先:↑↓/↩/Esc 归菜单,不落到发送
+          if (onKeyDown?.(e)) return;
           // 输入法组合态(选字/确认候选)的 Enter 不发送
           if (e.key === "Enter" && !e.shiftKey && !isImeEnter(e)) {
             e.preventDefault();

--- a/desktop/ui/src/icons.tsx
+++ b/desktop/ui/src/icons.tsx
@@ -282,6 +282,16 @@ export function IconPaperclip({ size = 13, color = "var(--t3)", style }: IconPro
   );
 }
 
+/** 斜杠指令(方框里的 /) */
+export function IconSlash({ size = 13, color = "var(--t3)", style }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none" style={{ ...base, ...style }}>
+      <rect x="1.4" y="1.4" width="11.2" height="11.2" rx="3" stroke={color} strokeWidth="1.2" />
+      <path d="M8.6 4.1 5.4 9.9" stroke={color} strokeWidth="1.3" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 /** 发送(上箭头) */
 export function IconSend({ size = 13, color = "var(--onAcc)", style }: IconProps) {
   return (

--- a/desktop/ui/src/reduce.test.ts
+++ b/desktop/ui/src/reduce.test.ts
@@ -521,6 +521,30 @@ describe("轮次与系统帧", () => {
     expect(back.items.at(-1)).toEqual({ kind: "sys", text: "思考深度已调整为「默认」" });
   });
 
+  it("available_commands_update 只回写指令清单,不进对话流", () => {
+    const s = run([
+      acp({
+        sessionUpdate: "available_commands_update",
+        availableCommands: [
+          { name: "compact", description: "压缩上下文" },
+          { name: "review", input: { hint: "<file>" } },
+        ],
+      }),
+    ]);
+    expect(s.commands.map((c) => c.name)).toEqual(["compact", "review"]);
+    expect(s.items).toEqual([]);
+  });
+
+  it("指令清单是全量重发:后一帧整体替换,空清单即清空", () => {
+    const s = run([
+      acp({ sessionUpdate: "available_commands_update", availableCommands: [{ name: "a" }, { name: "" }] }),
+      acp({ sessionUpdate: "available_commands_update", availableCommands: [{ name: "b" }] }),
+    ]);
+    expect(s.commands.map((c) => c.name)).toEqual(["b"]);
+    // 缺字段/无名条目一律丢弃(菜单里的空指令点不出东西)
+    expect(run([acp({ sessionUpdate: "available_commands_update" })]).commands).toEqual([]);
+  });
+
   it("compact_status 与 llm_call_retry 渲染系统行", () => {
     const s = run([
       acp({ sessionUpdate: "compact_status", status: "started" }),

--- a/desktop/ui/src/reduce.ts
+++ b/desktop/ui/src/reduce.ts
@@ -3,7 +3,7 @@
 import { b64decode, frameData } from "./codec";
 import { stripTierPrefix } from "./modelMenu";
 import { toolContentText, toolResultText } from "./toolDetails";
-import type { AcpUpdate, AskQuestion, Frame, LogItem, PermOutcome, PlanEntry, SubEntry, ToolProgress, Usage } from "./types";
+import type { AcpUpdate, AskQuestion, Frame, LogItem, PermOutcome, PlanEntry, SlashCommand, SubEntry, ToolProgress, Usage } from "./types";
 
 export interface ChatState {
   items: LogItem[];
@@ -21,6 +21,8 @@ export interface ChatState {
   think: string;
   /** 会话权限模式(permission_mode_update 帧回写;空 = 以会话 meta 为准) */
   permMode: string;
+  /** Agent 上报的可用斜杠指令(available_commands_update 全量重发) */
+  commands: SlashCommand[];
   /** 渲染 key 的基准:key = keyBase + 下标。"加载更早"往前插 N 条时减 N,
    * 既有条目的 key 因此保持不变——否则下标 key 整体平移,React 认不出
    * 同一条,ToolCard/ThoughtView 的展开态串位、整列重挂载(markdown 全部
@@ -38,6 +40,7 @@ export const initialChat: ChatState = {
   model: "",
   think: "",
   permMode: "",
+  commands: [],
   keyBase: 0,
 };
 
@@ -390,6 +393,10 @@ function reduceAcp(s: ChatState, u: AcpUpdate, timestamp?: number): ChatState {
       }
       return u.text ? push(s, { kind: "sys", text: u.text }) : s;
     }
+    case "available_commands_update":
+      // 斜杠指令清单是"此刻"的会话状态(全量重发,不是对话内容):只回写
+      // 状态字段,不进对话流
+      return { ...s, commands: (u.availableCommands ?? []).filter((c) => !!c?.name) };
     case "usage_update":
       return { ...s, usage: { used: u.used ?? 0, size: u.size ?? 0 } };
     case "compact_status":

--- a/desktop/ui/src/slashCommands.test.ts
+++ b/desktop/ui/src/slashCommands.test.ts
@@ -1,0 +1,72 @@
+// 斜杠指令补全的纯逻辑单测:什么算"正在敲指令"、过滤排序、回填文本。
+import { describe, expect, it } from "vitest";
+import { commandText, filterCommands, nextActive, slashQuery } from "./slashCommands";
+import type { SlashCommand } from "./types";
+
+const cmd = (name: string, description?: string, hint?: string): SlashCommand => ({
+  name,
+  ...(description ? { description } : {}),
+  ...(hint ? { input: { hint } } : {}),
+});
+
+describe("slashQuery", () => {
+  it("整段输入以 / 开头且未敲空格时给出查询词", () => {
+    expect(slashQuery("/")).toBe("");
+    expect(slashQuery("/com")).toBe("com");
+  });
+
+  it("敲了空格即进入填参数阶段,不再补全", () => {
+    expect(slashQuery("/review src/a.ts")).toBeNull();
+    expect(slashQuery("/compact ")).toBeNull();
+  });
+
+  it("句中的 / 是路径或日期,不弹菜单", () => {
+    expect(slashQuery("看下 src/main.ts")).toBeNull();
+    expect(slashQuery("2026/08/02 的记录")).toBeNull();
+    expect(slashQuery("")).toBeNull();
+  });
+});
+
+describe("filterCommands", () => {
+  const all = [cmd("add-context"), cmd("compact", "压缩上下文"), cmd("review", "代码审查")];
+
+  it("空查询给全量", () => {
+    expect(filterCommands(all, "")).toEqual(all);
+  });
+
+  it("前缀匹配排在子串匹配之前", () => {
+    expect(filterCommands(all, "co").map((c) => c.name)).toEqual(["compact", "add-context"]);
+  });
+
+  it("描述命中也算匹配", () => {
+    expect(filterCommands(all, "审查").map((c) => c.name)).toEqual(["review"]);
+  });
+
+  it("大小写不敏感;无匹配给空列表", () => {
+    expect(filterCommands(all, "REV").map((c) => c.name)).toEqual(["review"]);
+    expect(filterCommands(all, "zzz")).toEqual([]);
+  });
+});
+
+describe("commandText", () => {
+  it("带参数提示的补一个空格,等着填参数", () => {
+    expect(commandText(cmd("review", "", "<file>"))).toBe("/review ");
+  });
+
+  it("无参数的原样填入,按 ↩ 可直接发出", () => {
+    expect(commandText(cmd("compact"))).toBe("/compact");
+  });
+});
+
+describe("nextActive", () => {
+  it("上下越界回绕", () => {
+    expect(nextActive(0, 1, 3)).toBe(1);
+    expect(nextActive(2, 1, 3)).toBe(0);
+    expect(nextActive(0, -1, 3)).toBe(2);
+  });
+
+  it("空列表恒为 0(不产生 NaN 下标)", () => {
+    expect(nextActive(0, 1, 0)).toBe(0);
+    expect(nextActive(3, -1, 0)).toBe(0);
+  });
+});

--- a/desktop/ui/src/slashCommands.ts
+++ b/desktop/ui/src/slashCommands.ts
@@ -1,0 +1,40 @@
+// 斜杠指令(Agent 上报的 available_commands)的纯逻辑:输入框里"正在敲的
+// 指令"识别、过滤排序、选中后的回填文本。UI 在 commandMenu.tsx,这里不触 DOM。
+import type { SlashCommand } from "./types";
+
+/** 输入框正在敲斜杠指令时返回查询词(不含 /),否则 null。
+ *
+ * 只认"整段输入以 / 开头且还没敲空格"这一种形态:指令必须是整条消息的
+ * 开头(云端按 `/name args` 解析),句中出现的 `/` 是路径/日期,弹菜单是打扰。 */
+export function slashQuery(input: string): string | null {
+  if (!input.startsWith("/")) return null;
+  const q = input.slice(1);
+  // 空格后即进入"填参数"阶段,指令已选定,不再补全
+  return /[\s]/.test(q) ? null : q;
+}
+
+/** 按查询词过滤:前缀匹配优先于子串匹配(敲 co 先给 /compact 而非 /add-context) */
+export function filterCommands(commands: SlashCommand[], query: string): SlashCommand[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return commands;
+  const prefix: SlashCommand[] = [];
+  const rest: SlashCommand[] = [];
+  for (const c of commands) {
+    const name = c.name.toLowerCase();
+    if (name.startsWith(q)) prefix.push(c);
+    else if (name.includes(q) || (c.description ?? "").toLowerCase().includes(q)) rest.push(c);
+  }
+  return [...prefix, ...rest];
+}
+
+/** 选中指令后的输入框内容:带参数提示的补一个空格(光标随即等着填参数),
+ * 无参数的原样——用户按 ↩ 即可直接发出。 */
+export function commandText(cmd: SlashCommand): string {
+  return cmd.input?.hint ? `/${cmd.name} ` : `/${cmd.name}`;
+}
+
+/** 键盘导航后的高亮下标(列表为空回 0;上下越界回绕) */
+export function nextActive(active: number, delta: number, length: number): number {
+  if (length <= 0) return 0;
+  return (active + delta + length) % length;
+}

--- a/desktop/ui/src/types.ts
+++ b/desktop/ui/src/types.ts
@@ -152,6 +152,15 @@ export interface AcpUpdate {
   mode?: string;
   /** 工具产出的图片(截图/读图)在工作区的相对路径 */
   images?: string[];
+  /** available_commands_update:Agent 上报的可用斜杠指令(全量重发) */
+  availableCommands?: SlashCommand[];
+}
+
+/** Agent 上报的斜杠指令(/compact、/review 等技能;input.hint 是参数提示) */
+export interface SlashCommand {
+  name: string;
+  description?: string;
+  input?: { hint?: string | null } | null;
 }
 
 /** tool_call_update{status:in_progress} 的执行期进度载荷 */

--- a/desktop/ui/src/useCloudTask.ts
+++ b/desktop/ui/src/useCloudTask.ts
@@ -29,7 +29,7 @@ import { groupCloudModels, type McCloudModelGroup } from "./cloud";
 import { MAX_CLOUD_ATTS, uploadCloudFile, type CloudUploadedAtt } from "./cloudUpload";
 import { frameData } from "./codec";
 import { answerAsk as applyAskAnswer, initialChat, reduceBatch, type ChatState } from "./reduce";
-import type { CloudAttachment, CloudTask, CloudTaskDetail, Frame } from "./types";
+import type { CloudAttachment, CloudTask, CloudTaskDetail, Frame, SlashCommand } from "./types";
 
 /** cursor 帧载荷:attach 下发时 data 既有裸 JSON 对象也有 base64(JSON)
  * 形态(云端契约不归本仓库管)——frameData 的双格式容错正是为此收口。 */
@@ -414,6 +414,8 @@ export interface CloudTaskHandle {
   queuedAtts: number;
   clearQueued(): void;
   send(): void;
+  /** Agent 上报的可用斜杠指令(composer 的 / 菜单;跨重连粘住最近一次非空清单) */
+  commands: SlashCommand[];
   /** 待发送附件(已上传完成;单条消息上限 3) */
   atts: CloudUploadedAtt[];
   /** 上传进行中的附件数(>0 时发送先拦下,避免半套附件出门) */
@@ -608,6 +610,16 @@ export function useCloudTask(
     return () => core.closeConn();
   }, [id, core, taskStatus, attachEpoch]);
 
+  // 斜杠指令清单是"事件驱动"的:只在 available_commands_update 到达时才有值,
+  // 而 attach 重连/新一轮会以历史帧重算 chat(commands 归零)。这里把最近一次
+  // 非空清单粘住,断线重连后 composer 的 / 菜单不会突然空掉。
+  const [commands, setCommands] = useState<SlashCommand[]>([]);
+  useEffect(() => {
+    if (chat.commands.length) setCommands(chat.commands);
+  }, [chat.commands]);
+  // 切任务时清空(App 以 id 为 key 重挂视图,这里是"key 被移除"时的兜底)
+  useEffect(() => setCommands([]), [id]);
+
   // 贴底跟随(简化版:仅程序滚动,不做锚点恢复——云端流为跟看场景)
   useEffect(() => {
     const el = scrollRef.current;
@@ -770,6 +782,7 @@ export function useCloudTask(
     queuedAtts: queuedAtts.length,
     clearQueued: () => core.clearQueued(),
     send,
+    commands,
     atts,
     uploading,
     addFiles,


### PR DESCRIPTION
指令(available_commands_update)此前在 desktop 被直接丢弃。现归约进 ChatState.commands,由 useCloudTask 粘住最近一次非空清单(attach 重连会 以历史帧重算 chat,不粘住菜单会突然空掉)。入口按桌面交互给两条:输入框
敲 / 就地补全(↑↓/↩/⇥/Esc),或点 composer 左侧 / 按钮浏览全部。

启动页(pending)原先只有一条黄色小横幅。现按 virtualmachine.conditions 展开成阶段时间线:已完成打勾、当前项转圈带进度条与详情、失败项红色带原因
与补救路径。与移动端有意的差异是 composer 保持可用——桌面本就有排队投递
(环境就绪自动送达),退化成只读等待页是丢功能。