### PR TITLE
优化并发触顶后的会员升级转化

### DIFF
--- a/frontend/src/components/console/data-provider.tsx
+++ b/frontend/src/components/console/data-provider.tsx
@@ -4,6 +4,7 @@ import { WechatMpBindDialog } from '@/components/console/wechat-mp-bind-dialog';
 import { getImageShortName } from '@/utils/common';
 import { IS_OFFLINE_EDITION } from '@/utils/edition';
 import { apiRequest } from '@/utils/requestUtils';
+import { identifyMatomoUser, trackPaidSubscriptionObserved } from '@/lib/matomo';
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
@@ -363,7 +364,13 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
     await apiRequest('v1UsersSubscriptionList', {}, [], (resp) => {
       if (resp.code === 0) {
-        setSubscription(resp.data || null)
+        const nextSubscription = resp.data || null
+        const userId = auth.user?.id
+        if (userId && nextSubscription) {
+          identifyMatomoUser(userId)
+          trackPaidSubscriptionObserved(userId, nextSubscription.plan, nextSubscription.expires_at)
+        }
+        setSubscription(nextSubscription)
       } else {
         toast.error(t("consoleDataProvider.toast.fetchSubscriptionFailed", { message: resp.message }))
       }
@@ -375,7 +382,7 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({ children
     if (showLoading) {
       setLoadingSubscription(false)
     }
-  }, [t])
+  }, [auth.user?.id, t])
 
   const fetchMembers = async () => {
     setLoadingMembers(true)

--- a/frontend/src/components/console/nav/subscription-plan-dialog.tsx
+++ b/frontend/src/components/console/nav/subscription-plan-dialog.tsx
@@ -22,6 +22,7 @@ import { Switch } from "@/components/ui/switch"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
+import { trackBasicConcurrencyUpgradeEvent } from "@/lib/matomo"
 import { apiRequest } from "@/utils/requestUtils"
 import { hasProSubscription } from "@/utils/common"
 import { useAppRuntime } from "@/components/app-runtime-provider"
@@ -211,7 +212,10 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
     }
 
     reloadSubscription()
-  }, [open, reloadSubscription])
+    if (!hasAdvancedPlan) {
+      trackBasicConcurrencyUpgradeEvent(user?.id || "", "subscription_plan_dialog_viewed")
+    }
+  }, [hasAdvancedPlan, open, reloadSubscription, user?.id])
 
   useEffect(() => {
     if (!open) {
@@ -259,10 +263,16 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
     }, [], (resp) => {
       const paymentUrl = resp.data?.url
       if (resp.code === 0 && paymentUrl) {
+        if (!hasAdvancedPlan) {
+          trackBasicConcurrencyUpgradeEvent(user?.id || "", "subscription_checkout_created", plan, selectedOrderTotal)
+        }
         setConfirmSubscriptionPlan(null)
         onOpenChange(false)
         window.open(paymentUrl, "_blank", "noopener,noreferrer")
       } else {
+        if (!hasAdvancedPlan) {
+          trackBasicConcurrencyUpgradeEvent(user?.id || "", "subscription_checkout_failed", plan)
+        }
         toast.error(resp.message || t(isRenewingCurrentPlan ? "subscriptionPlan.toast.renewFailed" : "subscriptionPlan.toast.subscribeFailed", { plan: planLabel }))
       }
     })
@@ -327,8 +337,13 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
                           "flex h-full w-full flex-col rounded-md border bg-background p-4 text-left transition-colors hover:border-primary/50 hover:bg-muted/40",
                           isSelected && "border-primary bg-primary/5",
                         )}
-                          onClick={() => setSelectedAccountPlanId(plan.id)}
-                        >
+                        onClick={() => {
+                          setSelectedAccountPlanId(plan.id)
+                          if (!hasAdvancedPlan) {
+                            trackBasicConcurrencyUpgradeEvent(user?.id || "", "subscription_plan_selected", plan.id)
+                          }
+                        }}
+                      >
                         <div className="flex items-center justify-between gap-3">
                           <div className="flex items-center gap-2 font-medium">
                             <IconCrown className={cn("size-4", isSelected ? "text-primary" : "text-muted-foreground")} />

