### PR TITLE
fix(frontend): preserve task dialog draft on dismiss

### DIFF
--- a/frontend/src/components/console/task/create-default-task-dialog.tsx
+++ b/frontend/src/components/console/task/create-default-task-dialog.tsx
@@ -153,7 +153,12 @@ export default function CreateDefaultTaskDialog({
       ? storedParams.imageId
       : selectImage(images, true)
 
-    setSelectedImageId(nextImageId)
+    setSelectedImageId((currentImageId) => {
+      if (currentImageId && images.some((image) => image.id === currentImageId)) {
+        return currentImageId
+      }
+      return nextImageId
+    })
 
     if (user.role === ConstsUserRole.UserRoleSubAccount) {
       const nextHostId = hosts.some((host) => host.id === storedParams.hostId && host.status === ConstsHostStatus.HostStatusOnline)
@@ -162,37 +167,51 @@ export default function CreateDefaultTaskDialog({
           ? (hosts.find((host) => host.id && host.status === ConstsHostStatus.HostStatusOnline)?.id || "")
           : selectHost(hosts, true)
 
-      setSelectedHostId(nextHostId)
+      setSelectedHostId((currentHostId) => {
+        const currentHostIsValid = currentHostId === "public_host"
+          || hosts.some((host) => host.id === currentHostId && host.status === ConstsHostStatus.HostStatusOnline)
+        return currentHostIsValid ? currentHostId : nextHostId
+      })
       return
     }
 
-    setSelectedHostId(selectHost(hosts, false))
+    const nextHostId = selectHost(hosts, false)
+    setSelectedHostId((currentHostId) => {
+      const currentHostIsValid = currentHostId === "public_host"
+        || hosts.some((host) => host.id === currentHostId && host.status === ConstsHostStatus.HostStatusOnline)
+      return currentHostIsValid ? currentHostId : nextHostId
+    })
   }, [hosts, images, user.role])
+
+  const resetDraft = () => {
+    modelTouchedRef.current = false
+    setContent("")
+    setCodeDropdownOpen(false)
+    setSkillPopoverOpen(false)
+    setSearchInput("")
+    setSelectedRepo("")
+    setSelectedRepoDisplayName("")
+    setSelectedRepoFromMyRepos(false)
+    setSelectedZipFile(null)
+    setSelectedSkill(
+      skillList.length > 0
+        ? filterSelectableSkillIds(defaultSkills, skillList)
+        : defaultSkills
+    )
+    setActiveSkillTag(ALL_SKILLS_TAG)
+    setAdvancedOptionsOpen(false)
+    setSelectedModelId("")
+    setSelectedHostId("")
+    setSelectedImageId("")
+    setSelectedIdentityId("")
+    setBranch("")
+  }
 
   useEffect(() => {
     if (!open) {
-
-      modelTouchedRef.current = false
-      setContent("")
       setCodeDropdownOpen(false)
       setSkillPopoverOpen(false)
       setSearchInput("")
-      setSelectedRepo("")
-      setSelectedRepoDisplayName("")
-      setSelectedRepoFromMyRepos(false)
-      setSelectedZipFile(null)
-      setSelectedSkill(
-        skillList.length > 0
-          ? filterSelectableSkillIds(defaultSkills, skillList)
-          : defaultSkills
-      )
-      setActiveSkillTag(ALL_SKILLS_TAG)
-      setAdvancedOptionsOpen(false)
-      setSelectedModelId("")
-      setSelectedHostId("")
-      setSelectedImageId("")
-      setSelectedIdentityId("")
-      setBranch("")
       return
     }
 
@@ -408,6 +427,7 @@ export default function CreateDefaultTaskDialog({
         toast.success(t("taskWorkflow.toast.taskStarted"))
         reloadProjects()
         reloadUnlinkedTasks()
+        resetDraft()
         onOpenChange(false)
         navigate(`/console/task/${resp.data?.id}`)
       } else if (resp.code === 10811) {
@@ -418,6 +438,11 @@ export default function CreateDefaultTaskDialog({
     })
 
     setCreatingTask(false)
+  }
+
+  const handleCancel = () => {
+    resetDraft()
+    onOpenChange(false)
   }
 
   const handleZipFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
@@ -767,7 +792,7 @@ export default function CreateDefaultTaskDialog({
         </div>
 
         <DialogFooter className="shrink-0 border-t pt-4">
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <Button variant="outline" onClick={handleCancel}>
             {t("taskWorkflow.dialog.params.cancel")}
           </Button>
           <Button onClick={handleConfirmExecute} disabled={!content.trim() || creatingTask || contentTooLong}>

--- a/frontend/test/create-default-task-dialog-model-selection.test.mjs
+++ b/frontend/test/create-default-task-dialog-model-selection.test.mjs
@@ -80,11 +80,15 @@ test("模型列表暂不可用或用户尚未完成选择时保持空值", () =>
   }), "")
 })
 
-test("侧边栏启动任务弹窗关闭时重置模型操作状态", () => {
+test("侧边栏启动任务弹窗关闭时保留草稿并关闭临时控件", () => {
   assert.match(
     dialogSource,
-    /if \(!open\) \{[\s\S]*?modelTouchedRef\.current = false[\s\S]*?setSelectedModelId\(""\)/,
+    /if \(!open\) \{[\s\S]*?setCodeDropdownOpen\(false\)[\s\S]*?setSkillPopoverOpen\(false\)[\s\S]*?setSearchInput\(""\)/,
   )
+  assert.doesNotMatch(dialogSource, /if \(!open\) \{[\s\S]*?setContent\(""\)/)
+  assert.match(dialogSource, /const resetDraft = \(\) => \{[\s\S]*?setContent\(""\)/)
+  assert.match(dialogSource, /const handleCancel = \(\) => \{[\s\S]*?resetDraft\(\)[\s\S]*?onOpenChange\(false\)/)
+  assert.match(dialogSource, /resetDraft\(\)[\s\S]*?onOpenChange\(false\)[\s\S]*?navigate\(`\/console\/task/)
 })
 
 test("侧边栏启动任务弹窗提交用户最后选择的模型", () => {


### PR DESCRIPTION
## 变更内容
- 保留创建任务弹窗在遮罩、Escape 和关闭按钮关闭后的草稿
- 点击取消或创建成功后清空草稿
- 保留有效的模型、宿主机和系统镜像选择
- 补充草稿关闭行为回归测试

## 验证
- `tsx --test test/start-develop-task-dialog.test.ts`
- `node --test test/create-default-task-dialog-model-selection.test.mjs`
- `npx eslint src/components/console/task/create-default-task-dialog.tsx test/create-default-task-dialog-model-selection.test.mjs`
- `npm run build`

测试环境： https://11180-44fb865d4a1f81e6.monkeycode-ai.online