### PR TITLE
fix(desktop): 会员模型行的悬停操作区移开不消失

### DIFF
--- a/desktop/ui/src/modelMenu.test.ts
+++ b/desktop/ui/src/modelMenu.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   filterModels,
   groupMemberSections,
+  memberCategory,
   modelDisplay,
   modelDisplayByName,
   modelMenuTabs,
@@ -108,6 +109,18 @@ describe("filterModels(tab 内过滤)", () => {
     // 导航由 tab 承担,组名不再是匹配面
     expect(filterModels(items, "会员")).toEqual([]);
     expect(filterModels(items, "不存在")).toEqual([]);
+  });
+});
+
+describe("memberCategory(设置页药丸与分节共用的分类词汇)", () => {
+  it("档位优先于 owner;公共非档位与旧同步条目都归付费", () => {
+    expect(memberCategory({ model: "monkeycode-basic/b", owner: "public" })).toBe("基础");
+    expect(memberCategory({ model: "monkeycode-pro/p", owner: "public" })).toBe("专业");
+    expect(memberCategory({ model: "monkeycode-ultra/u", owner: "private" })).toBe("旗舰");
+    expect(memberCategory({ model: "some-model", owner: "public" })).toBe("付费");
+    expect(memberCategory({ model: "another-model" })).toBe("付费"); // 改造前同步的条目无 owner
+    expect(memberCategory({ model: "my-model", owner: "private" })).toBe("我的");
+    expect(memberCategory({ model: "team-model", owner: "team" })).toBe("团队");
   });
 });
 

--- a/desktop/ui/src/modelMenu.ts
+++ b/desktop/ui/src/modelMenu.ts
@@ -101,27 +101,31 @@ export interface MemberSection {
   items: ModelInfo[];
 }
 
