### PR TITLE
修复 OIDC 登录误匹配管理员账号

### DIFF
--- a/backend/biz/team/repo/oidc.go
+++ b/backend/biz/team/repo/oidc.go
@@ -89,9 +89,16 @@ func (r *TeamOIDCRepo) UpsertConfig(ctx context.Context, teamID uuid.UUID, req *
 	return r.db.TeamOIDCConfig.Get(ctx, id)
 }
 
-func (r *TeamOIDCRepo) FindUserByOIDCIdentity(ctx context.Context, identityID string) (*db.User, error) {
+func (r *TeamOIDCRepo) FindUserByOIDCIdentity(ctx context.Context, teamID uuid.UUID, identityID string) (*db.User, error) {
 	identity, err := r.db.UserIdentity.Query().
-		Where(useridentity.PlatformEQ(consts.UserPlatformOIDC), useridentity.IdentityIDEQ(identityID)).
+		Where(
+			useridentity.PlatformEQ(consts.UserPlatformOIDC),
+			useridentity.IdentityIDEQ(identityID),
+			useridentity.HasUserWith(
+				user.RoleEQ(consts.UserRoleSubAccount),
+				user.HasTeamsWith(team.IDEQ(teamID)),
+			),
+		).
 		WithUser().
 		First(ctx)
 	if err != nil {
@@ -104,7 +111,11 @@ func (r *TeamOIDCRepo) FindTeamMemberByEmail(ctx context.Context, teamID uuid.UU
 	return r.db.TeamMember.Query().
 		Where(
 			teammember.TeamIDEQ(teamID),
-			teammember.HasUserWith(user.EmailEQ(normalizeEmail(email))),
+			teammember.RoleEQ(consts.TeamMemberRoleUser),
+			teammember.HasUserWith(
+				user.EmailEQ(normalizeEmail(email)),
+				user.RoleEQ(consts.UserRoleSubAccount),
+			),
 		).
 		WithUser().
 		First(ctx)

--- a/backend/biz/team/repo/oidc_test.go
+++ b/backend/biz/team/repo/oidc_test.go
@@ -56,6 +56,113 @@ func TestTeamOIDCConfigSchemaPersistsDefaults(t *testing.T) {
 	}
 }
 
+func TestTeamOIDCRepoFindsOnlyOrdinaryTeamMember(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.Open(t, "sqlite3", "file:team_oidc_member_role?mode=memory&cache=shared&_fk=1")
+	defer client.Close()
+
+	teamID := uuid.New()
+	if _, err := client.Team.Create().
+		SetID(teamID).
+		SetName("研发团队").
+		SetMemberLimit(10).
+		Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	adminOnlyTeamID := uuid.New()
+	if _, err := client.Team.Create().
+		SetID(adminOnlyTeamID).
+		SetName("仅管理员团队").
+		SetMemberLimit(10).
+		Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	admin, err := client.User.Create().
+		SetID(uuid.New()).
+		SetName("Admin").
+		SetEmail("same@example.com").
+		SetRole(consts.UserRoleEnterprise).
+		SetStatus(consts.UserStatusActive).
+		Save(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := client.User.Create().
+		SetID(uuid.New()).
+		SetName("Member").
+		SetEmail("same@example.com").
+		SetRole(consts.UserRoleSubAccount).
+		SetStatus(consts.UserStatusActive).
+		Save(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.TeamMember.Create().
+		SetID(uuid.New()).
+		SetTeamID(teamID).
+		SetUserID(admin.ID).
+		SetRole(consts.TeamMemberRoleAdmin).
+		Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.TeamMember.Create().
+		SetID(uuid.New()).
+		SetTeamID(teamID).
+		SetUserID(member.ID).
+		SetRole(consts.TeamMemberRoleUser).
+		Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.TeamMember.Create().
+		SetID(uuid.New()).
+		SetTeamID(adminOnlyTeamID).
+		SetUserID(admin.ID).
+		SetRole(consts.TeamMemberRoleAdmin).
+		Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.UserIdentity.Create().
+		SetID(uuid.New()).
+		SetUserID(admin.ID).
+		SetPlatform(consts.UserPlatformOIDC).
+		SetIdentityID("admin-identity").
+		SetUsername("Admin").
+		Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.UserIdentity.Create().
+		SetID(uuid.New()).
+		SetUserID(member.ID).
+		SetPlatform(consts.UserPlatformOIDC).
+		SetIdentityID("member-identity").
+		SetUsername("Member").
+		Save(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := &TeamOIDCRepo{db: client}
+	teamMember, err := repo.FindTeamMemberByEmail(ctx, teamID, "same@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if teamMember.Edges.User == nil || teamMember.Edges.User.ID != member.ID {
+		t.Fatalf("matched user = %+v, want member %s", teamMember.Edges.User, member.ID)
+	}
+	if _, err := repo.FindTeamMemberByEmail(ctx, adminOnlyTeamID, "same@example.com"); !db.IsNotFound(err) {
+		t.Fatalf("admin-only email lookup err = %v, want not found so auto-create can run", err)
+	}
+	if _, err := repo.FindUserByOIDCIdentity(ctx, teamID, "admin-identity"); !db.IsNotFound(err) {
+		t.Fatalf("admin identity err = %v, want not found", err)
+	}
+	found, err := repo.FindUserByOIDCIdentity(ctx, teamID, "member-identity")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found.ID != member.ID {
+		t.Fatalf("identity user = %s, want member %s", found.ID, member.ID)
+	}
+}
+
 func TestTeamOIDCRepoBindOIDCIdentitySkipsCreateWhenIdentityExists(t *testing.T) {
 	ctx := context.Background()
 	sqlDB, mock, err := sqlmock.New()

--- a/backend/biz/team/usecase/oidc.go
+++ b/backend/biz/team/usecase/oidc.go
@@ -259,7 +259,7 @@ func (u *TeamOIDCUsecase) resolveUser(ctx context.Context, teamID uuid.UUID, aut
 		"issuer_len", len(external.Issuer),
 		"subject_len", len(external.Subject),
 	)
-	user, err := u.repo.FindUserByOIDCIdentity(ctx, identityID)
+	user, err := u.repo.FindUserByOIDCIdentity(ctx, teamID, identityID)
 	if err != nil && !db.IsNotFound(err) {
 		return nil, err
 	}

--- a/backend/biz/team/usecase/oidc_test.go
+++ b/backend/biz/team/usecase/oidc_test.go
@@ -149,7 +149,7 @@ type oidcResolveRepoStub struct {
 	memberByEmail  *db.TeamMember
 }
 
-func (s *oidcResolveRepoStub) FindUserByOIDCIdentity(ctx context.Context, identityID string) (*db.User, error) {
+func (s *oidcResolveRepoStub) FindUserByOIDCIdentity(ctx context.Context, teamID uuid.UUID, identityID string) (*db.User, error) {
 	if s.userByIdentity != nil {
 		return s.userByIdentity, nil
 	}

--- a/backend/domain/team_oidc.go
+++ b/backend/domain/team_oidc.go
@@ -26,7 +26,7 @@ type TeamOIDCRepo interface {
 	GetConfig(ctx context.Context, teamID uuid.UUID) (*db.TeamOIDCConfig, error)
 	GetDefaultEnabledConfig(ctx context.Context) (*db.TeamOIDCConfig, error)
 	UpsertConfig(ctx context.Context, teamID uuid.UUID, req *SaveTeamOIDCConfigReq) (*db.TeamOIDCConfig, error)
-	FindUserByOIDCIdentity(ctx context.Context, identityID string) (*db.User, error)
+	FindUserByOIDCIdentity(ctx context.Context, teamID uuid.UUID, identityID string) (*db.User, error)
 	FindTeamMemberByEmail(ctx context.Context, teamID uuid.UUID, email string) (*db.TeamMember, error)
 	BindOIDCIdentity(ctx context.Context, userID uuid.UUID, external *OIDCExternalUser) error
 }


### PR DESCRIPTION
## 问题
管理员与普通成员使用相同邮箱时，OIDC 登录未校验账号角色，可能匹配或绑定到管理员账号；开启自动创建成员后也会因先命中管理员而跳过普通成员创建。

## 变更
- OIDC identity 查询限定当前团队的普通成员账号
- 团队邮箱匹配同时限定普通成员账号及成员角色
- 避免管理员账号阻断普通成员自动创建流程
- 增加同邮箱管理员与普通成员回归测试

## 验证
- `go test ./biz/team/...`
- `git diff --check`