### PR TITLE
feat: 支持 Stripe 订阅升级

### DIFF
--- a/frontend/src/api/Api.ts
+++ b/frontend/src/api/Api.ts
@@ -1375,9 +1375,15 @@ export interface DomainSubscribeReq {
 
 export interface DomainSubscriptionResp {
   auto_renew?: boolean;
+  billing_interval?: string;
+  billing_status?: string;
+  cancel_at_period_end?: boolean;
+  current_period_end?: string;
   /** 免费 Tokens 耗尽后是否继续启用积分消费模型，未配置时默认 true */
   enable_credit_consumption?: boolean;
   expires_at?: string;
+  grace_until?: string;
+  payment_provider?: string;
   /** "basic" | "pro" | "ultra" */
   plan?: string;
   /** "purchase" | "team_member" | "admin_grant" | "invitation" */

--- a/frontend/src/components/console/nav/nav-balance.tsx
+++ b/frontend/src/components/console/nav/nav-balance.tsx
@@ -58,6 +58,23 @@ function normalizeSubscriptionPlan(plan?: string | null): SubscriptionPlanKey {
   return "basic"
 }
 
+function formatBillingDateTime(value: string | undefined, language: string) {
+  if (!value) {
+    return null
+  }
+
+  const parsed = dayjs(value)
+  if (!parsed.isValid()) {
+    return value
+  }
+
+  const locale = language === "cn" || language.startsWith("zh") ? "zh-CN" : "en-US"
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(parsed.toDate())
+}
+
 export default function NavBalance({
   variant = "sidebar",
   hideTrigger = false,
@@ -66,7 +83,7 @@ export default function NavBalance({
   onOpenChange,
   initialSection = "account",
 }: NavBalanceProps) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const [dialogOpenInternal, setDialogOpenInternal] = useState(false);
   const [showSubscriptionPlanDialog, setShowSubscriptionPlanDialog] = useState(false);
   const [showLogoutDialog, setShowLogoutDialog] = useState(false);
@@ -114,6 +131,12 @@ export default function NavBalance({
   const triggerPlanLabel = t(`consoleShell.rewards.plans.${normalizedSubscriptionPlan}`)
   const canRenewSubscription = normalizedSubscriptionPlan === "pro" || normalizedSubscriptionPlan === "ultra"
   const subscriptionExpiry = formatSubscriptionExpiry(subscription?.expires_at)
+  const nextChargeTime = subscription?.payment_provider === "stripe"
+    && subscription.billing_status === "active"
+    && subscription.auto_renew
+    && !subscription.cancel_at_period_end
+    ? formatBillingDateTime(subscription.current_period_end, i18n.resolvedLanguage || i18n.language)
+    : null
 
   const handleLogout = () => {
     apiRequest("v1UsersLogoutCreate", {}, [], (resp) => {
@@ -411,19 +434,24 @@ export default function NavBalance({
       <section className="divide-y divide-border/60 border-y border-border/60">
         {!IS_OFFLINE_EDITION && (
           <>
-            <div className="flex min-h-12 items-center justify-between gap-4 py-2">
-              <div className="min-w-0">
+            <div className="flex min-h-12 flex-col gap-3 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+              <div className="min-w-0 flex-1">
                 <div className="text-xs text-muted-foreground">{t("navBalance.plan.currentPlan")}</div>
-                <div className="mt-1 truncate text-sm font-medium">
-                  {triggerPlanLabel}
-                  <span className="ml-2 text-xs font-normal text-muted-foreground">
+                <div className="mt-1 flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                  <span className="text-sm font-medium">{triggerPlanLabel}</span>
+                  <span className="whitespace-nowrap text-xs font-normal text-muted-foreground">
                     {subscriptionExpiry
                       ? t("navBalance.plan.validUntil", { date: subscriptionExpiry })
                       : t("navBalance.plan.lifetime")}
                   </span>
                 </div>
+                {nextChargeTime ? (
+                  <div className="mt-1 text-xs leading-5 text-muted-foreground">
+                    {t("navBalance.plan.nextCharge", { date: nextChargeTime })}
+                  </div>
+                ) : null}
               </div>
-              <div className="flex shrink-0 items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2 sm:shrink-0 sm:justify-end">
                 <Button
                   variant="outline"
                   size="sm"

--- a/frontend/src/components/console/nav/subscription-plan-dialog.tsx
+++ b/frontend/src/components/console/nav/subscription-plan-dialog.tsx
@@ -74,6 +74,33 @@ function normalizeAccountPlanId(plan?: string | null): PersonalAccountPlanId {
   return "basic"
 }
 
+function planRank(plan: PersonalAccountPlanId) {
+  if (plan === "ultra") {
+    return 2
+  }
+  if (plan === "pro") {
+    return 1
+  }
+  return 0
+}
+
+function billingPeriodRank(period: SubscriptionBillingPeriod) {
+  return period === "yearly" ? 2 : 1
+}
+
+function isStripeUpgradeTransition(
+  currentPlan: PersonalAccountPlanId,
+  currentPeriod: SubscriptionBillingPeriod,
+  targetPlan: PersonalAccountPlanId,
+  targetPeriod: SubscriptionBillingPeriod,
+) {
+  if (currentPlan === targetPlan && currentPeriod === targetPeriod) {
+    return false
+  }
+  return planRank(targetPlan) >= planRank(currentPlan)
+    && billingPeriodRank(targetPeriod) >= billingPeriodRank(currentPeriod)
+}
+
 export default function SubscriptionPlanDialog({ open, onOpenChange }: SubscriptionPlanDialogProps) {
   const { t } = useTranslation()
   const { serverConfig } = useAppRuntime()
@@ -180,12 +207,10 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
   const hasAdvancedPlan = hasProSubscription(subscription)
   const isBasicPlan = subscription?.plan === "basic"
   const isTeamUser = !!user?.team?.id
-  const triggerPlanLabel = t(`subscriptionPlan.plans.${normalizeAccountPlanId(subscription?.plan)}.name`)
-  const isRenewingCurrentPlan = confirmSubscriptionPlan === "pro"
-    ? isProPlan
-    : confirmSubscriptionPlan === "ultra"
-      ? isFlagshipPlan
-      : false
+  const currentAccountPlanId = normalizeAccountPlanId(subscription?.plan)
+  const currentBillingPeriod: SubscriptionBillingPeriod = subscription?.billing_interval === "year" ? "yearly" : "monthly"
+  const isStripeSubscription = subscription?.payment_provider === "stripe" && hasAdvancedPlan
+  const triggerPlanLabel = t(`subscriptionPlan.plans.${currentAccountPlanId}.name`)
   const confirmingPlanCard = accountPlanCards.find((plan) => plan.id === confirmSubscriptionPlan)
   const selectedAccountPlan = accountPlanCards.find((plan) => plan.id === selectedAccountPlanId) || accountPlanCards[0]
   const selectedAccountPlanFeatures = accountPlanComparisonRows.map((row) => ({
@@ -196,12 +221,32 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
   const selectedSubscriptionPlan = selectedAccountPlan.id === "basic" ? null : selectedAccountPlan.id
   const isSelectedCurrentPlan = selectedAccountPlan.id === "basic" ? !hasAdvancedPlan : selectedAccountPlan.id === "pro" ? isProPlan : selectedAccountPlan.id === "ultra" ? isFlagshipPlan : false
   const isSelectedPlanLoading = selectedAccountPlan.id === "pro" ? isProLoading : selectedAccountPlan.id === "ultra" ? isFlagshipLoading : false
-  const canSubscribeSelectedPlan = selectedSubscriptionPlan === "pro" ? !isFlagshipPlan : selectedSubscriptionPlan === "ultra"
+  const isSelectedStripeUpgrade = isStripeSubscription
+    && selectedSubscriptionPlan !== null
+    && isStripeUpgradeTransition(currentAccountPlanId, currentBillingPeriod, selectedSubscriptionPlan, selectedBillingPeriod)
+  const isConfirmingStripeUpgrade = isStripeSubscription
+    && confirmSubscriptionPlan !== null
+    && isStripeUpgradeTransition(currentAccountPlanId, currentBillingPeriod, confirmSubscriptionPlan, selectedBillingPeriod)
+  const isRenewingCurrentPlan = !isConfirmingStripeUpgrade && (confirmSubscriptionPlan === "pro"
+    ? isProPlan
+    : confirmSubscriptionPlan === "ultra"
+      ? isFlagshipPlan
+      : false)
+  const canSubscribeSelectedPlan = !isTeamUser && selectedSubscriptionPlan !== null && (isStripeSubscription
+    ? isSelectedStripeUpgrade
+    : selectedSubscriptionPlan === "pro"
+      ? !isFlagshipPlan
+      : selectedSubscriptionPlan === "ultra")
   const selectedPeriodAmount = selectedBillingPeriod === "monthly" ? selectedAccountPlan.monthlyAmount : selectedAccountPlan.yearlyAmount
   const selectedOrderTotal = selectedPeriodAmount * selectedPeriodCount
   const selectedOrderTotalLabel = formatRegionCurrency(selectedOrderTotal, pricingRegion)
+  const selectedPriceLabel = isSelectedStripeUpgrade ? t("subscriptionPlan.billing.proratedDifference") : selectedOrderTotalLabel
   const selectedPeriodUnit = selectedBillingPeriod === "monthly" ? ConstsSubscriptionPeriodUnit.PeriodMonth : ConstsSubscriptionPeriodUnit.PeriodYear
-  const subscriptionPeriodCounts = selectedBillingPeriod === "monthly" ? monthlyPeriodCounts : yearlyPeriodCounts
+  const subscriptionPeriodCounts = pricingRegion === "global"
+    ? [1]
+    : selectedBillingPeriod === "monthly"
+      ? monthlyPeriodCounts
+      : yearlyPeriodCounts
   const selectedPeriodCountLabel = selectedBillingPeriod === "monthly"
     ? t("subscriptionPlan.billing.monthCount", { count: selectedPeriodCount })
     : t("subscriptionPlan.billing.yearCount", { count: selectedPeriodCount })
@@ -227,13 +272,17 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
     queueMicrotask(() => {
       if (active) {
         setSelectedAccountPlanId(isFlagshipPlan ? "ultra" : isProPlan ? "pro" : "basic")
+        if (isStripeSubscription) {
+          setSelectedBillingPeriod(currentBillingPeriod)
+          setSelectedPeriodCount(1)
+        }
       }
     })
 
     return () => {
       active = false
     }
-  }, [isFlagshipPlan, isProPlan, open])
+  }, [currentBillingPeriod, isFlagshipPlan, isProPlan, isStripeSubscription, open])
 
   const handleToggleAutoRenew = async (checked: boolean) => {
     if (!hasAdvancedPlan) {
@@ -263,19 +312,29 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
       period_count: selectedPeriodCount,
     }, [], (resp) => {
       const paymentUrl = resp.data?.url
-      if (resp.code === 0 && paymentUrl) {
-        if (isBasicPlan) {
+      if (resp.code === 0) {
+        if (isBasicPlan && paymentUrl) {
           trackBasicConcurrencyUpgradeEvent(user?.id || "", "subscription_checkout_created", plan, selectedOrderTotal)
           trackBasicConcurrencyUpgradeGoal(user?.id || "", selectedOrderTotal)
         }
         setConfirmSubscriptionPlan(null)
         onOpenChange(false)
-        window.open(paymentUrl, "_blank", "noopener,noreferrer")
+        if (paymentUrl) {
+          window.open(paymentUrl, "_blank", "noopener,noreferrer")
+        } else {
+          toast.success(isConfirmingStripeUpgrade ? t("subscriptionPlan.toast.upgradeRequested") : t("subscriptionPlan.toast.subscriptionRequested"))
+          reloadSubscription()
+        }
       } else {
         if (isBasicPlan) {
           trackBasicConcurrencyUpgradeEvent(user?.id || "", "subscription_checkout_failed", plan)
         }
-        toast.error(resp.message || t(isRenewingCurrentPlan ? "subscriptionPlan.toast.renewFailed" : "subscriptionPlan.toast.subscribeFailed", { plan: planLabel }))
+        const errorKey = isConfirmingStripeUpgrade
+          ? "subscriptionPlan.toast.upgradeFailed"
+          : isRenewingCurrentPlan
+            ? "subscriptionPlan.toast.renewFailed"
+            : "subscriptionPlan.toast.subscribeFailed"
+        toast.error(resp.message || t(errorKey, { plan: planLabel }))
       }
     })
     setLoading(false)
@@ -433,31 +492,44 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
                       }}
                     >
                       <TabsList className="h-8 bg-muted group-data-horizontal/tabs:h-8">
-                        <TabsTrigger value="monthly" className="h-7 px-3 text-xs">{t("subscriptionPlan.billing.monthly")}</TabsTrigger>
+                        <TabsTrigger
+                          value="monthly"
+                          className="h-7 px-3 text-xs"
+                          disabled={isStripeSubscription && currentBillingPeriod === "yearly"}
+                        >
+                          {t("subscriptionPlan.billing.monthly")}
+                        </TabsTrigger>
                         <TabsTrigger value="yearly" className="h-7 px-3 text-xs">{t("subscriptionPlan.billing.yearly")}</TabsTrigger>
                       </TabsList>
                     </Tabs>
-                    <Select
-                      value={String(selectedPeriodCount)}
-                      onValueChange={(value) => setSelectedPeriodCount(Number(value))}
-                    >
-                      <SelectTrigger className="w-24 bg-background" size="sm">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {subscriptionPeriodCounts.map((count) => (
-                          <SelectItem key={count} value={String(count)}>
-                            {selectedBillingPeriod === "monthly"
-                              ? t("subscriptionPlan.billing.monthCount", { count })
-                              : t("subscriptionPlan.billing.yearCount", { count })}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    {pricingRegion !== "global" ? (
+                      <Select
+                        value={String(selectedPeriodCount)}
+                        onValueChange={(value) => setSelectedPeriodCount(Number(value))}
+                      >
+                        <SelectTrigger className="w-24 bg-background" size="sm">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {subscriptionPeriodCounts.map((count) => (
+                            <SelectItem key={count} value={String(count)}>
+                              {selectedBillingPeriod === "monthly"
+                                ? t("subscriptionPlan.billing.monthCount", { count })
+                                : t("subscriptionPlan.billing.yearCount", { count })}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : null}
                   </div>
                   <div className="flex flex-wrap items-center justify-end gap-3">
                     <div className="flex min-w-20 items-end justify-end">
-                      <span className="text-xl font-semibold leading-none">{selectedOrderTotalLabel}</span>
+                      <span className={cn(
+                        "font-semibold",
+                        isSelectedStripeUpgrade ? "text-sm leading-5 text-muted-foreground" : "text-xl leading-none",
+                      )}>
+                        {selectedPriceLabel}
+                      </span>
                     </div>
                     {canSubscribeSelectedPlan ? (
                       <Button
@@ -466,13 +538,17 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
                         disabled={isSelectedPlanLoading}
                       >
                         {isSelectedPlanLoading && <Spinner />}
-                        {isSelectedCurrentPlan
-                          ? t("subscriptionPlan.actions.renew")
-                          : t("subscriptionPlan.actions.subscribePlan", { plan: selectedAccountPlan.name })}
+                        {isSelectedStripeUpgrade
+                          ? t("subscriptionPlan.actions.upgrade")
+                          : isSelectedCurrentPlan
+                            ? t("subscriptionPlan.actions.renew")
+                            : t("subscriptionPlan.actions.subscribePlan", { plan: selectedAccountPlan.name })}
                       </Button>
                     ) : (
                       <div className="flex h-9 w-full items-center justify-center rounded-md border bg-background px-4 text-sm text-muted-foreground md:w-40">
-                        {isSelectedCurrentPlan ? t("subscriptionPlan.status.currentPlan") : t("subscriptionPlan.status.unavailable")}
+                        {isSelectedCurrentPlan && (!isStripeSubscription || selectedBillingPeriod === currentBillingPeriod)
+                          ? t("subscriptionPlan.status.currentPlan")
+                          : t("subscriptionPlan.status.unavailable")}
                       </div>
                     )}
                   </div>
@@ -485,15 +561,26 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
       <AlertDialog open={confirmSubscriptionPlan !== null} onOpenChange={(nextOpen) => !nextOpen && setConfirmSubscriptionPlan(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{isRenewingCurrentPlan ? t("subscriptionPlan.confirm.renewTitle") : t("subscriptionPlan.confirm.subscribeTitle")}</AlertDialogTitle>
+            <AlertDialogTitle>
+              {isConfirmingStripeUpgrade
+                ? t("subscriptionPlan.confirm.upgradeTitle")
+                : isRenewingCurrentPlan
+                  ? t("subscriptionPlan.confirm.renewTitle")
+                  : t("subscriptionPlan.confirm.subscribeTitle")}
+            </AlertDialogTitle>
             <AlertDialogDescription>
               {confirmingPlanCard
-                ? t("subscriptionPlan.confirm.description", {
-                    action: isRenewingCurrentPlan ? t("subscriptionPlan.actions.renew") : t("subscriptionPlan.actions.subscribe"),
-                    plan: confirmingPlanCard.name,
-                    period: selectedPeriodCountLabel,
-                    total: selectedOrderTotalLabel,
-                  })
+                ? isConfirmingStripeUpgrade
+                  ? t("subscriptionPlan.confirm.upgradeDescription", {
+                      plan: confirmingPlanCard.name,
+                      period: selectedPeriodCountLabel,
+                    })
+                  : t("subscriptionPlan.confirm.description", {
+                      action: isRenewingCurrentPlan ? t("subscriptionPlan.actions.renew") : t("subscriptionPlan.actions.subscribe"),
+                      plan: confirmingPlanCard.name,
+                      period: selectedPeriodCountLabel,
+                      total: selectedOrderTotalLabel,
+                    })
                 : ""}
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -507,7 +594,11 @@ export default function SubscriptionPlanDialog({ open, onOpenChange }: Subscript
               disabled={isProLoading || isFlagshipLoading}
             >
               {(isProLoading || isFlagshipLoading) && <Spinner className="mr-2 size-4" />}
-              {isRenewingCurrentPlan ? t("subscriptionPlan.confirm.renewAction") : t("subscriptionPlan.confirm.subscribeAction")}
+              {isConfirmingStripeUpgrade
+                ? t("subscriptionPlan.confirm.upgradeAction")
+                : isRenewingCurrentPlan
+                  ? t("subscriptionPlan.confirm.renewAction")
+                  : t("subscriptionPlan.confirm.subscribeAction")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/i18n/resources/cn.ts
+++ b/frontend/src/i18n/resources/cn.ts
@@ -1625,6 +1625,7 @@ const cn = {
       currentPlan: "当前套餐",
       lifetime: "长期有效",
       validUntil: "{{date}} 前有效",
+      nextCharge: "下次扣款：{{date}}",
       upgrade: "开通高级会员",
       renew: "续费",
     },

--- a/frontend/src/i18n/resources/cn.ts
+++ b/frontend/src/i18n/resources/cn.ts
@@ -1543,6 +1543,7 @@ const cn = {
       yearly: "年付",
       monthCount: "{{count}} 个月",
       yearCount: "{{count}} 年",
+      proratedDifference: "按剩余价值计算差价",
     },
     status: {
       lifetime: "长期有效",
@@ -1556,6 +1557,7 @@ const cn = {
     },
     actions: {
       renew: "续费",
+      upgrade: "升级",
       subscribe: "开通",
       subscribePlan: "开通{{plan}}",
     },
@@ -1565,13 +1567,19 @@ const cn = {
       autoRenewFailed: "自动续费设置失败",
       renewFailed: "续费{{plan}}失败",
       subscribeFailed: "开通{{plan}}失败",
+      upgradeFailed: "升级到{{plan}}失败",
+      upgradeRequested: "升级差价账单已创建",
+      subscriptionRequested: "订阅账单已创建",
     },
     confirm: {
       renewTitle: "确认续费套餐",
       subscribeTitle: "确认开通套餐",
+      upgradeTitle: "确认升级订阅",
       description: "确认{{action}}{{plan}}，购买 {{period}}，合计 {{total}}？",
+      upgradeDescription: "Stripe 将抵扣当前订阅未使用时长并立即收取升级差价。支付成功后，{{plan}} {{period}}立即生效，并发放目标完整周期积分。",
       renewAction: "确认续费",
       subscribeAction: "确认开通",
+      upgradeAction: "确认升级",
     },
   },
   navProject: {

--- a/frontend/src/i18n/resources/en.ts
+++ b/frontend/src/i18n/resources/en.ts
@@ -1625,6 +1625,7 @@ const en = {
       currentPlan: "Current plan",
       lifetime: "Lifetime",
       validUntil: "Valid until {{date}}",
+      nextCharge: "Next charge: {{date}}",
       upgrade: "Upgrade membership",
       renew: "Renew",
     },

--- a/frontend/src/i18n/resources/en.ts
+++ b/frontend/src/i18n/resources/en.ts
@@ -1543,6 +1543,7 @@ const en = {
       yearly: "Yearly",
       monthCount: "{{count}} month(s)",
       yearCount: "{{count}} year(s)",
+      proratedDifference: "Prorated difference",
     },
     status: {
       lifetime: "Lifetime",
@@ -1556,6 +1557,7 @@ const en = {
     },
     actions: {
       renew: "Renew",
+      upgrade: "Upgrade",
       subscribe: "subscribe to",
       subscribePlan: "Subscribe to {{plan}}",
     },
@@ -1565,13 +1567,19 @@ const en = {
       autoRenewFailed: "Failed to update auto-renewal",
       renewFailed: "Failed to renew {{plan}}",
       subscribeFailed: "Failed to subscribe to {{plan}}",
+      upgradeFailed: "Failed to upgrade to {{plan}}",
+      upgradeRequested: "Upgrade payment created",
+      subscriptionRequested: "Subscription payment created",
     },
     confirm: {
       renewTitle: "Confirm renewal",
       subscribeTitle: "Confirm subscription",
+      upgradeTitle: "Confirm upgrade",
       description: "Confirm {{action}} {{plan}} for {{period}}, total {{total}}?",
+      upgradeDescription: "Stripe will credit the unused time on your current subscription and charge the prorated difference immediately. After payment, {{plan}} for {{period}} starts immediately and grants the full-cycle credits.",
       renewAction: "Confirm renewal",
       subscribeAction: "Confirm subscription",
+      upgradeAction: "Confirm upgrade",
     },
   },
   navProject: {

--- a/frontend/test/console-nav-balance-i18n.test.ts
+++ b/frontend/test/console-nav-balance-i18n.test.ts
@@ -6,6 +6,7 @@ import cn from "../src/i18n/resources/cn.ts";
 import en from "../src/i18n/resources/en.ts";
 
 const source = readFileSync(new URL("../src/components/console/nav/nav-balance.tsx", import.meta.url), "utf8");
+const apiSource = readFileSync(new URL("../src/api/Api.ts", import.meta.url), "utf8");
 const cjkPattern = /[\u3400-\u9fff]/;
 
 test("账户余额入口使用 navBalance i18n key", () => {
@@ -22,6 +23,18 @@ test("账户余额入口使用 navBalance i18n key", () => {
   assert.doesNotMatch(source, cjkPattern);
 });
 
+test("套餐信息完整显示并仅为有效自动续费合同展示下次扣款时间", () => {
+  assert.match(source, /flex min-w-0 flex-wrap items-baseline/);
+  assert.match(source, /whitespace-nowrap text-xs font-normal text-muted-foreground/);
+  assert.match(source, /subscription\?\.payment_provider === "stripe"/);
+  assert.match(source, /subscription\.billing_status === "active"/);
+  assert.match(source, /subscription\.auto_renew/);
+  assert.match(source, /!subscription\.cancel_at_period_end/);
+  assert.match(source, /t\("navBalance\.plan\.nextCharge"/);
+  assert.match(apiSource, /current_period_end\?: string;/);
+  assert.match(apiSource, /payment_provider\?: string;/);
+});
+
 test("账户余额入口提供中英文资源", () => {
   assert.equal(cn.navBalance.account.title, "我的账户");
   assert.equal(en.navBalance.account.title, "My account");
@@ -29,6 +42,8 @@ test("账户余额入口提供中英文资源", () => {
   assert.equal(en.navBalance.plan.upgrade, "Upgrade membership");
   assert.equal(cn.navBalance.plan.renew, "续费");
   assert.equal(en.navBalance.plan.renew, "Renew");
+  assert.equal(cn.navBalance.plan.nextCharge, "下次扣款：{{date}}");
+  assert.equal(en.navBalance.plan.nextCharge, "Next charge: {{date}}");
   assert.equal(cn.navBalance.balance.creditBill, "积分账单");
   assert.equal(en.navBalance.balance.creditBill, "Credit bill");
   assert.equal(cn.navBalance.security.changePassword, "修改密码");

--- a/frontend/test/subscription-plan-dialog-i18n.test.ts
+++ b/frontend/test/subscription-plan-dialog-i18n.test.ts
@@ -14,6 +14,11 @@ test("套餐弹窗使用 subscriptionPlan i18n key", () => {
   assert.match(source, /t\("subscriptionPlan\.plans\.pro\.name"\)/);
   assert.match(source, /t\("subscriptionPlan\.features\.taskConcurrency\.label"\)/);
   assert.match(source, /t\("subscriptionPlan\.confirm\.renewTitle"\)/);
+  assert.match(source, /isStripeUpgradeTransition/);
+  assert.match(source, /subscription\?\.billing_interval === "year"/);
+  assert.match(source, /subscription\?\.payment_provider === "stripe"/);
+  assert.match(source, /t\("subscriptionPlan\.confirm\.upgradeDescription"/);
+  assert.match(source, /disabled=\{isStripeSubscription && currentBillingPeriod === "yearly"\}/);
   assert.doesNotMatch(source, cjkPattern);
 });
 
@@ -24,6 +29,10 @@ test("套餐弹窗提供中英文资源", () => {
   assert.equal(en.subscriptionPlan.plans.pro.name, "Pro");
   assert.equal(cn.subscriptionPlan.actions.subscribePlan, "开通{{plan}}");
   assert.equal(en.subscriptionPlan.actions.subscribePlan, "Subscribe to {{plan}}");
+  assert.equal(cn.subscriptionPlan.actions.upgrade, "升级");
+  assert.equal(en.subscriptionPlan.actions.upgrade, "Upgrade");
+  assert.match(cn.subscriptionPlan.confirm.upgradeDescription, /完整周期积分/);
+  assert.match(en.subscriptionPlan.confirm.upgradeDescription, /full-cycle credits/);
 });
 
 test("套餐弹窗使用固定设计高度并限制极小视口", () => {


### PR DESCRIPTION
## 变更说明

- 完善账户弹窗中的 Stripe 自动续费信息展示
- 支持 Pro → Ultra、月付 → 年付及组合升级入口
- 仅开放合法升级方向，禁止套餐降级和年付转月付
- 补充中英文文案、确认反馈和回归测试

## 验证

- Node 定向测试通过
- ESLint 通过
- 前端生产构建通过

关联后端 MR：ai/monkeycode/monkeycode-ai!770