-/** 会员 tab 分节(与 Web/groupCloudModels 同一分类词汇):档位三节 →
- * 付费(公共非档位;owner 缺失的旧同步条目也归这里——旧同步只收 public,
- * 语义正确)→ 我的(private)→ 团队(team,扁平单节)。徽标是资格说明;
- * 超档条目在档位节内以 locked 灰态出现。 */
-const MEMBER_SECTION_DEFS: {
-  label: string;
-  badge?: string;
-  match: (tier: string | undefined, owner: string | undefined) => boolean;
-}[] = [
-  { label: "基础模型", badge: "免费使用", match: (t) => t === "基础" },
-  { label: "专业模型", badge: "专业会员免费", match: (t) => t === "专业" },
-  { label: "旗舰模型", badge: "旗舰会员免费", match: (t) => t === "旗舰" },
-  { label: "付费模型", badge: "消耗积分", match: (t, o) => !t && o !== "private" && o !== "team" },
-  { label: "我的模型", match: (t, o) => !t && o === "private" },
-  { label: "团队模型", match: (t, o) => !t && o === "team" },
+/** 会员条目的分类词汇(与 Web/groupCloudModels 同一套,选择器分节与设置页
+ * 药丸共用这一处口径):档位三档(基础/专业/旗舰)→ 付费(公共非档位;
+ * owner 缺失的旧同步条目也归这里——旧同步只收 public,语义正确)→ 我的
+ * (private)→ 团队(team)。 */
+export function memberCategory(m: Pick<ModelInfo, "model" | "owner">): string {
+  const tier = builtinTierLabel(m.model);
+  if (tier) return tier;
+  return m.owner === "private" ? "我的" : m.owner === "team" ? "团队" : "付费";
+}
+
+/** 会员 tab 分节:节序即上面的分类序。徽标是资格说明;超档条目在档位节内
+ * 以 locked 灰态出现。 */
+const MEMBER_SECTION_DEFS: { cat: string; badge?: string }[] = [
+  { cat: "基础", badge: "免费使用" },
+  { cat: "专业", badge: "专业会员免费" },
+  { cat: "旗舰", badge: "旗舰会员免费" },
+  { cat: "付费", badge: "消耗积分" },
+  { cat: "我的" },
+  { cat: "团队" },
 ];
 
 export function groupMemberSections(items: ModelInfo[]): MemberSection[] {
   return MEMBER_SECTION_DEFS.map((d) => ({
-    label: d.label,
+    label: `${d.cat}模型`,
     badge: d.badge,
-    items: items.filter((m) => d.match(builtinTierLabel(m.model), m.owner)),
+    items: items.filter((m) => memberCategory(m) === d.cat),
   })).filter((s) => s.items.length > 0);
 }

--- a/desktop/ui/src/settings.tsx
+++ b/desktop/ui/src/settings.tsx
@@ -30,9 +30,8 @@ import { IconBack, IconGear, IconGlobe, IconMonitor, IconPlus, IconSpark } from 
 import { BaizhiLogo } from "./baizhi";
 import logoUrl from "./logo.png";
 import { Field, Section, input, select, whiteBtn } from "./settings-ui";
-import { builtinTierLabel } from "./cloud";
 import { mcModelsRevoke, mcModelsSync } from "./cloudapi";
-import { stripTierPrefix } from "./modelMenu";
+import { memberCategory, stripTierPrefix } from "./modelMenu";
 import {
   dedupeModelsByName,
   emptyMcp,
@@ -626,6 +625,11 @@ export function SettingsView({
   const [defaultIdx, setDefaultIdx] = useState(0);
   const [advOpen, setAdvOpen] = useState<Record<number, boolean>>({});
   const [expanded, setExpanded] = useState<number | null>(null); // 展开编辑的模型(真实索引)
+  // 行操作区(设为默认/删除)显隐认的模型行索引。WKWebView 里托管行的
+  // :hover 与 mouseleave 都可能不到达(操作区粘着不消失),所以判据不取
+  // 「行有没有收到离开事件」,而取**最后一次指针落在哪一行**:见下方
+  // useEffect,指针在页面里再动一下,陈旧的高亮就自愈
+  const [hoverRow, setHoverRow] = useState<number | null>(null);
   const [baizhiOpen, setBaizhiOpen] = useState(true); // 百智云组(账号优先,默认展开)
   const [mcModelsOpen, setMcModelsOpen] = useState(true); // MonkeyCode 会员模型组(默认展开)
   const [mcps, setMcps] = useState<McpEntry[]>([]);
@@ -694,6 +698,29 @@ export function SettingsView({
     setSoundOn(next); // 乐观置位:壳广播会回来盖一次,失败则由它纠回
     void setSoundEnabled(next).catch(() => void getSoundEnabled().then(setSoundOn).catch(() => {}));
   };
+
+  // 悬停行的唯一判据:指针每动一次就按落点重算(data-model-row 打在行上)。
+  // 不依赖行自己的 mouseenter/mouseleave——WKWebView 下托管行的离开事件可能
+  // 压根不到,操作区就永远留在屏上;按落点算则指针挪到任何地方都会归位。
+  // 滚动与窗口失焦另清:WebKit 滚动后不重算 hover,指针没动就不会有 move。
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      const el = e.target instanceof Element ? e.target.closest("[data-model-row]") : null;
+      const idx = el instanceof HTMLElement ? Number(el.dataset.modelRow) : NaN;
+      setHoverRow(Number.isInteger(idx) ? idx : null);
+    };
+    const clear = () => setHoverRow(null);
+    document.addEventListener("mousemove", onMove, true);
+    document.addEventListener("mouseleave", clear);
+    window.addEventListener("scroll", clear, true);
+    window.addEventListener("blur", clear);
+    return () => {
+      document.removeEventListener("mousemove", onMove, true);
+      document.removeEventListener("mouseleave", clear);
+      window.removeEventListener("scroll", clear, true);
+      window.removeEventListener("blur", clear);
+    };
+  }, []);
 
   // 登录态由 Shell 持有:账号页 BaizhiCard 与模型/MCP 页的引导条共用
   const [bzStatus, setBzStatus] = useState<BaizhiStatus | null>(null);
@@ -1185,13 +1212,17 @@ export function SettingsView({
     return (
       <>
         <div
-          className={managed ? "hrow" : "hrow hv2"}
+          // 托管行也带 hv2:悬停时整行背景变一次,行区域必被重绘。少了这条
+          // (改前托管行只有 .hrow),取消悬停时只有子元素 opacity 变,
+          // WKWebView 漏掉这次重绘,操作区的像素留在屏上抹不掉
+          className="hrow hv2"
+          data-model-row={i}
           onClick={managed ? undefined : () => setExpanded(isOpen ? null : i)}
           style={{ display: "flex", alignItems: "center", gap: 8, height: 40, padding: "0 14px", cursor: managed ? "default" : "pointer", userSelect: "none" }}
         >
-          {/* 托管行内不放任何 title 原生 tooltip:webkit 系 WebView 弹出
-              tooltip 会吞 mouseleave,行的 :hover 粘住,「设为默认/删除」
-              移开不消失(styles.css .hrow:hover .row-acts) */}
+          {/* 行内不放任何 title 原生 tooltip:webkit 系 WebView 弹出的 tooltip
+              是原生层,盖住行时页面收不到 mousemove,悬停态停在原地不动
+              ——操作区(下方 row-acts)就跟着粘住 */}
           <span
             className="ellipsis"
             style={{ fontSize: 12.5, fontFamily: MONO, color: m.name.trim() ? "var(--t1)" : "var(--t5)", minWidth: 0 }}
@@ -1200,13 +1231,10 @@ export function SettingsView({
           </span>
           <span style={pill}>{m.provider || "anthropic"}</span>
           {managed && (
-            // 档位即托管:会员条目必有档位/归属语境,一枚药丸承载两层信息
+            // 分类药丸:词汇与模型选择器的会员分节同出 memberCategory,
+            // 一个条目在两处只有一个叫法(基础/专业/旗舰/付费/我的/团队)
             <span style={{ ...pill, background: "var(--accBg)", color: "var(--accTx)" }}>
-              {(() => {
-                const tier = builtinTierLabel(m.model);
-                if (tier) return `${tier}会员`;
-                return m.owner === "private" ? "我的" : m.owner === "team" ? "团队" : "托管";
-              })()}
+              {memberCategory(m)}
             </span>
           )}
           {managed && m.locked && (
@@ -1217,7 +1245,23 @@ export function SettingsView({
             <span style={{ flex: "none", fontSize: 11, fontWeight: 700, color: "var(--accTx)", whiteSpace: "nowrap" }}>✓ 默认</span>
           )}
           <span style={{ flex: 1 }} />
-          <span className="row-acts" style={{ display: "flex", alignItems: "center", gap: 12, fontSize: 12, flex: "none" }}>
+          {/* 内联样式压过 .hrow:hover .row-acts,显隐只认 state。visibility 与
+              opacity 一起翻:光靠 opacity 变 0,WKWebView 会漏掉重绘把像素留在
+              屏上(visibility 是渲染树层面的变化,重绘必然发生);占位仍在,
+              所以行尾的 ▸ 不会随显隐左右跳 */}
+          <span
+            className="row-acts"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
+              fontSize: 12,
+              flex: "none",
+              opacity: hoverRow === i ? 1 : 0,
+              visibility: hoverRow === i ? "visible" : "hidden",
+              pointerEvents: hoverRow === i ? "auto" : "none",
+            }}
+          >
             {/* 锁定条目不物化进引擎,默认落它头上等于没有默认 → 不给入口 */}
             {i !== defaultIdx && !m.locked && (
               <span


### PR DESCRIPTION
设置页 MonkeyCode 会员模型行,鼠标移开后「设为默认/删除」留在屏上不走。

根因在重绘而非样式:操作区的显隐只改子元素 opacity,而托管行(不可点,
当时刻意不给 .hv2)悬停前后行本身没有任何视觉变化,WKWebView 漏掉这次
重绘,像素就留着——DOM 与计算样式一直是对的(实测 opacity 计算值为 0
时字仍在屏上)。百智云/自定义行有 .hv2 的背景变化整行重绘,所以无此症状。

- row-acts 的 visibility 与 opacity 一起翻:渲染树层面的变化,重绘必然 发生。占位不变,行尾 ▸ 不随显隐位移;代价是淡出没了(淡入保留)。
- 托管行补回 hv2:悬停时整行背景变一次,与其余行走同一条重绘路径,作为 第二重兜底。会员行因此多了一层淡底色。
- 悬停行改由指针落点判定(data-model-row + 页面级 mousemove),不再依赖 行自己的 mouseenter/mouseleave;滚动与窗口失焦另清(WebKit 滚动后不 重算 hover)。这不是本次症状的解,但比裸 :hover 稳。

顺带:设置页的会员分类药丸不再叫「托管」。该词只此一处,而它盖住的正是
选择器里叫「付费模型」的那批(公共非档位,含 owner 缺失的旧同步条目)。
新增 memberCategory 作单一出处,选择器分节与设置页药丸同词:基础/专业/
旗舰/付费/我的/团队(档位药丸随之从「专业会员」变为「专业」)。