### PR TITLE
fix: 修复团队 MCP 上游凭证泄露

### DIFF
--- a/backend/biz/team/handler/http/v1/mcp.go
+++ b/backend/biz/team/handler/http/v1/mcp.go
@@ -30,7 +30,7 @@ func NewTeamMCPHandler(i *do.Injector) (*TeamMCPHandler, error) {
 
 	g := w.Group("/api/v1/teams/mcp")
 	g.Use(auth.TeamAuth())
-	g.GET("/upstreams", web.BaseHandler(h.ListUpstreams))
+	g.GET("/upstreams", web.BaseHandler(h.ListUpstreams), adminAuth)
 	g.POST("/upstreams", web.BindHandler(h.CreateUpstream), adminAuth, audit.Audit("create_team_mcp_upstream"))
 	g.PUT("/upstreams/:upstream_id", web.BindHandler(h.UpdateUpstream), adminAuth, audit.Audit("update_team_mcp_upstream"))
 	g.DELETE("/upstreams/:upstream_id", web.BindHandler(h.DeleteUpstream), adminAuth, audit.Audit("delete_team_mcp_upstream"))

--- a/backend/biz/team/handler/http/v1/mcp_route_test.go
+++ b/backend/biz/team/handler/http/v1/mcp_route_test.go
@@ -4,14 +4,21 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/GoYoko/web"
+	"github.com/alicebob/miniredis/v2"
 	"github.com/google/uuid"
 	"github.com/samber/do"
 
+	"github.com/chaitin/MonkeyCode/backend/config"
+	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/middleware"
+	"github.com/chaitin/MonkeyCode/backend/pkg/session"
 )
 
 func TestNewTeamMCPHandlerRegistersRoutes(t *testing.T) {
@@ -48,14 +55,88 @@ func TestNewTeamMCPHandlerRegistersRoutes(t *testing.T) {
 	}
 }
 
+func TestTeamMCPListUpstreamsRequiresAdmin(t *testing.T) {
+	tests := []struct {
+		name       string
+		role       consts.TeamMemberRole
+		wantStatus int
+		wantCalls  int
+	}{
+		{name: "普通成员", role: consts.TeamMemberRoleUser, wantStatus: http.StatusForbidden},
+		{name: "管理员", role: consts.TeamMemberRoleAdmin, wantStatus: http.StatusOK, wantCalls: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := web.New()
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			mr := miniredis.RunT(t)
+			port, err := strconv.Atoi(mr.Port())
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg := &config.Config{}
+			cfg.Redis.Host = "127.0.0.1"
+			cfg.Redis.Port = port
+			cfg.Session.ExpireDay = 1
+			sess := session.New(cfg)
+			usecase := &teamMCPUsecaseStub{}
+			repo := &teamMCPRepoStub{role: tt.role}
+
+			injector := do.New()
+			do.ProvideValue(injector, w)
+			do.ProvideValue(injector, middleware.NewAuthMiddleware(sess, nil, logger))
+			do.ProvideValue(injector, middleware.NewAuditMiddleware(logger, nil, nil))
+			do.ProvideValue[domain.TeamMCPUsecase](injector, usecase)
+			do.ProvideValue[domain.TeamMCPRepo](injector, repo)
+			if _, err := NewTeamMCPHandler(injector); err != nil {
+				t.Fatal(err)
+			}
+
+			userID := uuid.New()
+			teamID := uuid.New()
+			saveReq := httptest.NewRequest(http.MethodGet, "/", nil)
+			saveRec := httptest.NewRecorder()
+			saveCtx := w.Echo().NewContext(saveReq, saveRec)
+			if _, err := sess.Save(saveCtx, consts.MonkeyCodeAITeamSession, userID, &domain.User{
+				ID:   userID,
+				Team: &domain.Team{ID: teamID},
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/teams/mcp/upstreams", nil)
+			for _, cookie := range saveRec.Result().Cookies() {
+				req.AddCookie(cookie)
+			}
+			rec := httptest.NewRecorder()
+			w.Echo().ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d, body = %s", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+			if usecase.listCalls != tt.wantCalls {
+				t.Fatalf("list calls = %d, want %d", usecase.listCalls, tt.wantCalls)
+			}
+		})
+	}
+}
+
 type teamMCPUsecaseStub struct {
 	domain.TeamMCPUsecase
+	listCalls int
+}
+
+func (s *teamMCPUsecaseStub) ListUpstreams(context.Context, *domain.TeamUser) (*domain.ListTeamMCPUpstreamsResp, error) {
+	s.listCalls++
+	return &domain.ListTeamMCPUpstreamsResp{}, nil
 }
 
 type teamMCPRepoStub struct {
 	domain.TeamMCPRepo
+	role consts.TeamMemberRole
 }
 
 func (s *teamMCPRepoStub) GetMember(context.Context, uuid.UUID, uuid.UUID) (*domain.TeamMember, error) {
-	return &domain.TeamMember{}, nil
+	return &domain.TeamMember{TeamRole: s.role}, nil
 }

