### PR TITLE
fix(desktop): 切模型的系统行带出寻址后缀

### DIFF
--- a/desktop/ui/src/reduce.test.ts
+++ b/desktop/ui/src/reduce.test.ts
@@ -511,6 +511,15 @@ describe("轮次与系统帧", () => {
     expect(s.items.filter((it) => it.kind === "sys")).toHaveLength(2);
   });
 
+  it("model_update 的系统行剥寻址后缀与会员档位前缀,状态仍存原始名", () => {
+    const s = run([acp({ sessionUpdate: "model_update", model: "monkeycode-pro/deepseek@monkeycode#cfg-9" })]);
+    expect(s.items.at(-1)).toEqual({ kind: "sys", text: "模型已切换为 deepseek" });
+    expect(s.model).toBe("monkeycode-pro/deepseek@monkeycode#cfg-9");
+
+    const remark = run([acp({ sessionUpdate: "model_update", model: "深度求索@monkeycode#cfg-9" })]);
+    expect(remark.items.at(-1)).toEqual({ kind: "sys", text: "模型已切换为 深度求索" });
+  });
+
   it("think_update 回写档位并留系统行,空档位显示为默认", () => {
     const s = run([acp({ sessionUpdate: "think_update", think: "high" })]);
     expect(s.think).toBe("high");

--- a/desktop/ui/src/reduce.ts
+++ b/desktop/ui/src/reduce.ts
@@ -1,7 +1,7 @@
 // 帧 → 对话流渲染项的归约:流式文本聚合、工具状态回写、审批卡片终态、
 // AI 提问卡(ask_user_question)等。纯函数,不触 DOM。
 import { b64decode, frameData } from "./codec";
-import { stripTierPrefix } from "./modelMenu";
+import { stripSourceSuffix, stripTierPrefix } from "./modelMenu";
 import { toolContentText, toolResultText } from "./toolDetails";
 import type { AcpUpdate, AskQuestion, Frame, LogItem, PermOutcome, PlanEntry, SlashCommand, SubEntry, ToolProgress, Usage } from "./types";
 
@@ -405,10 +405,12 @@ function reduceAcp(s: ChatState, u: AcpUpdate, timestamp?: number): ChatState {
         text: u.status === "started" ? "⟳ 上下文接近上限,正在压缩…" : "⟳ 上下文压缩完成",
       });
     case "model_update": {
-      // 系统行外显短名(剥会员档位前缀);状态 model 保持原始名——它是
+      // 系统行外显短名(先剥 @来源#配置id 的寻址后缀,再剥会员档位前缀,
+      // 与 modelMenu.modelDisplay 同序);状态 model 保持原始名——它是
       // 按 name 回查模型/think 档的键
       const name = u.model ?? "";
-      return { ...push(s, { kind: "sys", text: `模型已切换为 ${stripTierPrefix(name)}` }), model: name };
+      const shown = stripTierPrefix(stripSourceSuffix(name));
+      return { ...push(s, { kind: "sys", text: `模型已切换为 ${shown}` }), model: name };
     }
     case "think_update": {
       const level = u.think ?? "";


### PR DESCRIPTION
model_update 帧携带的是模型落盘原始名,`@monkeycode#<配置id>` 这段
来源后缀只是引擎寻址键的一部分(见 settingsConfig.syncedName),展示面
必须剥掉。reduce 里这条系统行只剥了会员档位前缀(stripTierPrefix),
于是会话里显示成「模型已切换为 深度求索@monkeycode#cfg-9」;菜单触发器
走 modelMenu.modelDisplay 剥了两层,所以只有这一处漏。

补上 stripSourceSuffix,顺序与 modelDisplay 一致(先剥后缀再剥档位
前缀)。状态里的 model 仍存原始名——它是按 name 回查模型/think 档的键。