### PR TITLE
修复关闭 Captcha 后空 Token 登录失败

### DIFF
--- a/backend/biz/team/handler/http/v1/user.go
+++ b/backend/biz/team/handler/http/v1/user.go
@@ -97,7 +97,7 @@ func NewTeamGroupUserHandler(i *do.Injector) (*TeamGroupUserHandler, error) {
 //	@Router			/api/v1/teams/users/login [post]
 func (h *TeamGroupUserHandler) Login(c *web.Context, req domain.TeamLoginReq) error {
 	ctx := c.Request().Context()
-	if !h.captcha.ValidateToken(ctx, req.CaptchaToken) {
+	if h.config.Security.CaptchaEnabled && !h.captcha.ValidateToken(ctx, req.CaptchaToken) {
 		return errcode.ErrForbidden
 	}
 

--- a/backend/biz/team/handler/http/v1/user_captcha_test.go
+++ b/backend/biz/team/handler/http/v1/user_captcha_test.go
@@ -1,10 +1,12 @@
 package v1
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -42,6 +44,37 @@ func TestTeamLoginCaptchaToggle(t *testing.T) {
 			}
 			if usecase.called != tt.called {
 				t.Fatalf("Login usecase called = %v, want %v", usecase.called, tt.called)
+			}
+		})
+	}
+}
+
+func TestTeamLoginAcceptsEmptyCaptchaTokenWhenDisabled(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing", body: `{"email":"admin@example.com","password":"password"}`},
+		{name: "empty", body: `{"email":"admin@example.com","password":"password","captcha_token":""}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			usecase := &teamLoginUsecaseStub{}
+			h := &TeamGroupUserHandler{
+				logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+				usecase: usecase,
+				captcha: captcha.NewCaptcha(false),
+			}
+			w := web.New()
+			w.POST("/login", web.BindHandler(h.Login))
+
+			req := httptest.NewRequest(http.MethodPost, "/login", bytes.NewBufferString(tt.body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			w.Echo().ServeHTTP(httptest.NewRecorder(), req)
+
+			if !usecase.called {
+				t.Fatal("Login usecase was not called")
 			}
 		})
 	}

--- a/backend/biz/team/handler/http/v1/user_captcha_test.go
+++ b/backend/biz/team/handler/http/v1/user_captcha_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/GoYoko/web"
 	"github.com/labstack/echo/v4"
 
+	"github.com/chaitin/MonkeyCode/backend/config"
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/errcode"
 	"github.com/chaitin/MonkeyCode/backend/pkg/captcha"
@@ -33,9 +34,10 @@ func TestTeamLoginCaptchaToggle(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			usecase := &teamLoginUsecaseStub{}
 			h := &TeamGroupUserHandler{
+				config:  &config.Config{Security: config.Security{CaptchaEnabled: tt.enabled}},
 				logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
 				usecase: usecase,
-				captcha: captcha.NewCaptcha(tt.enabled),
+				captcha: captcha.NewCaptcha(),
 			}
 
 			err := h.Login(teamTestWebContext(), domain.TeamLoginReq{})
@@ -62,9 +64,10 @@ func TestTeamLoginAcceptsEmptyCaptchaTokenWhenDisabled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			usecase := &teamLoginUsecaseStub{}
 			h := &TeamGroupUserHandler{
+				config:  &config.Config{Security: config.Security{CaptchaEnabled: false}},
 				logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
 				usecase: usecase,
-				captcha: captcha.NewCaptcha(false),
+				captcha: captcha.NewCaptcha(),
 			}
 			w := web.New()
 			w.POST("/login", web.BindHandler(h.Login))

--- a/backend/biz/user/handler/v1/auth.go
+++ b/backend/biz/user/handler/v1/auth.go
@@ -242,7 +242,7 @@ func oauthErrorCode(err error) string {
 //	@Router			/api/v1/users/password-login [post]
 func (h *AuthHandler) PasswordLogin(c *web.Context, req domain.TeamLoginReq) error {
 	ctx := c.Request().Context()
-	if !h.captcha.ValidateToken(ctx, req.CaptchaToken) {
+	if h.config.Security.CaptchaEnabled && !h.captcha.ValidateToken(ctx, req.CaptchaToken) {
 		return errcode.ErrForbidden
 	}
 

--- a/backend/biz/user/handler/v1/auth_captcha_test.go
+++ b/backend/biz/user/handler/v1/auth_captcha_test.go
@@ -1,10 +1,12 @@
 package v1
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -42,6 +44,37 @@ func TestPasswordLoginCaptchaToggle(t *testing.T) {
 			}
 			if usecase.called != tt.called {
 				t.Fatalf("PasswordLogin usecase called = %v, want %v", usecase.called, tt.called)
+			}
+		})
+	}
+}
+
+func TestPasswordLoginAcceptsEmptyCaptchaTokenWhenDisabled(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing", body: `{"email":"user@example.com","password":"password"}`},
+		{name: "empty", body: `{"email":"user@example.com","password":"password","captcha_token":""}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			usecase := &passwordLoginUsecaseStub{}
+			h := &AuthHandler{
+				logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+				usecase: usecase,
+				captcha: captcha.NewCaptcha(false),
+			}
+			w := web.New()
+			w.POST("/login", web.BindHandler(h.PasswordLogin))
+
+			req := httptest.NewRequest(http.MethodPost, "/login", bytes.NewBufferString(tt.body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			w.Echo().ServeHTTP(httptest.NewRecorder(), req)
+
+			if !usecase.called {
+				t.Fatal("PasswordLogin usecase was not called")
 			}
 		})
 	}

--- a/backend/biz/user/handler/v1/auth_captcha_test.go
+++ b/backend/biz/user/handler/v1/auth_captcha_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/GoYoko/web"
 	"github.com/labstack/echo/v4"
 
+	"github.com/chaitin/MonkeyCode/backend/config"
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/errcode"
 	"github.com/chaitin/MonkeyCode/backend/pkg/captcha"
@@ -33,9 +34,10 @@ func TestPasswordLoginCaptchaToggle(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			usecase := &passwordLoginUsecaseStub{}
 			h := &AuthHandler{
+				config:  &config.Config{Security: config.Security{CaptchaEnabled: tt.enabled}},
 				logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
 				usecase: usecase,
-				captcha: captcha.NewCaptcha(tt.enabled),
+				captcha: captcha.NewCaptcha(),
 			}
 
 			err := h.PasswordLogin(testWebContext(), domain.TeamLoginReq{})
@@ -62,9 +64,10 @@ func TestPasswordLoginAcceptsEmptyCaptchaTokenWhenDisabled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			usecase := &passwordLoginUsecaseStub{}
 			h := &AuthHandler{
+				config:  &config.Config{Security: config.Security{CaptchaEnabled: false}},
 				logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
 				usecase: usecase,
-				captcha: captcha.NewCaptcha(false),
+				captcha: captcha.NewCaptcha(),
 			}
 			w := web.New()
 			w.POST("/login", web.BindHandler(h.PasswordLogin))


### PR DESCRIPTION
## 背景

私有化部署关闭 Captcha 后，登录请求会省略 captcha_token 或传入空字符串。登录 handler 仍无条件调用验证码校验，导致请求可能返回 403，无法进入登录业务。

## 改动

- 普通用户密码登录根据 security.captcha_enabled 决定是否校验 captcha_token
- 团队管理员登录使用相同规则
- Captcha 开启时继续严格校验 token
- 增加真实 JSON 绑定和 HTTP 路由测试，覆盖 captcha_token 缺失与空字符串
- 测试使用默认开启的 Captcha 实例，确保关闭配置由登录接口明确处理

## 验证

GOWORK=off go test ./biz/user/handler/v1 ./biz/team/handler/http/v1 ./pkg/captcha -count=1