--- a/backend/biz/team/repo/mcp.go
+++ b/backend/biz/team/repo/mcp.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"entgo.io/ent/dialect/sql"
 	"github.com/google/uuid"
@@ -107,7 +108,7 @@ func (r *teamMCPRepo) UpdateUpstream(ctx context.Context, teamID uuid.UUID, req 
 			update = update.SetURL(*req.URL)
 		}
 		if req.Headers != nil {
-			update = update.SetHeaders(headersToMap(*req.Headers))
+			update = update.SetHeaders(mergeHeaders(*req.Headers, row.Headers))
 		}
 		if req.Description != nil {
 			update = update.SetDescription(*req.Description)
@@ -232,6 +233,26 @@ func headersToMap(headers []domain.MCPHeader) map[string]string {
 	result := make(map[string]string, len(headers))
 	for _, header := range headers {
 		if header.Name == "" {
+			continue
+		}
+		result[header.Name] = header.Value
+	}
+	return result
+}
+
+func mergeHeaders(headers []domain.MCPHeader, current map[string]string) map[string]string {
+	result := make(map[string]string, len(headers))
+	for _, header := range headers {
+		if header.Name == "" {
+			continue
+		}
+		if header.Value == domain.MCPHeaderMask {
+			for name, value := range current {
+				if strings.EqualFold(name, header.Name) {
+					result[header.Name] = value
+					break
+				}
+			}
 			continue
 		}
 		result[header.Name] = header.Value

--- a/backend/biz/team/repo/mcp_test.go
+++ b/backend/biz/team/repo/mcp_test.go
@@ -1,0 +1,57 @@
+package repo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+func TestTeamMCPUpdatePreservesMaskedHeaderValues(t *testing.T) {
+	ctx := context.Background()
+	client := newTeamRepoTestDB(t)
+	teamID := createTeamRepoTestTeam(t, client)
+	createTeamRepoDefaultGroup(t, client, teamID)
+	repo := &teamMCPRepo{db: client}
+
+	upstream, err := repo.CreateUpstream(ctx, teamID, &domain.CreateTeamMCPUpstreamReq{
+		Name: "private-mcp",
+		Slug: "private-mcp",
+		URL:  "https://mcp.example.com/mcp",
+		Headers: []domain.MCPHeader{
+			{Name: "Authorization", Value: "Bearer secret"},
+			{Name: "X-API-Key", Value: "api secret"},
+			{Name: "X-Trace", Value: "old trace"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	headers := []domain.MCPHeader{
+		{Name: "authorization", Value: domain.MCPHeaderMask},
+		{Name: "X-API-Key", Value: domain.MCPHeaderMask},
+		{Name: "X-Trace", Value: "new trace"},
+	}
+	updated, err := repo.UpdateUpstream(ctx, teamID, &domain.UpdateTeamMCPUpstreamReq{
+		UpstreamID: upstream.ID,
+		Headers:    &headers,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]string{
+		"authorization": "Bearer secret",
+		"X-API-Key":     "api secret",
+		"X-Trace":       "new trace",
+	}
+	if len(updated.Headers) != len(want) {
+		t.Fatalf("headers = %#v, want %#v", updated.Headers, want)
+	}
+	for name, value := range want {
+		if updated.Headers[name] != value {
+			t.Fatalf("header %s = %q, want %q", name, updated.Headers[name], value)
+		}
+	}
+}

--- a/backend/domain/team_mcp.go
+++ b/backend/domain/team_mcp.go
@@ -8,6 +8,8 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/db"
 )
 
+const MCPHeaderMask = "******"
+
 type TeamMCPUsecase interface {
 	ListUpstreams(ctx context.Context, teamUser *TeamUser) (*ListTeamMCPUpstreamsResp, error)
 	CreateUpstream(ctx context.Context, teamUser *TeamUser, req CreateTeamMCPUpstreamReq) (*TeamMCPUpstream, error)
@@ -37,6 +39,11 @@ func (m *TeamMCPUpstream) From(src *db.MCPUpstream) *TeamMCPUpstream {
 		return m
 	}
 	m.MCPUpstream = (&MCPUpstream{}).From(src)
+	for i := range m.Headers {
+		if m.Headers[i].Value != "" {
+			m.Headers[i].Value = MCPHeaderMask
+		}
+	}
 	if src.TeamID != nil {
 		m.TeamID = *src.TeamID
 	}

--- a/backend/domain/team_mcp_test.go
+++ b/backend/domain/team_mcp_test.go
@@ -1,0 +1,33 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chaitin/MonkeyCode/backend/db"
+)
+
+func TestTeamMCPUpstreamFromMasksHeaderValues(t *testing.T) {
+	upstream := (&TeamMCPUpstream{}).From(&db.MCPUpstream{
+		Headers: map[string]string{
+			"Authorization": "Bearer secret",
+			"X-Custom-Auth": "custom secret",
+			"X-Empty":       "",
+		},
+		CreatedAt: time.Now(),
+	})
+
+	values := make(map[string]string, len(upstream.Headers))
+	for _, header := range upstream.Headers {
+		values[header.Name] = header.Value
+	}
+	if values["Authorization"] != MCPHeaderMask {
+		t.Fatalf("Authorization = %q, want mask", values["Authorization"])
+	}
+	if values["X-Custom-Auth"] != MCPHeaderMask {
+		t.Fatalf("X-Custom-Auth = %q, want mask", values["X-Custom-Auth"])
+	}
+	if values["X-Empty"] != "" {
+		t.Fatalf("X-Empty = %q, want empty", values["X-Empty"])
+	}
+}

--- a/backend/middleware/audit.go
+++ b/backend/middleware/audit.go
@@ -157,7 +157,31 @@ func maskSensitiveData(operation, reqBody, respBody string) (string, string, err
 		if err != nil {
 			return "", "", err
 		}
+	case "create_team_mcp_upstream":
+		reqBody, err = maskJSON(reqBody, func(req *domain.CreateTeamMCPUpstreamReq) {
+			maskMCPHeaders(req.Headers)
+		})
+		if err != nil {
+			return "", "", err
+		}
+	case "update_team_mcp_upstream":
+		reqBody, err = maskJSON(reqBody, func(req *domain.UpdateTeamMCPUpstreamReq) {
+			if req.Headers != nil {
+				maskMCPHeaders(*req.Headers)
+			}
+		})
+		if err != nil {
+			return "", "", err
+		}
 	}
 
 	return reqBody, respBody, nil
+}
+
+func maskMCPHeaders(headers []domain.MCPHeader) {
+	for i := range headers {
+		if headers[i].Value != "" {
+			headers[i].Value = domain.MCPHeaderMask
+		}
+	}
 }

--- a/backend/middleware/audit_test.go
+++ b/backend/middleware/audit_test.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+func TestMaskSensitiveDataMasksTeamMCPHeaders(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation string
+		body      string
+	}{
+		{
+			name:      "创建",
+			operation: "create_team_mcp_upstream",
+			body:      `{"name":"private-mcp","headers":[{"name":"Authorization","value":"Bearer secret"},{"name":"X-Empty","value":""}]}`,
+		},
+		{
+			name:      "更新",
+			operation: "update_team_mcp_upstream",
+			body:      `{"headers":[{"name":"X-Custom-Auth","value":"custom secret"}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			masked, _, err := maskSensitiveData(tt.operation, tt.body, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var req struct {
+				Headers []domain.MCPHeader `json:"headers"`
+			}
+			if err := json.Unmarshal([]byte(masked), &req); err != nil {
+				t.Fatal(err)
+			}
+			for _, header := range req.Headers {
+				if header.Value != "" && header.Value != domain.MCPHeaderMask {
+					t.Fatalf("header %s leaked value %q", header.Name, header.Value)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 修复内容

- 为 `GET /api/v1/teams/mcp/upstreams` 增加团队管理员权限校验
- 团队 MCP Upstream 响应统一隐藏所有非空 Header 值
- 更新请求回传 `******` 时保留原始凭证，Header 名按大小写不敏感匹配
- 对创建、更新 MCP Upstream 的审计请求体进行 Header 脱敏
- 增加权限、响应脱敏、凭证保留和审计脱敏测试

## 测试

- `go test ./domain ./middleware ./biz/team/repo ./biz/team/handler/http/v1`
- `go test ./biz/team/... ./middleware ./domain`

以上测试全部通过。

`go test ./...` 中本次涉及的包均通过；全量命令仍有两处仓库既有测试桩编译失败：

- `biz/host/usecase/host_test.go`：`hostTaskRepoStub` 缺少 `UpdateAgentResourceSelection`
- `pkg/lifecycle/taskhook_test.go`：`taskHookRepoStub` 缺少 `UpdateAgentResourceSelection`

上述文件不在本 PR 变更范围内。