### PR TITLE
将前端镜像改为非 root 运行

### DIFF
--- a/frontend/docker/Dockerfile
+++ b/frontend/docker/Dockerfile
@@ -1,17 +1,13 @@
-# 直接使用 nginx 镜像，因为应用已经在 CI 中构建完成
 FROM nginx:alpine
 
-# 复制构建产物到 nginx 目录
-COPY dist/ /usr/share/nginx/html/
+RUN mkdir -p /etc/nginx/locations
 
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY --chown=nginx:nginx dist/ /usr/share/nginx/html/
+COPY --chown=nginx:nginx nginx.conf /etc/nginx/nginx.conf
 
-# 复制启动脚本
-COPY start.sh /start.sh
-RUN chmod +x /start.sh
+USER nginx
 
-# 暴露端口
-EXPOSE 80
+EXPOSE 8080
 
-# 使用启动脚本启动
-CMD ["/start.sh"]
+ENTRYPOINT []
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/docker/nginx.conf
+++ b/frontend/docker/nginx.conf
@@ -1,3 +1,5 @@
+pid /tmp/nginx.pid;
+
 events {
     worker_connections 1024;
 }
@@ -11,8 +13,14 @@ http {
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"';
     
-    access_log /var/log/nginx/access.log main;
-    error_log /var/log/nginx/error.log;
+    access_log /dev/stdout main;
+    error_log /dev/stderr;
+
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path /tmp/proxy_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
     
     # 基本设置
     sendfile on;
@@ -28,10 +36,12 @@ http {
     gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
 
     server {
-        listen 80;
+        listen 8080;
         server_name localhost;
         root /usr/share/nginx/html;
         index index.html;
+
+        include /etc/nginx/locations/*.conf;
         
         # 处理前端路由（SPA）
         location / {

--- a/frontend/docker/start.sh
+++ b/frontend/docker/start.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# 启动 nginx
-nginx -g "daemon off;"


### PR DESCRIPTION
## 变更

- 前端 Nginx 改为 UID/GID 101 运行
- 监听端口由 80 调整为 8080
- 将 PID、临时目录和日志调整为只读根文件系统兼容路径
- 预留 Nginx location 配置目录，供 Helm 挂载 OSS 代理配置
- 移除多余启动脚本，直接使用 JSON CMD 启动 Nginx

## 验证

- frontend Docker 镜像构建通过
- 容器运行用户验证为 UID/GID 101
- 只读根文件系统加 tmpfs 场景下 nginx -t 通过
- 合并 OSS location 后代理请求验证返回 200