### PR TITLE
fix: 为 internal 敏感接口增加强制认证

### DIFF
--- a/backend/biz/host/handler/v1/internal.go
+++ b/backend/biz/host/handler/v1/internal.go
@@ -2,22 +2,26 @@ package v1
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/GoYoko/web"
 	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
 	"github.com/patrickmn/go-cache"
 	"github.com/redis/go-redis/v9"
 	"github.com/samber/do"
 
 	gituc "github.com/chaitin/MonkeyCode/backend/biz/git/usecase"
 	vmidle "github.com/chaitin/MonkeyCode/backend/biz/vmidle/usecase"
+	"github.com/chaitin/MonkeyCode/backend/config"
 	"github.com/chaitin/MonkeyCode/backend/consts"
 	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/domain"
@@ -49,6 +53,7 @@ type InternalHostHandler struct {
 	projectUsecase domain.ProjectUsecase
 	tokenProvider  *gituc.TokenProvider
 	idleRefresher  vmidle.VMIdleRefresher
+	internalToken  string
 }
 
 type taskLogStoreRepo interface {
@@ -63,6 +68,11 @@ const vmActivityTaskRefreshInterval = 5 * time.Minute
 
 func NewInternalHostHandler(i *do.Injector) (*InternalHostHandler, error) {
 	w := do.MustInvoke[*web.Web](i)
+	cfg := do.MustInvoke[*config.Config](i)
+	internalToken := strings.TrimSpace(cfg.TaskFlow.CallbackToken)
+	if internalToken == "" {
+		return nil, errors.New("taskflow.callback_token is required")
+	}
 	tf := do.MustInvoke[taskflow.Clienter](i)
 	rdb := do.MustInvoke[*redis.Client](i)
 	taskRepo := do.MustInvoke[domain.TaskRepo](i)
@@ -89,9 +99,11 @@ func NewInternalHostHandler(i *do.Injector) (*InternalHostHandler, error) {
 		projectUsecase: do.MustInvoke[domain.ProjectUsecase](i),
 		tokenProvider:  do.MustInvoke[*gituc.TokenProvider](i),
 		idleRefresher:  do.MustInvoke[vmidle.VMIdleRefresher](i),
+		internalToken:  internalToken,
 	}
 
 	g := w.Group("/internal")
+	g.Use(h.internalAuth())
 	g.POST("/check-token", web.BindHandler(h.CheckToken))
 	g.POST("/host-info", web.BindHandler(h.ReportHostInfo))
 	g.POST("/vm-info", web.BindHandler(h.ReportVirtualMachine))
@@ -107,6 +119,20 @@ func NewInternalHostHandler(i *do.Injector) (*InternalHostHandler, error) {
 	g.POST("/task-stream-ips", web.BindHandler(h.GetTaskStreamIPs))
 
 	return h, nil
+}
+
+func (h *InternalHostHandler) internalAuth() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			parts := strings.Fields(c.Request().Header.Get(echo.HeaderAuthorization))
+			if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") ||
+				subtle.ConstantTimeCompare([]byte(parts[1]), []byte(h.internalToken)) != 1 {
+				c.Response().Header().Set("WWW-Authenticate", "Bearer")
+				return c.String(http.StatusUnauthorized, "Unauthorized")
+			}
+			return next(c)
+		}
+	}
 }
 
 type VMActivityReq struct {

--- a/backend/biz/host/handler/v1/internal_middleware_test.go
+++ b/backend/biz/host/handler/v1/internal_middleware_test.go
@@ -1,0 +1,51 @@
+package v1
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestInternalAuth(t *testing.T) {
+	const token = "test-internal-token"
+
+	tests := []struct {
+		name          string
+		authorization string
+		wantStatus    int
+	}{
+		{name: "missing token", wantStatus: http.StatusUnauthorized},
+		{name: "invalid scheme", authorization: "Basic " + token, wantStatus: http.StatusUnauthorized},
+		{name: "invalid token", authorization: "Bearer invalid", wantStatus: http.StatusUnauthorized},
+		{name: "valid token", authorization: "Bearer " + token, wantStatus: http.StatusNoContent},
+		{name: "case insensitive scheme", authorization: "bearer " + token, wantStatus: http.StatusNoContent},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			h := &InternalHostHandler{internalToken: token}
+			g := e.Group("/internal")
+			g.Use(h.internalAuth())
+			g.GET("/test", func(c echo.Context) error {
+				return c.NoContent(http.StatusNoContent)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/internal/test", nil)
+			if tt.authorization != "" {
+				req.Header.Set(echo.HeaderAuthorization, tt.authorization)
+			}
+			resp := httptest.NewRecorder()
+			e.ServeHTTP(resp, req)
+
+			if resp.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", resp.Code, tt.wantStatus)
+			}
+			if tt.wantStatus == http.StatusUnauthorized && resp.Header().Get("WWW-Authenticate") != "Bearer" {
+				t.Fatalf("WWW-Authenticate = %q, want Bearer", resp.Header().Get("WWW-Authenticate"))
+			}
+		})
+	}
+}

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -175,9 +175,10 @@ type InitTeam struct {
 }
 
 type TaskFlow struct {
-	GrpcHost string `mapstructure:"grpc_host"`
-	GrpcPort int    `mapstructure:"grpc_port"`
-	GrpcURL  string `mapstructure:"grpc_url"`
+	GrpcHost      string `mapstructure:"grpc_host"`
+	GrpcPort      int    `mapstructure:"grpc_port"`
+	GrpcURL       string `mapstructure:"grpc_url"`
+	CallbackToken string `mapstructure:"callback_token"`
 }
 
 type MCPHub struct {
@@ -379,6 +380,7 @@ func Init(dir string) (*Config, error) {
 	v.SetDefault("init_team.image", "")
 	v.SetDefault("init_team.extension_package_dir", "/app/extensions/packages")
 	v.SetDefault("taskflow.grpc_url", "")
+	v.SetDefault("taskflow.callback_token", "")
 	v.SetDefault("task.at_keyword", "")
 	v.SetDefault("task.host_ids", []string{})
 	v.SetDefault("task.create_req_ttl_seconds", 600)

--- a/backend/config/internal_auth_config_test.go
+++ b/backend/config/internal_auth_config_test.go
@@ -1,0 +1,15 @@
+package config
+
+import "testing"
+
+func TestTaskflowCallbackTokenFromEnv(t *testing.T) {
+	t.Setenv("MCAI_TASKFLOW_CALLBACK_TOKEN", "test-callback-token")
+
+	cfg, err := Init(t.TempDir())
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if cfg.TaskFlow.CallbackToken != "test-callback-token" {
+		t.Fatalf("callback token = %q", cfg.TaskFlow.CallbackToken)
+	}
+}

--- a/backend/config/server/config.yaml.example
+++ b/backend/config/server/config.yaml.example
@@ -11,6 +11,11 @@ security:
   # 可通过 MCAI_SECURITY_CAPTCHA_ENABLED 环境变量覆盖。
   captcha_enabled: true
 
+taskflow:
+  # taskflow 回调 /internal 接口时使用的共享密钥，生产环境请通过环境变量注入随机值。
+  # 后端环境变量：MCAI_TASKFLOW_CALLBACK_TOKEN。
+  callback_token: ""
+
 database:
   master: "postgres://monkeycode:monkeycode@localhost:5432/monkeycode?sslmode=disable"
   slave: ""

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -122,6 +122,7 @@ services:
       MCAI_JWT_RELAY_HOST: ${REMOTE_IP}
       MCAI_JWT_RELAY_PORT: 7000
       MCAI_JWT_RELAY_USE_TLS: false
+      MCAI_REPORT_TOKEN: ${TASKFLOW_CALLBACK_TOKEN:?TASKFLOW_CALLBACK_TOKEN is required}
     networks:
       monkeycode:
         ipv4_address: "${SUBNET_PREFIX:-10.100.50}.16"
@@ -164,6 +165,7 @@ services:
       MCAI_TASK_LLM_PROXY_ENABLED: false
       MCAI_OBJECT_STORAGE_ACCESS_ENDPOINT: http://${REMOTE_IP}:${NGINX_PORT:-80}/oss
       MCAI_TASKFLOW_GRPC_URL: ${REMOTE_IP}:50443
+      MCAI_TASKFLOW_CALLBACK_TOKEN: ${TASKFLOW_CALLBACK_TOKEN:?TASKFLOW_CALLBACK_TOKEN is required}
     volumes:
       - ${INSTALL_DIR}/static:/app/static
     networks:


### PR DESCRIPTION
## 变更

- 为整个 `/internal` 路由组增加 Bearer 认证中间件
- 使用常量时间比较凭证，缺失或错误凭证返回 401
- 未配置 `taskflow.callback_token` 时拒绝初始化，避免降级为无认证
- 增加配置示例、Compose 注入和认证回归测试

## 安全影响

修复 CWE-306：未认证调用可读取 LLM/Git 凭证并篡改 Host/VM 状态。

## 配套变更

- taskflow 调用端 MR：https://git.in.chaitin.net/ai/monkeycode/taskflow/-/merge_requests/172
- MonkeyCodePro 私有化部署 PR：https://github.com/chaitin/MonkeyCodePro/pull/137

三个变更需要配套发布，两端必须配置相同的随机 token。

## 验证

```bash
go test ./biz/host/handler/v1 ./config
```

上述测试通过。全仓测试另有 `main` 已存在的 `hostTaskRepoStub` 接口实现缺失问题，与本 PR 无关。