### PR TITLE
feat(frontend): update website content

### DIFF
--- a/frontend/src/components/welcome/terminal-chrome.tsx
+++ b/frontend/src/components/welcome/terminal-chrome.tsx
@@ -105,7 +105,8 @@ export function TerminalHeader({ homeAnchors = true }: { homeAnchors?: boolean }
 
   const pageNav = [
     { labelKey: "welcomeShell.nav.showcase", href: SHOWCASE_LINK[i18n.language], external: true },
-    { labelKey: "welcomeShell.nav.client", href: `${navPrefix}#desktop-client` },
+    { labelKey: "welcomeShell.nav.desktopClient", href: `${navPrefix}#desktop-client` },
+    { labelKey: "welcomeShell.nav.mobileClient", href: `${navPrefix}#mobile-client` },
     { labelKey: "welcomeShell.nav.selfHosting", href: SELF_HOSTING_PAGE_PATH },
   ];
 

--- a/frontend/src/components/welcome/terminal-native-page.tsx
+++ b/frontend/src/components/welcome/terminal-native-page.tsx
@@ -56,7 +56,7 @@ const featureItems = [
   },
   {
     key: "04",
-    cmd: "--mobile --cross-device",
+    cmd: "--work --cross-device",
     i18nKey: "mobile",
   },
   {
@@ -85,7 +85,7 @@ const useCaseItems = [
     key: "security",
   },
   {
-    tag: "paper",
+    tag: "office",
     key: "paper",
   },
   {
@@ -93,7 +93,7 @@ const useCaseItems = [
     key: "data",
   },
   {
-    tag: "research",
+    tag: "automation",
     key: "research",
   },
 ] as const;
@@ -135,6 +135,7 @@ const desktopClientItems = [
 ] as const;
 
 const selfHostingAdvantageKeys = ["dataBoundary", "governance", "integration", "offline"] as const;
+const monkeyCodeWorkAdvantageKeys = ["localFiles", "cloudTasks", "modelsAndTools", "browser"] as const;
 
 const compareColumns = ["MonkeyCode", "Cursor", "Claude Code", "Codex"] as const;
 
@@ -384,6 +385,7 @@ export default function TerminalNativePage() {
   const [openFaq, setOpenFaq] = React.useState(0);
   const [billingPeriod, setBillingPeriod] = React.useState<BillingPeriod>("monthly");
   const selfHostingAdvantages = selfHostingAdvantageKeys.map((key) => t(`terminalNative.selfHosting.advantages.${key}`));
+  const monkeyCodeWorkAdvantages = monkeyCodeWorkAdvantageKeys.map((key) => t(`terminalNative.monkeyCodeWork.advantages.${key}`));
   const testimonialItems = testimonialKeys.map((key) => ({
     key,
     quote: String(t(`terminalNative.testimonials.items.${key}.quote`)),
@@ -568,6 +570,29 @@ export default function TerminalNativePage() {
                 </a>
               </div>
             ))}
+          </div>
+          <div className="mt-6">
+            <div className="grid gap-4 lg:grid-cols-[0.9fr_1.1fr]">
+              <div className="rounded-md border border-[var(--a-line)] bg-[var(--a-panel)] p-6">
+                <div className="text-[10px] tracking-[0.12em] text-[var(--a-accent)]">$ monkey work --local</div>
+                <h4 className="mt-3 text-2xl font-semibold tracking-[-0.02em] text-[var(--a-fg)]">
+                  {t("terminalNative.monkeyCodeWork.cardTitle")}
+                </h4>
+                <p className="mt-4 text-sm leading-7 text-[var(--a-fg-dim)]">
+                  {t("terminalNative.monkeyCodeWork.cardBody")}
+                </p>
+              </div>
+              <div className="grid gap-px overflow-hidden rounded-md border border-[var(--a-line)] bg-[var(--a-line)]">
+                {monkeyCodeWorkAdvantages.map((item, index) => (
+                  <div key={item} className="flex gap-4 bg-[var(--a-panel)] p-5">
+                    <span className="mt-1 text-[11px] tracking-[0.12em] text-[var(--a-accent)]">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <p className="text-sm leading-7 text-[var(--a-fg-dim)]">{item}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
         </SectionShell>
 

--- a/frontend/src/i18n/resources/cn.ts
+++ b/frontend/src/i18n/resources/cn.ts
@@ -1903,7 +1903,8 @@ const cn = {
       openSource: "开源",
       openSourceRepo: "开源仓库",
       showcase: "作品集",
-      client: "客户端",
+      desktopClient: "桌面客户端",
+      mobileClient: "移动客户端",
       selfHosting: "私有化",
       toggleMenu: "切换导航菜单",
     },
@@ -2111,8 +2112,8 @@ const cn = {
         body: "GLM、Kimi、MiniMax、Qwen、DeepSeek 等都已接入，按任务类型切换，也能手动指定。",
       },
       mobile: {
-        title: "移动端原生支持",
-        body: "深度适配 iOS / Android，PC 和手机数据实时同步。通勤路上也能把任务交给 Agent 继续跑。",
+        title: "桌面办公与移动端协同",
+        body: "MonkeyWork 可在桌面端处理本地文件、连接浏览器并完成办公任务；移动端可随时查看进度、继续对话，让任务在不同设备间持续推进。",
       },
       openSource: {
         title: "完全开源",
@@ -2144,9 +2145,9 @@ const cn = {
         stack: ["OWASP Top 10", "依赖 CVE", "SAST 规则"],
       },
       paper: {
-        title: "写毕业论文",
-        body: "帮你查文献、列提纲、补实验代码、跑数据、画图、排版 LaTeX，从选题到定稿都能接力。",
-        stack: ["文献检索", "实验脚本", "LaTeX 排版"],
+        title: "整理文档",
+        body: "读取本地 Word、PDF、Markdown 等资料，自动总结、改写、翻译并整理内容，快速生成报告、方案和会议纪要。",
+        stack: ["文档总结", "内容改写", "报告生成"],
       },
       data: {
         title: "数据分析",
@@ -2154,9 +2155,9 @@ const cn = {
         stack: ["Pandas / Polars", "Matplotlib", "自动写结论"],
       },
       research: {
-        title: "产品 / 技术调研",
-        body: "AI 拉公开资料、跑 benchmark、出对比报告，带引用链接，适合做技术选型和产品预研。",
-        stack: ["公开资料聚合", "横向对比", "带引用"],
+        title: "处理网页任务",
+        body: "连接浏览器后，协助读取网页、收集资料、填写信息、点击操作和截图，减少重复的桌面办公流程。",
+        stack: ["资料收集", "网页操作", "办公自动化"],
       },
     },
     mobile: {
@@ -2197,6 +2198,16 @@ const cn = {
         governance: "统一管理团队成员、开发环境、AI 模型和任务流程，便于研发负责人做治理和审计。",
         integration: "支持对接企业已有的大模型、Git 平台和开发环境宿主机，适配内部研发基础设施。",
         offline: "可按在线或离线方式安装，适合有网络隔离、合规要求或本地算力资源的团队。",
+      },
+    },
+    monkeyCodeWork: {
+      cardTitle: "让 AI 直接参与你的桌面工作",
+      cardBody: "MonkeyWork 同时面向开发和日常办公。选择一个工作目录并描述目标，AI 就能在授权范围内处理本地文件；需要跨设备继续时，也可以接续 MonkeyCode 云端任务。",
+      advantages: {
+        localFiles: "授权本地工作目录后，可读取、创建和修改其中的代码、文档与素材，无需提前上传文件。",
+        cloudTasks: "绑定 MonkeyCode 账号后，可在桌面端查看并继续网页端和移动端的云端任务。",
+        modelsAndTools: "支持使用 MonkeyCode 账号模型、百智云模型资源、自定义模型以及 MCP 服务。",
+        browser: "配对浏览器扩展后，可读取网页内容，并协助打开页面、点击、输入信息和截图。",
       },
     },
     compare: {

--- a/frontend/src/i18n/resources/en.ts
+++ b/frontend/src/i18n/resources/en.ts
@@ -1903,7 +1903,8 @@ const en = {
       openSource: "Open Source",
       openSourceRepo: "Open Source Repo",
       showcase: "Gallery",
-      client: "Clients",
+      desktopClient: "Desktop client",
+      mobileClient: "Mobile client",
       selfHosting: "Self-hosting",
       toggleMenu: "Toggle navigation menu",
     },
@@ -2111,8 +2112,8 @@ const en = {
         body: "GLM, Kimi, MiniMax, Qwen, DeepSeek, and other major models are connected. Switch by task type or choose one manually.",
       },
       mobile: {
-        title: "Native mobile support",
-        body: "Deep support for iOS and Android, with real-time sync between desktop and mobile. Let the agent keep running tasks even while you are commuting.",
+        title: "Desktop and mobile collaboration",
+        body: "MonkeyWork handles local files, browser actions, and office tasks on desktop, while mobile lets you check progress and continue conversations so work keeps moving across devices.",
       },
       openSource: {
         title: "Fully open source",
@@ -2197,6 +2198,16 @@ const en = {
         governance: "Centrally manage team members, development environments, AI models, and task workflows for governance and auditability.",
         integration: "Connect existing enterprise models, Git platforms, and environment hosts to fit internal engineering infrastructure.",
         offline: "Install online or offline for teams with network isolation, compliance requirements, or local compute resources.",
+      },
+    },
+    monkeyCodeWork: {
+      cardTitle: "Put AI directly into your desktop workflow",
+      cardBody: "MonkeyWork supports both development and everyday office tasks. Select a working folder and describe the goal to let AI handle authorized local files, or continue MonkeyCode cloud tasks across devices.",
+      advantages: {
+        localFiles: "Authorize a local working folder so AI can read, create, and modify code, documents, and assets without uploading them first.",
+        cloudTasks: "Connect your MonkeyCode account to view and continue cloud tasks from the web and mobile apps on desktop.",
+        modelsAndTools: "Use MonkeyCode account models, Baizhi Cloud model resources, custom models, and MCP services.",
+        browser: "Pair the browser extension to read page content and assist with opening pages, clicking, entering information, and taking screenshots.",
       },
     },
     compare: {


### PR DESCRIPTION
更新 MonkeyCode 官网首页文案与导航，聚焦桌面客户端、移动客户端和 MonkeyWork 介绍，并同步中英文内容。\n\n验证：\n- frontend 类型检查通过：./node_modules/.bin/tsc -b\n- 改动范围仅限 frontend/src 下 4 个文件\n\n预览：\n- 中文：https://11180-e74df98c96a8f5a9.monkeycode-ai.online\n- 英文：https://11181-e74df98c96a8f5a9.monkeycode-ai.online