### PR TITLE
feat(desktop): 云端项目行展开时按需拉取任务

### DIFF
--- a/desktop/ui/src/App.tsx
+++ b/desktop/ui/src/App.tsx
@@ -10,7 +10,7 @@ import {
   windowContextLabel,
   type AppMainView,
 } from "./appView";
-import { mcLogin, mcLogout, mcPasswordLogin, mcTaskDelete, mcTaskStop } from "./cloudapi";
+import { mcLogin, mcLogout, mcPasswordLogin, mcTaskDelete, mcTasks, mcTaskStop } from "./cloudapi";
 import {
   getHostConfig,
   getHostInfo,
@@ -55,7 +55,7 @@ import TitleBar from "./titlebar";
 import { uploadFileURL } from "./uploads";
 import { lastSessionId, useSession } from "./useSession";
 import { updateGate } from "./updateGate";
-import type { CloudProject, CloudTask, EngineStatus, HostInfo, LogItem, McConnectionState, ModelInfo, SessionMeta, UpdateStatus } from "./types";
+import type { CloudProject, CloudProjectTasks, CloudTask, EngineStatus, HostInfo, LogItem, McConnectionState, ModelInfo, SessionMeta, UpdateStatus } from "./types";
 import { engineBannerView, engineTransition } from "./engineBanner";
 
 /** 内核与页面同机(serve 仅绑 loopback),浏览器 UA 即宿主平台 */
@@ -177,6 +177,31 @@ export default function App() {
   const [cloudTasks, setCloudTasks] = useState<CloudTask[]>([]);
   const [cloudHistory, setCloudHistory] = useState<CloudTask[]>([]);
   const [cloudProjects, setCloudProjects] = useState<CloudProject[]>([]);
+  /** 项目行展开时按需拉取的任务(按项目 id 缓存)。项目列表接口只捎带每个
+   * 项目最多 3 条**运行中**的任务,历史任务在里面一条都没有——想在项目下看
+   * 到任务,只能展开时按 project_id 单独拉一次。 */
+  const [cloudProjectTasks, setCloudProjectTasks] = useState<Record<string, CloudProjectTasks>>({});
+  const loadCloudProjectTasks = useCallback(async (project: CloudProject) => {
+    const id = project.id;
+    if (!id) return;
+    let skip = false;
+    setCloudProjectTasks((cur) => {
+      // 在途/已到的不重拉;要刷新走下面的清缓存(整体同步时)
+      if (cur[id]?.loading || cur[id]?.tasks) {
+        skip = true;
+        return cur;
+      }
+      return { ...cur, [id]: { loading: true } };
+    });
+    if (skip) return;
+    try {
+      const resp = await mcTasks(1, 20, "", { projectId: id });
+      const tasks = [...(resp.tasks ?? [])].sort((a, b) => Number(b.created_at ?? 0) - Number(a.created_at ?? 0));
+      setCloudProjectTasks((cur) => ({ ...cur, [id]: { tasks } }));
+    } catch (e) {
+      setCloudProjectTasks((cur) => ({ ...cur, [id]: { error: e instanceof Error ? e.message : String(e) } }));
+    }
+  }, []);
   const [mcConnection, setMcConnection] = useState<McConnectionState>({
     phase: "checking",
     host: "monkeycode-ai.com",
@@ -207,6 +232,9 @@ export default function App() {
       if (snapshot.tasks !== undefined) setCloudTasks(snapshot.tasks);
       if (snapshot.historicalTasks !== undefined) setCloudHistory(snapshot.historicalTasks);
       if (snapshot.projects !== undefined) setCloudProjects(snapshot.projects);
+      // 整体刷新连带清掉项目任务缓存:仍展开着的项目由侧栏的按需拉取补回,
+      // 收起的等下次展开——不在这里替所有项目预拉
+      setCloudProjectTasks({});
       if (snapshot.taskError) setCloudError(snapshot.taskError);
     } catch (e) {
       if (op !== cloudOp.current) return;
@@ -798,6 +826,8 @@ export default function App() {
           cloudTasks={cloudTasks}
           cloudHistory={cloudHistory}
           cloudProjects={cloudProjects}
+          cloudProjectTasks={cloudProjectTasks}
+          onLoadCloudProjectTasks={(project) => void loadCloudProjectTasks(project)}
           activeCloudId={view === "cloud" ? cloudTask?.id ?? null : null}
           cloudSyncing={cloudSyncing}
           cloudError={cloudError}

--- a/desktop/ui/src/cloudProjectRow.test.tsx
+++ b/desktop/ui/src/cloudProjectRow.test.tsx
@@ -1,0 +1,91 @@
+// 侧栏「项目」组里的云端项目行。项目列表接口每项只捎带 ≤3 条**运行中**的任务
+// (后端按 pending/processing 过滤),历史任务一条不带:所以"没任务"多半只是
+// "此刻没在跑"。有在跑的默认展开,其余默认收起、点开再按 project_id 拉。
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Sidebar } from "./sidebar";
+import type { CloudProject, CloudProjectTasks } from "./types";
+
+beforeEach(() => {
+  // 云端内容只在「云端」空间渲染:让侧栏从持久化里恢复到该空间
+  vi.stubGlobal("window", {});
+  vi.stubGlobal("navigator", { userAgent: "vitest" });
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => (k === "mc.sidebarSpace" ? "cloud" : null),
+    setItem: vi.fn(),
+  });
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+const render = (cloudProjects: CloudProject[], cloudProjectTasks: Record<string, CloudProjectTasks> = {}) =>
+  renderToStaticMarkup(
+    <Sidebar
+      sessions={[]}
+      archivedProjects={new Set()}
+      currentId={null}
+      attention={new Set()}
+      sessionActive={false}
+      connected
+      status="已连接"
+      mcConnection={{ phase: "connected", host: "monkeycode-ai.com" }}
+      cloudTasks={[]}
+      cloudProjects={cloudProjects}
+      cloudProjectTasks={cloudProjectTasks}
+      onLoadCloudProjectTasks={() => {}}
+      onConnectCloud={() => {}}
+      onNewCloudTask={() => {}}
+      onOpenCloudTask={() => {}}
+      onSelect={() => {}}
+      onNewTask={() => {}}
+      onProjectArchive={() => {}}
+      onNewChat={() => {}}
+      onOpenSettings={() => {}}
+      onArchive={() => {}}
+      onDelete={() => {}}
+      onRename={() => {}}
+    />,
+  );
+
+const idle: CloudProject = { id: "p-idle", name: "闲置项目", repo_url: "git@x:o/idle.git", tasks: [] };
+const busy: CloudProject = {
+  id: "p-busy",
+  name: "在跑的项目",
+  repo_url: "git@x:o/busy.git",
+  tasks: [{ id: "t-run", title: "重做启动页", status: "processing" }],
+};
+
+describe("云端项目行的默认展开", () => {
+  it("没有在跑任务的项目默认收起:不摊开、不占位", () => {
+    const html = render([idle]);
+    expect(html).toContain("闲置项目");
+    expect(html).not.toContain("暂无任务");
+    expect(html).toContain('aria-expanded="false"');
+    // 新建入口留着:侧栏仍能直接在这个项目里起任务
+    expect(html).toContain("在 闲置项目 中新建任务");
+    // 悬停提示交代它是可以点开的
+    expect(html).toContain("展开查看任务");
+  });
+
+  it("有在跑任务的项目照常默认展开,任务行渲染出来", () => {
+    const html = render([busy]);
+    expect(html).toContain("重做启动页");
+    expect(html).toContain('aria-expanded="true"');
+    expect(html).toContain("1 个进行中");
+  });
+
+  it("拉到过任务的项目按拉取结果显示条数(含已完成的历史任务)", () => {
+    const html = render([busy], {
+      "p-busy": {
+        tasks: [
+          { id: "t-run", title: "重做启动页", status: "processing" },
+          { id: "t-done", title: "修复登录跳转", status: "finished" },
+        ],
+      },
+    });
+    expect(html).toContain("重做启动页");
+    expect(html).toContain("修复登录跳转");
+    expect(html).toContain("2 个任务");
+  });
+});

--- a/desktop/ui/src/sidebar.tsx
+++ b/desktop/ui/src/sidebar.tsx
@@ -24,7 +24,7 @@ import logoUrl from "./logo.png";
 import { isProjectArchived, projectArchiveKey } from "./projectArchive";
 import { applyProjectOrder, persistProjectOrder, readProjectOrder, reorderProjects } from "./projectOrder";
 import { MacBrandBand, MacWindowControls } from "./titlebar";
-import type { CloudProject, CloudTask, EngineStatus, McConnectionState, SessionMeta } from "./types";
+import type { CloudProject, CloudProjectTasks, CloudTask, EngineStatus, McConnectionState, SessionMeta } from "./types";
 
 export interface ProjectGroup {
   dir: string;
@@ -666,6 +666,8 @@ export function Sidebar({
   cloudTasks,
   cloudHistory = [],
   cloudProjects = [],
+  cloudProjectTasks = {},
+  onLoadCloudProjectTasks,
   activeCloudId,
   cloudSyncing,
   cloudError,
@@ -704,6 +706,9 @@ export function Sidebar({
   cloudTasks: CloudTask[];
   cloudHistory?: CloudTask[];
   cloudProjects?: CloudProject[];
+  /** 项目 id → 展开时按需拉到的任务;缺省项 = 还没拉过 */
+  cloudProjectTasks?: Record<string, CloudProjectTasks>;
+  onLoadCloudProjectTasks?: (project: CloudProject) => void;
   activeCloudId?: string | null;
   cloudSyncing?: boolean;
   cloudError?: string;
@@ -734,6 +739,9 @@ export function Sidebar({
   const [chatArchiveOpen, setChatArchiveOpen] = useState(() => localStorage.getItem("mc.archivedOpen") === "1");
   const [projectArchiveOpen, setProjectArchiveOpen] = useState(() => localStorage.getItem("mc.projectArchiveOpen") === "1");
   const [cloudHistoryOpen, setCloudHistoryOpen] = useState(() => localStorage.getItem("mc.cloudHistoryOpen") === "1");
+  // 没有运行中任务的云端项目默认收起(展开也只有一行占位),这里记的是用户
+  // 显式点开的那些。不持久化:开着的项目每次启动都要重新拉一遍任务,不值当
+  const [openedCloudProjects, setOpenedCloudProjects] = useState<Set<string>>(new Set());
   const [projectOrder, setProjectOrder] = useState<string[]>(readProjectOrder);
   // 冷启动宽限:starting/attempt=0 持续超过 3s 才亮引擎卡——快速启动不闪卡,
   // WSL 预热/慢盘的长启动期不再零反馈(横幅对这段刻意留白,见 engineBanner.ts)
@@ -779,6 +787,16 @@ export function Sidebar({
       if (next.has(dir)) next.delete(dir);
       else next.add(dir);
       storeSet("mc.collapsedGroups", next);
+      return next;
+    });
+  };
+  // 没有在跑任务的云端项目:默认收起,这里记显式点开的(展开后由上面的
+  // 按需拉取补内容)。与 collapsed 分开存,免得两套默认态互相打架
+  const toggleCloudProject = (key: string) => {
+    setOpenedCloudProjects((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
       return next;
     });
   };
@@ -922,14 +940,37 @@ export function Sidebar({
   }
   const filteredCloudTasks = cloudTasks.filter(matchesCloud);
   const filteredCloudHistory = cloudHistory.filter(matchesCloud);
-  const filteredCloudProjects: { project: CloudProject; tasks: CloudTask[] }[] = [];
+  // 项目列表接口每个项目只捎带 ≤3 条**运行中**的任务(后端按 pending/processing
+  // 过滤),历史任务一条都没有——所以"项目下没任务"多半只是"此刻没有在跑的"。
+  // 展开时按 project_id 单拉一次(loaded),拉到就以它为准。
+  const filteredCloudProjects: { project: CloudProject; tasks: CloudTask[]; key: string; open: boolean; state?: CloudProjectTasks }[] = [];
   for (const project of cloudProjects) {
     const projectMatch = !norm || `${project.name ?? ""} ${project.full_name ?? ""} ${project.repo_url ?? ""}`.toLocaleLowerCase().includes(norm);
-    const tasks = [...(project.tasks ?? [])]
+    const state = project.id ? cloudProjectTasks[project.id] : undefined;
+    const running = project.tasks ?? [];
+    const tasks = [...(state?.tasks ?? running)]
       .sort((a, b) => Number(b.created_at ?? 0) - Number(a.created_at ?? 0))
       .filter((task) => projectMatch || matchesCloud(task));
-    if (projectMatch || tasks.length > 0) filteredCloudProjects.push({ project, tasks });
+    if (!projectMatch && tasks.length === 0) continue;
+    const key = `cloud:${project.id || project.repo_url || project.name || filteredCloudProjects.length}`;
+    // 有在跑的任务就默认展开(和以前一样,collapsed 记显式收起的);其余默认
+    // 收起,openedCloudProjects 记显式点开的——一屏项目全摊开只有噪音
+    const open = !!norm || (running.length > 0 ? !collapsed.has(key) : openedCloudProjects.has(key));
+    filteredCloudProjects.push({ project, tasks, key, open, state });
   }
+  // 展开着的项目按需补拉任务(App 侧缓存去重,拉过/在途的不重发)。搜索期间
+  // 全部临时展开,那时不拉:一次搜索不该顺带打一串请求。
+  const pendingTaskLoads = norm || space !== "cloud"
+    ? []
+    : filteredCloudProjects.filter((e) => e.open && e.project.id && !e.state).map((e) => e.project.id as string);
+  const pendingTaskLoadKey = pendingTaskLoads.join(",");
+  useEffect(() => {
+    if (!onLoadCloudProjectTasks || !pendingTaskLoadKey) return;
+    for (const id of pendingTaskLoadKey.split(",")) {
+      const project = cloudProjects.find((p) => p.id === id);
+      if (project) onLoadCloudProjectTasks(project);
+    }
+  }, [pendingTaskLoadKey]);
 
   const sessionRow = (meta: SessionMeta, archived: boolean, depth = 0) => (
     <SessionRow
@@ -1069,22 +1110,26 @@ export function Sidebar({
         {filteredCloudProjects.length > 0 && (
           <div style={{ display: "flex", flexDirection: "column", gap: 1, borderTop: "1px solid var(--line2)", marginTop: 9, paddingTop: 8 }}>
             <span style={{ padding: "3px 9px 4px", color: "var(--t5)", fontSize: 10.5, fontWeight: 700, letterSpacing: 0.35 }}>项目</span>
-            {filteredCloudProjects.map(({ project, tasks }, index) => {
-              const key = `cloud:${project.id || project.repo_url || project.name || index}`;
+            {filteredCloudProjects.map(({ project, tasks, key, open, state }) => {
               const name = project.name || project.full_name || "未命名项目";
+              const running = (project.tasks ?? []).length;
               return (
                 <ProjectGroup
                   key={key}
                   name={name}
-                  detail={`${project.repo_url || project.full_name || "云端项目"}\n${tasks.length} 个任务`}
+                  detail={`${project.repo_url || project.full_name || "云端项目"}\n${state?.tasks ? `${tasks.length} 个任务` : running ? `${running} 个进行中` : "展开查看任务"}`}
                   project
-                  expanded={!!norm || !collapsed.has(key)}
-                  onToggle={() => toggleGroup(key)}
+                  expanded={open}
+                  onToggle={() => (running > 0 ? toggleGroup(key) : toggleCloudProject(key))}
                   onNewTask={() => onNewCloudTask(project)}
                 >
                   {tasks.length > 0
                     ? tasks.map((task) => cloudTaskRow(task, 1))
-                    : <span style={{ padding: "3px 12px 5px 38px", color: "var(--t6)", fontSize: 10.5 }}>暂无任务</span>}
+                    : (
+                      <span style={{ padding: "3px 12px 5px 38px", color: state?.error ? "var(--warn)" : "var(--t6)", fontSize: 10.5 }}>
+                        {state?.loading || (!state && running === 0) ? "加载中…" : state?.error ? `任务加载失败：${state.error}` : "暂无任务"}
+                      </span>
+                    )}
                 </ProjectGroup>
               );
             })}

--- a/desktop/ui/src/types.ts
+++ b/desktop/ui/src/types.ts
@@ -465,6 +465,14 @@ export interface CloudProject {
   tasks?: CloudTask[];
 }
 
+/** 项目行展开时按需拉取的任务(App 持有缓存,侧栏只读):三态互斥,
+ * 都缺省 = 还没拉过。 */
+export interface CloudProjectTasks {
+  loading?: boolean;
+  tasks?: CloudTask[];
+  error?: string;
+}
+
 export interface CloudProjectsResp {
   projects?: CloudProject[];
   page?: { cursor?: string; has_more?: boolean };


### PR DESCRIPTION
侧栏云端项目组要么一排「暂无任务」,要么(上一版收成单行后)点不开——两者
同源:项目列表接口每项只捎带 ≤3 条**运行中**的任务(后端按 pending/processing 过滤,见 backend/biz/project/repo/project.go),历史任务一条不带。绝大多数项目 此刻没在跑任务,到侧栏就是空数组,而"空"并不等于这个项目没有任务。

- 有在跑任务的项目:仍默认展开,收起态照旧记 mc.collapsedGroups。
- 没有在跑任务的项目:默认收起(不再摊一排占位),点开才展;展开态单独记在 组件内,不持久化——否则每次启动都要替它们各拉一次任务。
- 展开即按 project_id 拉最近 20 条(不限状态),拉到就以它为准:项目下从此 能看到历史任务,这是以前侧栏看不到的。mc_tasks 的 IPC 早就带 project_id, 壳侧未改。缓存按项目 id 存在 App,去重且不重发;整体同步时清空,仍展开的 项目由侧栏的按需拉取补回。
- 拉取中「加载中…」、失败「任务加载失败：…」,确认为空才「暂无任务」。 悬停提示随之三态:展开查看任务 / N 个进行中 / N 个任务。

搜索期间全部临时展开,那时不触发拉取——一次搜索不该顺带打一串请求。