### PR TITLE
fix(desktop): 提示音的两条命令补进 ACL 允许列表

### DIFF
--- a/desktop/build.rs
+++ b/desktop/build.rs
@@ -13,6 +13,13 @@ fn main() {
 
     // 为应用自定义命令生成 ACL 权限(allow-<command>):
     // capability 中引用的每个自定义命令都必须在此登记。
+    //
+    // 新增一条命令要同时动三处:main.rs 的 invoke_handler、这里、以及
+    // tauri.conf.json 里**用得到它的每个** capability。两个方向的失手代价
+    // 不对称:capability 里名字写错是编译期硬错(UnknownPermission),而漏加
+    // capability 只在运行期被 ACL 拒掉——UI 侧若把 invoke 的报错 catch 掉,
+    // 症状就是"按钮点了没反应",编译与测试全绿。桌宠页与主窗口是两个
+    // capability,只给一边放行同样是这个症状。
     tauri_build::try_build(
         tauri_build::Attributes::new().app_manifest(
             tauri_build::AppManifest::new().commands(&[
@@ -22,6 +29,8 @@ fn main() {
                 "host_info",
                 "show_main",
                 "pet_native_render",
+                "sound_enabled",
+                "set_sound_enabled",
                 "update_check",
                 "update_install",
                 "open_extension_dir",

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -37,6 +37,8 @@
             "allow-save-config",
             "allow-take-ui-intent",
             "allow-host-info",
+            "allow-sound-enabled",
+            "allow-set-sound-enabled",
             "allow-update-check",
             "allow-update-install",
             "allow-open-extension-dir",
@@ -123,7 +125,8 @@
             "core:window:allow-outer-position",
             "allow-sessions-list",
             "allow-show-main",
-            "allow-pet-native-render"
+            "allow-pet-native-render",
+            "allow-sound-enabled"
           ]
         }
       ]

--- a/desktop/ui/public/pet.html
+++ b/desktop/ui/public/pet.html
@@ -255,7 +255,7 @@
   // 每次启动仍要挨一声。取不到(命令异常)按默认"开"继续,不拖住状态渲染。
   invoke('sound_enabled')
     .then((on) => { soundEnabled = on !== false; })
-    .catch(() => {})
+    .catch((e) => console.warn('[pet] 读取提示音开关失败,按开处理', e))
     .then(snapshot);
 
   // ---- 交互:拖动(位移阈值)与点击(唤回主窗口) ----

--- a/desktop/ui/src/settings.tsx
+++ b/desktop/ui/src/settings.tsx
@@ -683,7 +683,7 @@ export function SettingsView({
     let alive = true;
     void getSoundEnabled().then((on) => {
       if (alive) setSoundOn(on);
-    }).catch(() => {});
+    }).catch((e) => console.warn("[settings] 读取提示音开关失败", e));
     const off = onHostEvent<boolean>("sound-enabled", (on) => setSoundOn(on !== false));
     return () => {
       alive = false;
@@ -691,8 +691,14 @@ export function SettingsView({
     };
   }, []);
   const pickSound = (next: boolean) => {
-    setSoundOn(next); // 乐观置位:壳广播会回来盖一次,失败则由它纠回
-    void setSoundEnabled(next).catch(() => void getSoundEnabled().then(setSoundOn).catch(() => {}));
+    setSoundOn(next); // 乐观置位:壳广播会回来盖一次,失败则回滚并报错
+    setErr("");
+    void setSoundEnabled(next).catch((e) => {
+      // 静默回滚会让按钮看着像坏了(命令没在 ACL 里放行就是这个症状):
+      // 把壳的原话摆出来,下次同类故障一眼可诊
+      setSoundOn(!next);
+      setErr("提示音开关切换失败: " + (e instanceof Error ? e.message : String(e)));
+    });
   };
 
   // 登录态由 Shell 持有:账号页 BaizhiCard 与模型/MCP 页的引导条共用


### PR DESCRIPTION
设置页的开关点了没反应,托盘的却好使——两处走的是同一个
apply_sound_enabled,差别只在设置页要经 IPC。本仓对每条自定义命令做显式
ACL 允许列表,sound_enabled/set_sound_enabled 没登记,invoke 被 Tauri 拒在 门外;UI 侧又把错误 catch 掉了,于是表现为按钮是死的。

三处补齐:build.rs 生成 allow-* 权限、main-app capability 放行两条(设置页 读+写)、pet-page 放行 sound_enabled(桌宠页启动要读一次——它此前同样被拒, 回落默认"开",所以只有托盘的事件广播能静音,事件不过 ACL)。

顺带把吞掉的错误露出来:设置页切换失败改为回滚并把壳的原话显示在错误位,
两处读取失败降级为 console.warn。静默 catch 正是这个 bug 编译测试全绿却
线上不工作的原因。build.rs 头部记下这个不对称:capability 里名字写错是
编译期硬错,漏加 capability 只在运行期被拒。