### PR TITLE
修复历史团队模型关联缺失

### DIFF
--- a/backend/migration/000026_backfill_team_models.down.sql
+++ b/backend/migration/000026_backfill_team_models.down.sql
@@ -1,0 +1,1 @@
+-- Historical team-model associations are valid data and intentionally retained on rollback.

--- a/backend/migration/000026_backfill_team_models.up.sql
+++ b/backend/migration/000026_backfill_team_models.up.sql
@@ -1,0 +1,19 @@
+INSERT INTO team_models (id, team_id, model_id, created_at)
+SELECT
+    gen_random_uuid(),
+    tg.team_id,
+    tgm.model_id,
+    MIN(tgm.created_at)
+FROM team_group_models tgm
+JOIN team_groups tg
+    ON tg.id = tgm.group_id
+   AND tg.deleted_at IS NULL
+JOIN teams t
+    ON t.id = tg.team_id
+   AND t.deleted_at IS NULL
+JOIN models m
+    ON m.id = tgm.model_id
+   AND m.deleted_at IS NULL
+WHERE tgm.deleted_at IS NULL
+GROUP BY tg.team_id, tgm.model_id
+ON CONFLICT (team_id, model_id) DO NOTHING;

--- a/backend/migration/migration_test.go
+++ b/backend/migration/migration_test.go
@@ -23,6 +23,27 @@ func TestMigrationsUseDeletedAtForSoftDelete(t *testing.T) {
 	}
 }
 
+func TestTeamModelBackfillUsesGroupTeamOwnership(t *testing.T) {
+	data, err := os.ReadFile("000026_backfill_team_models.up.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql := strings.ToLower(string(data))
+	for _, want := range []string{
+		"insert into team_models",
+		"join team_groups",
+		"join teams",
+		"join models",
+		"tgm.deleted_at is null",
+		"group by tg.team_id, tgm.model_id",
+		"on conflict (team_id, model_id) do nothing",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("team model backfill migration missing %q", want)
+		}
+	}
+}
+
 func TestMigrationsWidenUserIdentityIDForOIDC(t *testing.T) {
 	data, err := os.ReadFile("000015_alter_user_identities_identity_id_text.up.sql")
 	if err != nil {


### PR DESCRIPTION
## 变更说明
- 新增数据迁移，按有效的团队分组模型关系回填缺失的 `team_models`
- 过滤已软删除的模型、分组及团队
- 通过分组键聚合与 `ON CONFLICT` 保证迁移幂等
- 回滚时保留已恢复的有效关联，避免误删业务数据

## 验证
- `go test ./migration`
- `git diff --check`