### PR TITLE
fix(frontend): 海外版隐藏微信公众号绑定

### DIFF
--- a/frontend/src/components/console/settings/notifications.tsx
+++ b/frontend/src/components/console/settings/notifications.tsx
@@ -58,7 +58,9 @@ import { Spinner } from "@/components/ui/spinner"
 import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia } from "@/components/ui/empty"
 import { WechatMpBindDialog } from "@/components/console/wechat-mp-bind-dialog"
 import { useCommonData } from "@/components/console/data-provider"
+import { useAppRuntime } from "@/components/app-runtime-provider"
 import { IS_ONLINE_EDITION } from "@/utils/edition"
+import { shouldShowWechatMp } from "@/utils/wechat-mp"
 import { useTranslation } from "react-i18next"
 
 /** Receiver type used by the UI; wechat_work maps to the API wecom kind. */
@@ -103,6 +105,8 @@ function getReceiverTypeIcon(type: ReceiverType): React.ReactNode {
 export default function Notifications() {
   const { t } = useTranslation()
   const { user, reloadUser } = useCommonData()
+  const { serverConfig } = useAppRuntime()
+  const showWechatMp = shouldShowWechatMp(IS_ONLINE_EDITION, serverConfig?.region)
   const [channels, setChannels] = useState<DomainNotifyChannel[]>([])
   const [eventTypes, setEventTypes] = useState<ConstsNotifyEventTypeInfo[]>([])
   const [loadingChannels, setLoadingChannels] = useState(true)
@@ -456,7 +460,7 @@ export default function Notifications() {
         </Button>
       </div>
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain">
-        {IS_ONLINE_EDITION && wechatMpStatusCard}
+        {showWechatMp && wechatMpStatusCard}
         {loadingChannels ? (
           loadingContent
         ) : channels.length > 0 ? (
@@ -605,7 +609,7 @@ export default function Notifications() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-      {IS_ONLINE_EDITION && (
+      {showWechatMp && (
         <>
           <WechatMpBindDialog
             open={wechatMpBindDialogOpen}

--- a/frontend/src/utils/wechat-mp.ts
+++ b/frontend/src/utils/wechat-mp.ts
@@ -1,0 +1,6 @@
+export function shouldShowWechatMp(
+  isOnlineEdition: boolean,
+  region?: string,
+): boolean {
+  return isOnlineEdition && region === "cn";
+}

--- a/frontend/test/console-settings-notifications-i18n.test.ts
+++ b/frontend/test/console-settings-notifications-i18n.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 
 import cn from "../src/i18n/resources/cn.ts";
 import en from "../src/i18n/resources/en.ts";
+import { shouldShowWechatMp } from "../src/utils/wechat-mp.ts";
 
 const source = readFileSync(
   new URL("../src/components/console/settings/notifications.tsx", import.meta.url),
@@ -24,4 +25,25 @@ test("设置通知页面提供中英文资源", () => {
   assert.equal(en.consoleSettings.notifications.actions.addReceiver, "Add receiver");
   assert.equal(cn.consoleSettings.notifications.remove.description, "确定要移除接收端 \"{{name}}\" 吗？此操作不可撤销。");
   assert.equal(en.consoleSettings.notifications.remove.description, "Remove receiver \"{{name}}\"? This action cannot be undone.");
+});
+
+test("海外 SaaS 隐藏微信公众号绑定并保留企业微信机器人", () => {
+  assert.match(source, /useAppRuntime/);
+  assert.match(
+    source,
+    /const showWechatMp = shouldShowWechatMp\(IS_ONLINE_EDITION, serverConfig\?\.region\)/,
+  );
+  assert.match(source, /\{showWechatMp && wechatMpStatusCard\}/);
+  assert.match(
+    source,
+    /\{showWechatMp && \([\s\S]*<WechatMpBindDialog[\s\S]*open=\{wechatMpUnbindDialogOpen\}[\s\S]*\n\s{6}\)\}/,
+  );
+  assert.match(source, /value: "wechat_work"/);
+});
+
+test("微信公众号绑定仅在国内在线版显示", () => {
+  assert.equal(shouldShowWechatMp(true, "cn"), true);
+  assert.equal(shouldShowWechatMp(true, "global"), false);
+  assert.equal(shouldShowWechatMp(true, undefined), false);
+  assert.equal(shouldShowWechatMp(false, "cn"), false);
 });


### PR DESCRIPTION
## 变更说明

本次仅调整前端通知设置页，复用现有 `serverConfig.region` 区分 SaaS 区域：

- 国内 SaaS（`region=cn`）继续显示微信公众号状态卡和绑定、解绑弹窗，原有功能保持不变。
- 海外 SaaS（`region=global`）隐藏微信公众号绑定相关 UI。
- 企业微信机器人 `wechat_work` 保持原样。
- 配置加载期间默认隐藏微信公众号入口，避免海外页面短暂闪现。

后端、API、数据库和微信公众号绑定接口均无改动。

## 实现方式

新增 `shouldShowWechatMp` 区域判定函数，仅在在线版且 `region=cn` 时返回 `true`。通知设置页使用同一个结果控制微信公众号状态卡及绑定、解绑弹窗。

## 验证

- 区域矩阵与相关回归测试：39 项通过。
- 目标 ESLint：通过。
- TypeScript 编译：通过。
- Online Vite 构建：通过。
- 独立代码审查：Ready to merge。

补充：本地全量 Node 测试共 321 项，312 项通过，9 项既有失败集中在 manager skills、模块路径解析和 offline skills，与本次改动文件无关联。