### PR TITLE
fix(frontend): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ You can also get support through:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=chaitin/MonkeyCode&type=Date)](https://star-history.com/#chaitin/MonkeyCode&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=chaitin/MonkeyCode&type=Date)](https://star-history.dera.page/#chaitin/MonkeyCode&type=Date)
 
 ## License
 

--- a/readme.cn.md
+++ b/readme.cn.md
@@ -125,7 +125,7 @@ bash -c "$(curl -fsSL 'https://monkeycode-ai.com/online/install')"
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=chaitin/MonkeyCode&type=Date)](https://star-history.com/#chaitin/MonkeyCode&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=chaitin/MonkeyCode&type=Date)](https://star-history.dera.page/#chaitin/MonkeyCode&type=Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is broken and shows no data, so the project's popularity history is no longer visible. This change updates the chart link in the English and Chinese README so it renders correctly again.