### PR TITLE
fix(frontend): 本地化 AI 提问的其它选项

### DIFF
--- a/frontend/src/components/console/task/ask-user-option-label.ts
+++ b/frontend/src/components/console/task/ask-user-option-label.ts
@@ -1,0 +1,12 @@
+const OTHER_OPTION_LABELS = new Set(["其它", "其他", "Other"])
+
+export function getAskUserOptionDisplayLabel(
+  label: string | null | undefined,
+  otherLabel: string,
+): string {
+  if (!label) {
+    return ""
+  }
+
+  return OTHER_OPTION_LABELS.has(label.trim()) ? otherLabel : label
+}

--- a/frontend/src/components/console/task/message-ask-user-question.tsx
+++ b/frontend/src/components/console/task/message-ask-user-question.tsx
@@ -9,6 +9,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useTranslation } from "react-i18next"
+import { getAskUserOptionDisplayLabel } from "./ask-user-option-label"
 
 type AskUserQuestionStatus = "pending" | "queued" | "submitting" | "completed" | "expired"
 
@@ -189,7 +190,7 @@ export const AskUserQuestionMessageItem = ({ message, onResponse }: { message: M
                         htmlFor={`${message.data.askId}-${questionIndex}-${option.label}`}
                         className={cn("font-normal truncate", (!isInteractive && !isCheckboxChecked(questionIndex, option.label)) ? "text-muted-foreground/50" : "")}
                       >
-                        {option.label}
+                        {getAskUserOptionDisplayLabel(option.label, t("taskDetail.askUser.other"))}
                       </Label>
                     </Field>
                   ))}
@@ -262,7 +263,7 @@ export const AskUserQuestionMessageItem = ({ message, onResponse }: { message: M
                         htmlFor={`${message.data.askId}-${questionIndex}-${option.label}`}
                         className={cn("font-normal truncate", (!isInteractive && selectedRadioValue !== option.label) ? "text-muted-foreground/50" : "")}
                       >
-                        {option.label}
+                        {getAskUserOptionDisplayLabel(option.label, t("taskDetail.askUser.other"))}
                       </FieldLabel>
                     </Field>
                   ))}

--- a/frontend/src/i18n/resources/cn.ts
+++ b/frontend/src/i18n/resources/cn.ts
@@ -4320,6 +4320,7 @@ const cn = {
       expired: "问题已过期",
       custom: "其他 - 自定义",
       customPlaceholder: "请输入其他答案",
+      other: "其他",
       submit: "提交",
       submitIncomplete: "提交 (未完成)",
     },

--- a/frontend/src/i18n/resources/en.ts
+++ b/frontend/src/i18n/resources/en.ts
@@ -4320,6 +4320,7 @@ const en = {
       expired: "Question expired",
       custom: "Other - custom",
       customPlaceholder: "Enter another answer",
+      other: "Other",
       submit: "Submit",
       submitIncomplete: "Submit (incomplete)",
     },

--- a/frontend/test/task-ask-user-option-i18n.test.ts
+++ b/frontend/test/task-ask-user-option-i18n.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { getAskUserOptionDisplayLabel } from "../src/components/console/task/ask-user-option-label.ts";
+import cn from "../src/i18n/resources/cn.ts";
+import en from "../src/i18n/resources/en.ts";
+
+const source = readFileSync(
+  new URL(
+    "../src/components/console/task/message-ask-user-question.tsx",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+test("AI 提问的其它选项按界面语言显示", () => {
+  assert.equal(
+    getAskUserOptionDisplayLabel("其它", en.taskDetail.askUser.other),
+    "Other",
+  );
+  assert.equal(
+    getAskUserOptionDisplayLabel("其他", en.taskDetail.askUser.other),
+    "Other",
+  );
+  assert.equal(
+    getAskUserOptionDisplayLabel("Other", cn.taskDetail.askUser.other),
+    "其他",
+  );
+  assert.equal(
+    getAskUserOptionDisplayLabel(" 其它 ", en.taskDetail.askUser.other),
+    "Other",
+  );
+});
+
+test("普通 AI 选项保持原始显示文本", () => {
+  assert.equal(
+    getAskUserOptionDisplayLabel("方案 A", en.taskDetail.askUser.other),
+    "方案 A",
+  );
+  assert.equal(
+    getAskUserOptionDisplayLabel(" Option A ", en.taskDetail.askUser.other),
+    " Option A ",
+  );
+  assert.equal(
+    getAskUserOptionDisplayLabel(undefined, en.taskDetail.askUser.other),
+    "",
+  );
+});
+
+test("单选和多选只转换显示文本并保留原始选项值", () => {
+  const displayCalls =
+    source.match(
+      /getAskUserOptionDisplayLabel\(option\.label, t\("taskDetail\.askUser\.other"\)\)/g,
+    ) || [];
+  assert.equal(displayCalls.length, 2);
+  assert.match(
+    source,
+    /handleCheckboxClick\(questionIndex, option\.label, checked === true\)/,
+  );
+  assert.match(source, /value=\{option\.label\}/);
+});


### PR DESCRIPTION
## 变更说明

- 在 AI 提问选择框中按当前界面语言显示“其它/其他/Other”选项
- 单选与多选继续使用原始 option.label 作为选择和提交值
- 增加中英文资源及显示映射测试

## 验证

- 相关 node:test：11/11 通过
- 目标 ESLint：通过
- TypeScript tsc -b：通过
- git diff --check：通过