--- a/frontend/src/components/console/nav/subscription-plan-dialog.tsx
+++ b/frontend/src/components/console/nav/subscription-plan-dialog.tsx
@@ -178,6 +178,7 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
   const isProPlan = subscription?.plan === "pro"
   const isFlagshipPlan = subscription?.plan === "flagship" || subscription?.plan === "ultra"
   const hasAdvancedPlan = hasProSubscription(subscription)
+  const isBasicPlan = subscription?.plan === "basic"
   const isTeamUser = !!user?.team?.id
   const triggerPlanLabel = t(`subscriptionPlan.plans.${normalizeAccountPlanId(subscription?.plan)}.name`)
   const isRenewingCurrentPlan = confirmSubscriptionPlan === "pro"
@@ -212,10 +213,10 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
     }
 
     reloadSubscription()
-    if (!hasAdvancedPlan) {
+    if (isBasicPlan) {
       trackBasicConcurrencyUpgradeEvent(user?.id || "", "subscription_plan_dialog_viewed")
     }
-  }, [hasAdvancedPlan, open, reloadSubscription, user?.id])
+  }, [isBasicPlan, open, reloadSubscription, user?.id])
 
   useEffect(() => {
     if (!open) {
@@ -263,14 +264,14 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
     }, [], (resp) => {
       const paymentUrl = resp.data?.url
       if (resp.code === 0 && paymentUrl) {
-        if (!hasAdvancedPlan) {
+        if (isBasicPlan) {
           trackBasicConcurrencyUpgradeEvent(user?.id || "", "subscription_checkout_created", plan, selectedOrderTotal)
         }
         setConfirmSubscriptionPlan(null)
         onOpenChange(false)
         window.open(paymentUrl, "_blank", "noopener,noreferrer")
       } else {
-        if (!hasAdvancedPlan) {
+        if (isBasicPlan) {
           trackBasicConcurrencyUpgradeEvent(user?.id || "", "subscription_checkout_failed", plan)
         }
         toast.error(resp.message || t(isRenewingCurrentPlan ? "subscriptionPlan.toast.renewFailed" : "subscriptionPlan.toast.subscribeFailed", { plan: planLabel }))

--- a/frontend/src/components/console/nav/subscription-plan-dialog.tsx
+++ b/frontend/src/components/console/nav/subscription-plan-dialog.tsx
@@ -22,7 +22,7 @@ import { Switch } from "@/components/ui/switch"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
-import { trackBasicConcurrencyUpgradeEvent } from "@/lib/matomo"
+import { trackBasicConcurrencyUpgradeEvent, trackBasicConcurrencyUpgradeGoal } from "@/lib/matomo"
 import { apiRequest } from "@/utils/requestUtils"
 import { hasProSubscription } from "@/utils/common"
 import { useAppRuntime } from "@/components/app-runtime-provider"
@@ -266,6 +266,7 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
       if (resp.code === 0 && paymentUrl) {
         if (isBasicPlan) {
           trackBasicConcurrencyUpgradeEvent(user?.id || "", "subscription_checkout_created", plan, selectedOrderTotal)
+          trackBasicConcurrencyUpgradeGoal(user?.id || "", selectedOrderTotal)
         }
         setConfirmSubscriptionPlan(null)
         onOpenChange(false)

--- a/frontend/src/components/console/task/task-concurrent-limit-dialog.tsx
+++ b/frontend/src/components/console/task/task-concurrent-limit-dialog.tsx
@@ -5,7 +5,8 @@ import { Spinner } from "@/components/ui/spinner"
 import { useCommonData } from "@/components/console/data-provider"
 import { getTaskDisplayName, hasProSubscription } from "@/utils/common"
 import { apiRequest } from "@/utils/requestUtils"
-import { IconPlayerStopFilled } from "@tabler/icons-react"
+import { startBasicConcurrencyUpgradeJourney, trackBasicConcurrencyUpgradeEvent } from "@/lib/matomo"
+import { IconArrowRight, IconCrown, IconPlayerStopFilled } from "@tabler/icons-react"
 import { useCallback, useState, useEffect } from "react"
 import { toast } from "sonner"
 import { useTranslation } from "react-i18next"
@@ -23,8 +24,9 @@ export function TaskConcurrentLimitDialog({ open, onOpenChange, onStopped }: Tas
   const [tasks, setTasks] = useState<DomainProjectTask[]>([])
   const [loading, setLoading] = useState(false)
   const [stoppingId, setStoppingId] = useState<string | null>(null)
-  const { subscription } = useCommonData()
+  const { subscription, user } = useCommonData()
   const hasAdvancedPlan = hasProSubscription(subscription)
+  const isBasicPlan = subscription?.plan === "basic"
   const planLabel = (() => {
     switch (subscription?.plan) {
       case "flagship":
@@ -58,6 +60,12 @@ export function TaskConcurrentLimitDialog({ open, onOpenChange, onStopped }: Tas
     return () => window.clearTimeout(timer)
   }, [open, loadRunningTasks])
 
+  useEffect(() => {
+    if (open && subscription?.plan === "basic" && user.id) {
+      startBasicConcurrencyUpgradeJourney(user.id)
+    }
+  }, [open, subscription?.plan, user.id])
+
   const handleStop = async (taskId: string) => {
     setStoppingId(taskId)
     await apiRequest("v1UsersTasksStopUpdate", { id: taskId }, [], (resp) => {
@@ -73,10 +81,13 @@ export function TaskConcurrentLimitDialog({ open, onOpenChange, onStopped }: Tas
   }
 
   const handleUpgradePlan = () => {
+    if (!isBasicPlan) return
+
+    trackBasicConcurrencyUpgradeEvent(user.id || "", "concurrency_limit_upgrade_clicked", "basic")
     onOpenChange(false)
     window.setTimeout(() => {
       window.dispatchEvent(new CustomEvent(OPEN_WALLET_DIALOG_EVENT, {
-        detail: { section: "account" },
+        detail: { section: "plan" },
       }))
     }, 0)
   }
@@ -119,15 +130,25 @@ export function TaskConcurrentLimitDialog({ open, onOpenChange, onStopped }: Tas
             ))
           )}
         </div>
-        {!hasAdvancedPlan && (
-          <div className="text-sm">
-            <button
-              type="button"
-              className="text-primary underline-offset-4 hover:underline"
-              onClick={handleUpgradePlan}
-            >
-              {t("taskWorkflow.concurrentLimit.upgrade")}
-            </button>
+        {isBasicPlan && (
+          <div className="mt-2 rounded-lg border border-primary/25 bg-primary/5 p-3">
+            <div className="flex items-start gap-3">
+              <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                <IconCrown className="size-5" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-foreground">
+                  {t("taskWorkflow.concurrentLimit.upgradeTitle")}
+                </p>
+                <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                  {t("taskWorkflow.concurrentLimit.upgradeDescription")}
+                </p>
+              </div>
+            </div>
+            <Button className="mt-3 w-full" onClick={handleUpgradePlan}>
+              {t("taskWorkflow.concurrentLimit.upgradeAction")}
+              <IconArrowRight className="size-4" />
+            </Button>
           </div>
         )}
       </DialogContent>

--- a/frontend/src/components/console/task/task-concurrent-limit-dialog.tsx
+++ b/frontend/src/components/console/task/task-concurrent-limit-dialog.tsx
@@ -5,7 +5,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { useCommonData } from "@/components/console/data-provider"
 import { getTaskDisplayName, hasProSubscription } from "@/utils/common"
 import { apiRequest } from "@/utils/requestUtils"
-import { startBasicConcurrencyUpgradeJourney, trackBasicConcurrencyUpgradeEvent } from "@/lib/matomo"
+import { startBasicConcurrencyUpgradeJourney, trackBasicConcurrencyUpgradeEvent, trackSubscriptionConversion } from "@/lib/matomo"
 import { IconArrowRight, IconCrown, IconPlayerStopFilled } from "@tabler/icons-react"
 import { useCallback, useState, useEffect } from "react"
 import { toast } from "sonner"
@@ -61,10 +61,10 @@ export function TaskConcurrentLimitDialog({ open, onOpenChange, onStopped }: Tas
   }, [open, loadRunningTasks])
 
   useEffect(() => {
-    if (open && subscription?.plan === "basic" && user.id) {
-      startBasicConcurrencyUpgradeJourney(user.id)
+    if (open && isBasicPlan && user.id) {
+      trackSubscriptionConversion("concurrency_limit_viewed", "basic")
     }
-  }, [open, subscription?.plan, user.id])
+  }, [isBasicPlan, open, user.id])
 
   const handleStop = async (taskId: string) => {
     setStoppingId(taskId)
@@ -83,6 +83,7 @@ export function TaskConcurrentLimitDialog({ open, onOpenChange, onStopped }: Tas
   const handleUpgradePlan = () => {
     if (!isBasicPlan) return
 
+    startBasicConcurrencyUpgradeJourney(user.id || "")
     trackBasicConcurrencyUpgradeEvent(user.id || "", "concurrency_limit_upgrade_clicked", "basic")
     onOpenChange(false)
     window.setTimeout(() => {

--- a/frontend/src/i18n/resources/cn.ts
+++ b/frontend/src/i18n/resources/cn.ts
@@ -3959,7 +3959,9 @@ const cn = {
       empty: "暂无运行中的任务",
       unnamedTask: "未命名任务",
       stop: "终止",
-      upgrade: "升级专业会员或旗舰会员，可支持同时运行 3 个任务",
+      upgradeTitle: "解锁更高任务并发",
+      upgradeDescription: "升级专业会员或旗舰会员，最多可同时运行 3 个开发任务。",
+      upgradeAction: "查看会员套餐",
     },
     voice: {
       microphoneDenied: "无法访问麦克风，请检查权限设置",

--- a/frontend/src/i18n/resources/en.ts
+++ b/frontend/src/i18n/resources/en.ts
@@ -3959,7 +3959,9 @@ const en = {
       empty: "No running tasks",
       unnamedTask: "Untitled task",
       stop: "Stop",
-      upgrade: "Upgrade to Pro or Ultra to run up to 3 tasks at the same time",
+      upgradeTitle: "Unlock more concurrent tasks",
+      upgradeDescription: "Upgrade to Pro or Ultra to run up to 3 development tasks at the same time.",
+      upgradeAction: "View membership plans",
     },
     voice: {
       microphoneDenied: "Cannot access the microphone. Please check permissions.",

--- a/frontend/src/lib/matomo.ts
+++ b/frontend/src/lib/matomo.ts
@@ -8,6 +8,13 @@ declare global {
 
 let identifiedUserId: string | null = null;
 let lastObservedUrl = getCurrentUrl();
+const paidSubscriptionFingerprints = new Map<string, string>();
+const basicConcurrencyUpgradeStartedAt = new Map<string, number>();
+const SUBSCRIPTION_CONVERSION_CATEGORY = "subscription_conversion";
+const PAID_SUBSCRIPTION_STORAGE_PREFIX = "matomo_paid_subscription_observed:";
+const BASIC_CONCURRENCY_UPGRADE_STORAGE_PREFIX =
+  "matomo_basic_concurrency_upgrade_started_at:";
+const BASIC_CONCURRENCY_UPGRADE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 function getCurrentUrl() {
   return typeof window === "undefined" ? "" : window.location.href;
@@ -37,6 +44,165 @@ export function identifyMatomoUser(userId: string) {
 
 export function trackMatomoAuthenticated() {
   getMatomoQueue()?.push(["trackEvent", "user", "authenticated"]);
+}
+
+export function trackSubscriptionConversion(
+  action: string,
+  name?: string,
+  value?: number,
+) {
+  const queue = getMatomoQueue();
+  if (!queue || !action) {
+    return false;
+  }
+
+  const command: MatomoCommand = [
+    "trackEvent",
+    SUBSCRIPTION_CONVERSION_CATEGORY,
+    action,
+  ];
+  if (name !== undefined || value !== undefined) {
+    command.push(name ?? "");
+  }
+  if (value !== undefined) {
+    command.push(value);
+  }
+  queue.push(command);
+  return true;
+}
+
+function getBasicConcurrencyUpgradeStorageKey(userId: string) {
+  return `${BASIC_CONCURRENCY_UPGRADE_STORAGE_PREFIX}${userId}`;
+}
+
+function getBasicConcurrencyUpgradeStartedAt(userId: string) {
+  const sessionStartedAt = basicConcurrencyUpgradeStartedAt.get(userId);
+  if (sessionStartedAt !== undefined) {
+    return sessionStartedAt;
+  }
+
+  try {
+    const storedStartedAt = Number(
+      window.localStorage.getItem(getBasicConcurrencyUpgradeStorageKey(userId)),
+    );
+    if (Number.isFinite(storedStartedAt) && storedStartedAt > 0) {
+      basicConcurrencyUpgradeStartedAt.set(userId, storedStartedAt);
+      return storedStartedAt;
+    }
+  } catch {
+    // Session-level attribution still applies when storage is unavailable.
+  }
+
+  return null;
+}
+
+function clearBasicConcurrencyUpgradeJourney(userId: string) {
+  basicConcurrencyUpgradeStartedAt.delete(userId);
+  try {
+    window.localStorage.removeItem(getBasicConcurrencyUpgradeStorageKey(userId));
+  } catch {
+    // The in-memory journey has already been cleared.
+  }
+}
+
+export function hasActiveBasicConcurrencyUpgradeJourney(userId: string) {
+  const normalizedUserId = String(userId).trim();
+  if (!normalizedUserId) {
+    return false;
+  }
+
+  const startedAt = getBasicConcurrencyUpgradeStartedAt(normalizedUserId);
+  if (startedAt === null) {
+    return false;
+  }
+  if (Date.now() - startedAt > BASIC_CONCURRENCY_UPGRADE_WINDOW_MS) {
+    clearBasicConcurrencyUpgradeJourney(normalizedUserId);
+    return false;
+  }
+  return true;
+}
+
+export function startBasicConcurrencyUpgradeJourney(userId: string) {
+  const normalizedUserId = String(userId).trim();
+  if (!normalizedUserId) {
+    return false;
+  }
+
+  const startedAt = Date.now();
+  basicConcurrencyUpgradeStartedAt.set(normalizedUserId, startedAt);
+  try {
+    window.localStorage.setItem(
+      getBasicConcurrencyUpgradeStorageKey(normalizedUserId),
+      String(startedAt),
+    );
+  } catch {
+    // Session-level attribution still applies when storage is unavailable.
+  }
+  return trackSubscriptionConversion("concurrency_limit_viewed", "basic");
+}
+
+export function trackBasicConcurrencyUpgradeEvent(
+  userId: string,
+  action: string,
+  name?: string,
+  value?: number,
+) {
+  if (!hasActiveBasicConcurrencyUpgradeJourney(userId)) {
+    return false;
+  }
+  return trackSubscriptionConversion(action, name, value);
+}
+
+export function trackPaidSubscriptionObserved(
+  userId: string,
+  plan?: string | null,
+  expiresAt?: string | null,
+) {
+  const normalizedUserId = String(userId).trim();
+  const normalizedPlan = String(plan || "").toLowerCase();
+  if (
+    !normalizedUserId ||
+    !["pro", "flagship", "ultra"].includes(normalizedPlan)
+  ) {
+    return false;
+  }
+
+  if (!hasActiveBasicConcurrencyUpgradeJourney(normalizedUserId)) {
+    return false;
+  }
+
+  const fingerprint = `${normalizedPlan}:${expiresAt || ""}`;
+  if (paidSubscriptionFingerprints.get(normalizedUserId) === fingerprint) {
+    return false;
+  }
+
+  const storageKey = `${PAID_SUBSCRIPTION_STORAGE_PREFIX}${normalizedUserId}`;
+  try {
+    if (window.localStorage.getItem(storageKey) === fingerprint) {
+      paidSubscriptionFingerprints.set(normalizedUserId, fingerprint);
+      return false;
+    }
+  } catch {
+    // Session-level deduplication still applies when storage is unavailable.
+  }
+
+  if (
+    !trackSubscriptionConversion(
+      "paid_subscription_observed",
+      normalizedPlan,
+    )
+  ) {
+    return false;
+  }
+
+  paidSubscriptionFingerprints.set(normalizedUserId, fingerprint);
+  try {
+    window.localStorage.setItem(storageKey, fingerprint);
+  } catch {
+    // Tracking remains valid when persistence is unavailable.
+  }
+  clearBasicConcurrencyUpgradeJourney(normalizedUserId);
+  return true;
 }
 
 export function resetMatomoUser() {

--- a/frontend/src/lib/matomo.ts
+++ b/frontend/src/lib/matomo.ts
@@ -138,7 +138,7 @@ export function startBasicConcurrencyUpgradeJourney(userId: string) {
   } catch {
     // Session-level attribution still applies when storage is unavailable.
   }
-  return trackSubscriptionConversion("concurrency_limit_viewed", "basic");
+  return true;
 }
 
 export function trackBasicConcurrencyUpgradeEvent(

--- a/frontend/src/lib/matomo.ts
+++ b/frontend/src/lib/matomo.ts
@@ -11,6 +11,7 @@ let lastObservedUrl = getCurrentUrl();
 const paidSubscriptionFingerprints = new Map<string, string>();
 const basicConcurrencyUpgradeStartedAt = new Map<string, number>();
 const SUBSCRIPTION_CONVERSION_CATEGORY = "subscription_conversion";
+const BASIC_CONCURRENCY_UPGRADE_GOAL_ID = 3;
 const PAID_SUBSCRIPTION_STORAGE_PREFIX = "matomo_paid_subscription_observed:";
 const BASIC_CONCURRENCY_UPGRADE_STORAGE_PREFIX =
   "matomo_basic_concurrency_upgrade_started_at:";
@@ -151,6 +152,23 @@ export function trackBasicConcurrencyUpgradeEvent(
     return false;
   }
   return trackSubscriptionConversion(action, name, value);
+}
+
+export function trackBasicConcurrencyUpgradeGoal(
+  userId: string,
+  revenue: number,
+) {
+  if (!hasActiveBasicConcurrencyUpgradeJourney(userId)) {
+    return false;
+  }
+
+  const queue = getMatomoQueue();
+  if (!queue || !Number.isFinite(revenue) || revenue < 0) {
+    return false;
+  }
+
+  queue.push(["trackGoal", BASIC_CONCURRENCY_UPGRADE_GOAL_ID, revenue]);
+  return true;
 }
 
 export function trackPaidSubscriptionObserved(

--- a/frontend/test/matomo.test.ts
+++ b/frontend/test/matomo.test.ts
@@ -31,6 +31,7 @@ test("Matomo 在识别用户后记录 Console 页面且避免重复 PV", async (
     startBasicConcurrencyUpgradeJourney,
     trackMatomoAuthenticated,
     trackBasicConcurrencyUpgradeEvent,
+    trackBasicConcurrencyUpgradeGoal,
     trackPaidSubscriptionObserved,
     trackSubscriptionConversion,
   } = await import("../src/lib/matomo.ts");
@@ -108,6 +109,11 @@ test("Matomo 在识别用户后记录 Console 页面且避免重复 PV", async (
     "pro",
     99,
   ]);
+
+  assert.equal(trackBasicConcurrencyUpgradeGoal("user-1", 99), true);
+  assert.deepEqual(queue.at(-1), ["trackGoal", 3, 99]);
+  assert.equal(trackBasicConcurrencyUpgradeGoal("paid-user", 99), false);
+  assert.equal(trackBasicConcurrencyUpgradeGoal("user-1", Number.NaN), false);
 
   assert.equal(trackPaidSubscriptionObserved("user-1", "basic"), false);
   assert.equal(

--- a/frontend/test/matomo.test.ts
+++ b/frontend/test/matomo.test.ts
@@ -4,12 +4,18 @@ import test from "node:test";
 test("Matomo 在识别用户后记录 Console 页面且避免重复 PV", async () => {
   const queue: unknown[][] = [];
   const location = new URL("https://monkeycode-ai.com/login");
+  const storage = new Map<string, string>();
 
   Object.defineProperty(globalThis, "window", {
     configurable: true,
     value: {
       _paq: queue,
       location,
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+      },
     },
   });
   Object.defineProperty(globalThis, "document", {
@@ -19,9 +25,14 @@ test("Matomo 在识别用户后记录 Console 页面且避免重复 PV", async (
 
   const {
     identifyMatomoUser,
+    hasActiveBasicConcurrencyUpgradeJourney,
     observeMatomoRoute,
     resetMatomoUser,
+    startBasicConcurrencyUpgradeJourney,
     trackMatomoAuthenticated,
+    trackBasicConcurrencyUpgradeEvent,
+    trackPaidSubscriptionObserved,
+    trackSubscriptionConversion,
   } = await import("../src/lib/matomo.ts");
 
   assert.equal(identifyMatomoUser("user-1"), true);
@@ -46,4 +57,81 @@ test("Matomo 在识别用户后记录 Console 页面且避免重复 PV", async (
     ["trackEvent", "user", "logout_success"],
     ["resetUserId"],
   ]);
+
+  assert.equal(startBasicConcurrencyUpgradeJourney("user-1"), true);
+  assert.deepEqual(queue.at(-1), [
+    "trackEvent",
+    "subscription_conversion",
+    "concurrency_limit_viewed",
+    "basic",
+  ]);
+
+  assert.equal(hasActiveBasicConcurrencyUpgradeJourney("user-1"), true);
+  assert.equal(
+    trackBasicConcurrencyUpgradeEvent(
+      "user-1",
+      "subscription_plan_selected",
+      "pro",
+    ),
+    true,
+  );
+  assert.equal(
+    trackBasicConcurrencyUpgradeEvent(
+      "paid-user",
+      "subscription_plan_selected",
+      "ultra",
+    ),
+    false,
+  );
+
+  assert.equal(
+    trackSubscriptionConversion("subscription_checkout_created", "pro", 99),
+    true,
+  );
+  assert.deepEqual(queue.at(-1), [
+    "trackEvent",
+    "subscription_conversion",
+    "subscription_checkout_created",
+    "pro",
+    99,
+  ]);
+
+  assert.equal(trackPaidSubscriptionObserved("user-1", "basic"), false);
+  assert.equal(
+    trackPaidSubscriptionObserved("user-1", "pro", "2026-09-11T00:00:00Z"),
+    true,
+  );
+  assert.deepEqual(queue.at(-1), [
+    "trackEvent",
+    "subscription_conversion",
+    "paid_subscription_observed",
+    "pro",
+  ]);
+  assert.equal(
+    trackPaidSubscriptionObserved("user-1", "pro", "2026-09-11T00:00:00Z"),
+    false,
+  );
+  assert.equal(
+    trackPaidSubscriptionObserved("user-1", "ultra", "2026-10-11T00:00:00Z"),
+    false,
+  );
+  assert.equal(hasActiveBasicConcurrencyUpgradeJourney("user-1"), false);
+  assert.equal(
+    trackPaidSubscriptionObserved("paid-user", "pro", "2026-10-11T00:00:00Z"),
+    false,
+  );
+  assert.equal(
+    trackPaidSubscriptionObserved(
+      "flagship-user",
+      "ultra",
+      "2026-10-11T00:00:00Z",
+    ),
+    false,
+  );
+
+  const staleJourneyKey =
+    "matomo_basic_concurrency_upgrade_started_at:stale-user";
+  storage.set(staleJourneyKey, String(Date.now() - 7 * 24 * 60 * 60 * 1000 - 1));
+  assert.equal(hasActiveBasicConcurrencyUpgradeJourney("stale-user"), false);
+  assert.equal(storage.has(staleJourneyKey), false);
 });

--- a/frontend/test/matomo.test.ts
+++ b/frontend/test/matomo.test.ts
@@ -58,7 +58,20 @@ test("Matomo 在识别用户后记录 Console 页面且避免重复 PV", async (
     ["resetUserId"],
   ]);
 
+  assert.equal(
+    trackSubscriptionConversion("concurrency_limit_viewed", "basic"),
+    true,
+  );
+  assert.deepEqual(queue.at(-1), [
+    "trackEvent",
+    "subscription_conversion",
+    "concurrency_limit_viewed",
+    "basic",
+  ]);
+
+  const queueLengthBeforeJourneyStart = queue.length;
   assert.equal(startBasicConcurrencyUpgradeJourney("user-1"), true);
+  assert.equal(queue.length, queueLengthBeforeJourneyStart);
   assert.deepEqual(queue.at(-1), [
     "trackEvent",
     "subscription_conversion",

--- a/frontend/test/subscription-conversion-tracking.test.ts
+++ b/frontend/test/subscription-conversion-tracking.test.ts
@@ -26,6 +26,7 @@ test("会员转化漏斗覆盖并发弹窗、套餐下单和订阅生效", () =>
   assert.match(subscriptionPlanDialog, /"subscription_plan_dialog_viewed"/);
   assert.match(subscriptionPlanDialog, /"subscription_plan_selected"/);
   assert.match(subscriptionPlanDialog, /"subscription_checkout_created"/);
+  assert.match(subscriptionPlanDialog, /trackBasicConcurrencyUpgradeGoal\(user\?\.id \|\| "", selectedOrderTotal\)/);
   assert.match(subscriptionPlanDialog, /"subscription_checkout_failed"/);
   assert.match(subscriptionPlanDialog, /const isBasicPlan = subscription\?\.plan === "basic"/);
   assert.match(dataProvider, /trackPaidSubscriptionObserved/);

--- a/frontend/test/subscription-conversion-tracking.test.ts
+++ b/frontend/test/subscription-conversion-tracking.test.ts
@@ -16,7 +16,9 @@ test("会员转化漏斗覆盖并发弹窗、套餐下单和订阅生效", () =>
   const dataProvider = readSource("../src/components/console/data-provider.tsx");
 
   assert.match(concurrentLimitDialog, /startBasicConcurrencyUpgradeJourney/);
+  assert.match(concurrentLimitDialog, /trackSubscriptionConversion\("concurrency_limit_viewed", "basic"\)/);
   assert.match(concurrentLimitDialog, /"concurrency_limit_upgrade_clicked"/);
+  assert.match(concurrentLimitDialog, /startBasicConcurrencyUpgradeJourney\(user\.id \|\| ""\)/);
   assert.match(concurrentLimitDialog, /const isBasicPlan = subscription\?\.plan === "basic"/);
   assert.match(concurrentLimitDialog, /\{isBasicPlan && \(/);
   assert.match(concurrentLimitDialog, /detail: \{ section: "plan" \}/);
@@ -25,6 +27,7 @@ test("会员转化漏斗覆盖并发弹窗、套餐下单和订阅生效", () =>
   assert.match(subscriptionPlanDialog, /"subscription_plan_selected"/);
   assert.match(subscriptionPlanDialog, /"subscription_checkout_created"/);
   assert.match(subscriptionPlanDialog, /"subscription_checkout_failed"/);
+  assert.match(subscriptionPlanDialog, /const isBasicPlan = subscription\?\.plan === "basic"/);
   assert.match(dataProvider, /trackPaidSubscriptionObserved/);
   assert.doesNotMatch(subscriptionPlanDialog, /trackSubscriptionConversion/);
 });

--- a/frontend/test/subscription-conversion-tracking.test.ts
+++ b/frontend/test/subscription-conversion-tracking.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function readSource(path: string) {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+test("会员转化漏斗覆盖并发弹窗、套餐下单和订阅生效", () => {
+  const concurrentLimitDialog = readSource(
+    "../src/components/console/task/task-concurrent-limit-dialog.tsx",
+  );
+  const subscriptionPlanDialog = readSource(
+    "../src/components/console/nav/subscription-plan-dialog.tsx",
+  );
+  const dataProvider = readSource("../src/components/console/data-provider.tsx");
+
+  assert.match(concurrentLimitDialog, /startBasicConcurrencyUpgradeJourney/);
+  assert.match(concurrentLimitDialog, /"concurrency_limit_upgrade_clicked"/);
+  assert.match(concurrentLimitDialog, /const isBasicPlan = subscription\?\.plan === "basic"/);
+  assert.match(concurrentLimitDialog, /\{isBasicPlan && \(/);
+  assert.match(concurrentLimitDialog, /detail: \{ section: "plan" \}/);
+  assert.doesNotMatch(concurrentLimitDialog, /!hasAdvancedPlan && \(/);
+  assert.match(subscriptionPlanDialog, /"subscription_plan_dialog_viewed"/);
+  assert.match(subscriptionPlanDialog, /"subscription_plan_selected"/);
+  assert.match(subscriptionPlanDialog, /"subscription_checkout_created"/);
+  assert.match(subscriptionPlanDialog, /"subscription_checkout_failed"/);
+  assert.match(dataProvider, /trackPaidSubscriptionObserved/);
+  assert.doesNotMatch(subscriptionPlanDialog, /trackSubscriptionConversion/);
+});


### PR DESCRIPTION
## 变更说明

- 仅向基础版用户展示并发升级权益卡，并支持直接进入套餐选择
- 将并发触顶弹窗曝光与转化归因分开统计
- 用户点击升级操作后开始 7 天归因
- 将成功创建支付订单作为前端核心转化指标
- 将付费订阅生效作为辅助观测指标，并进行去重
- 补充中英文升级文案和专项转化追踪测试

## Matomo 转化漏斗

- `concurrency_limit_viewed`：并发触顶弹窗曝光
- `concurrency_limit_upgrade_clicked`：用户表达升级意向，并开始 7 天归因
- `subscription_plan_dialog_viewed`：到达套餐选择页
- `subscription_plan_selected`：选择目标套餐
- `subscription_checkout_created`：核心转化；订单接口成功返回支付地址后上报
- `subscription_checkout_failed`：创建支付订单失败
- `paid_subscription_observed`：辅助观测订阅生效

## 验证结果

- `pnpm lint`：通过
- `/usr/local/bin/tsx --test test/matomo.test.ts test/subscription-conversion-tracking.test.ts`：2/2 通过
- `pnpm build`：通过，共转换 12,488 个模块
- `git diff --check`：通过