### PR TITLE
修复私有 Gitee HTTP 地址被改为 HTTPS

### DIFF
--- a/backend/biz/git/usecase/token.go
+++ b/backend/biz/git/usecase/token.go
@@ -218,8 +218,11 @@ func (p *TokenProvider) refreshGitea(ctx context.Context, gi *db.GitIdentity) (s
 	return resp.AccessToken, resp.RefreshToken, time.Unix(resp.ExpiresAt(), 0), nil
 }
 
-func (p *TokenProvider) refreshGitee(_ context.Context, gi *db.GitIdentity) (string, string, time.Time, error) {
-	resp, err := oauth.RefreshGitee(gi.OauthRefreshToken)
+func (p *TokenProvider) refreshGitee(ctx context.Context, gi *db.GitIdentity) (string, string, time.Time, error) {
+	if err := p.guard.ValidateURL(ctx, gi.BaseURL); err != nil {
+		return "", "", time.Time{}, err
+	}
+	resp, err := oauth.RefreshGitee(gi.BaseURL, gi.OauthRefreshToken, p.proxies...)
 	if err != nil {
 		return "", "", time.Time{}, err
 	}

--- a/backend/biz/project/usecase/project.go
+++ b/backend/biz/project/usecase/project.go
@@ -40,7 +40,6 @@ type ProjectUsecase struct {
 	logger          *slog.Logger
 	cfg             *config.Config
 	gh              *github.Github
-	gte             *gitee.Gitee
 	gta             *gitea.Gitea
 	glDomestic      *gitlab.Gitlab
 	glInternational *gitlab.Gitlab
@@ -70,7 +69,6 @@ func NewProjectUsecase(i *do.Injector) (domain.ProjectUsecase, error) {
 		logger:          logger.With("module", "usecase.ProjectUsecase"),
 		cfg:             cfg,
 		gh:              github.NewGithub(logger, cfg),
-		gte:             gitee.NewGitee(cfg.Gitee.BaseURL, logger),
 		gta:             gitea.NewGitea(logger, cfg.GetGiteaBaseURL()),
 		glDomestic:      glDomestic,
 		glInternational: glInternational,
@@ -319,7 +317,12 @@ func (u *ProjectUsecase) getClient(ctx context.Context, p *db.Project) (domain.G
 
 	case consts.GitPlatformGitee:
 		owner, repo, _ := gitee.ParseRepoPath(p.RepoURL)
-		return u.gte, &ClientContext{
+		baseURL := gi.BaseURL
+		if baseURL == "" {
+			baseURL = u.cfg.Gitee.BaseURL
+		}
+		client := gitee.NewGitee(baseURL, u.logger)
+		return client, &ClientContext{
 			Owner: owner, Repo: repo, DefaultBranch: p.Branch, Token: token, IsOAuth: gi.OauthRefreshToken != "",
 		}, nil
 

--- a/backend/pkg/git/gitee/gitee.go
+++ b/backend/pkg/git/gitee/gitee.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -26,14 +27,11 @@ func NewGitee(baseURL string, logger *slog.Logger) *Gitee {
 	if baseURL == "" {
 		baseURL = "https://gitee.com"
 	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
 	return &Gitee{
 		logger:  logger.With("module", "gitee"),
 		baseURL: baseURL,
-		client: request.NewClient(
-			"https",
-			strings.TrimPrefix(baseURL, "https://"),
-			time.Second*30,
-		),
+		client:  newRequestClient(baseURL),
 	}
 }
 
@@ -49,11 +47,13 @@ func ParseRepoPath(repoURL string) (owner, repo string, err error) {
 
 func parseGiteeRepoPath(repoURL string) (string, string, error) {
 	repoURL = strings.TrimSuffix(repoURL, ".git")
-	repoURL = strings.TrimPrefix(repoURL, "https://gitee.com/")
-	repoURL = strings.TrimPrefix(repoURL, "http://gitee.com/")
-	repoURL = strings.TrimPrefix(repoURL, "git@gitee.com:")
+	if parsed, err := url.Parse(repoURL); err == nil && parsed.Host != "" {
+		repoURL = strings.TrimPrefix(parsed.Path, "/")
+	} else if _, path, ok := strings.Cut(repoURL, ":"); ok {
+		repoURL = path
+	}
 	parts := strings.Split(repoURL, "/")
-	if len(parts) < 2 {
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", fmt.Errorf("invalid gitee repo url: %s", repoURL)
 	}
 	return parts[0], parts[1], nil
@@ -112,7 +112,7 @@ func (g *Gitee) CheckPAT(ctx context.Context, token string, repoURL string) (boo
 
 // GetUserInfoByPAT 根据 PAT 获取用户信息
 func (g *Gitee) GetUserInfoByPAT(ctx context.Context, token string) (*domain.PlatformUserInfo, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://gitee.com/api/v5/user", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.baseURL+"/api/v5/user", nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
@@ -139,11 +139,7 @@ func (g *Gitee) ListUserReposByToken(baseURL, token string, page, perPage int) (
 	if perPage > 100 {
 		perPage = 100
 	}
-	client := request.NewClient(
-		"https",
-		strings.TrimPrefix(baseURL, "https://"),
-		time.Second*30,
-	)
+	client := newRequestClient(baseURL)
 	path := "/api/v5/user/repos"
 	query := map[string]string{
 		"access_token": token,
@@ -158,11 +154,12 @@ func (g *Gitee) ListUserReposByToken(baseURL, token string, page, perPage int) (
 	return *repos, nil
 }
 
+func newRequestClient(baseURL string) *request.Client {
+	parsed, _ := url.Parse(baseURL)
+	return request.NewClient(parsed.Scheme, parsed.Host, time.Second*30)
+}
+
 // newRequestClientForToken 使用指定 token 创建 request client
 func (g *Gitee) newRequestClientForToken(token string) *request.Client {
-	return request.NewClient(
-		"https",
-		"gitee.com",
-		time.Second*30,
-	)
+	return newRequestClient(g.baseURL)
 }

--- a/backend/pkg/git/gitee/gitee_test.go
+++ b/backend/pkg/git/gitee/gitee_test.go
@@ -1,0 +1,100 @@
+package gitee
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/chaitin/MonkeyCode/backend/domain"
+)
+
+func TestGiteeUsesConfiguredHTTPBaseURL(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v5/user/repos":
+			if got := r.URL.Query().Get("access_token"); got != "test-token" {
+				t.Errorf("access_token = %q, want test-token", got)
+			}
+			fmt.Fprint(w, `[{"full_name":"owner/repo","html_url":"http://example.com/owner/repo"}]`)
+		case "/api/v5/user":
+			if got := r.Header.Get("Authorization"); got != "token test-token" {
+				t.Errorf("Authorization = %q, want token test-token", got)
+			}
+			fmt.Fprint(w, `{"login":"alice"}`)
+		case "/api/v5/repos/owner/repo/branches":
+			if got := r.Header.Get("Authorization"); got != "token test-token" {
+				t.Errorf("Authorization = %q, want token test-token", got)
+			}
+			fmt.Fprint(w, `[{"name":"main"}]`)
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	client := NewGitee(server.URL+"/", logger)
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := client.BaseURL(); got != server.URL {
+		t.Fatalf("BaseURL() = %q, want %q", got, server.URL)
+	}
+	if got := client.client.GetScheme(); got != "http" {
+		t.Fatalf("client scheme = %q, want http", got)
+	}
+	if got := client.client.GetHost(); got != parsed.Host {
+		t.Fatalf("client host = %q, want %q", got, parsed.Host)
+	}
+
+	repos, err := client.Repositories(context.Background(), &domain.RepositoryOptions{Token: "test-token"})
+	if err != nil {
+		t.Fatalf("Repositories() error = %v", err)
+	}
+	if len(repos.Repositories) != 1 || repos.Repositories[0].FullName != "owner/repo" {
+		t.Fatalf("Repositories() = %+v", repos.Repositories)
+	}
+
+	user, err := client.UserInfo(context.Background(), "test-token")
+	if err != nil {
+		t.Fatalf("UserInfo() error = %v", err)
+	}
+	if user.Name != "alice" {
+		t.Fatalf("UserInfo().Name = %q, want alice", user.Name)
+	}
+
+	branches, err := client.Branches(context.Background(), &domain.BranchesOptions{
+		Token: "test-token", Owner: "owner", Repo: "repo", Page: 1, PerPage: 20,
+	})
+	if err != nil {
+		t.Fatalf("Branches() error = %v", err)
+	}
+	if len(branches) != 1 || branches[0].Name != "main" {
+		t.Fatalf("Branches() = %+v", branches)
+	}
+
+	if got := requests.Load(); got != 3 {
+		t.Fatalf("request count = %d, want 3", got)
+	}
+}
+
+func TestParseGiteeRepoPathWithPrivateInstance(t *testing.T) {
+	owner, repo, err := ParseRepoPath("http://gitee.internal/owner/repo.git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if owner != "owner" || repo != "repo" {
+		t.Fatalf("ParseRepoPath() = %q, %q; want owner, repo", owner, repo)
+	}
+}

--- a/backend/pkg/git/gitee/operation.go
+++ b/backend/pkg/git/gitee/operation.go
@@ -285,10 +285,10 @@ func (g *Gitee) GetRepoArchive(ctx context.Context, token, owner, repo, ref stri
 }
 
 // ListBranches 获取 Gitee 仓库分支列表
-func ListBranches(ctx context.Context, token, owner, repo string, page, perPage int, isOAuth bool) ([]*BranchInfo, error) {
+func ListBranches(ctx context.Context, baseURL, token, owner, repo string, page, perPage int, isOAuth bool) ([]*BranchInfo, error) {
 	client := &http.Client{Timeout: 30 * time.Second}
-	apiURL := fmt.Sprintf("https://gitee.com/api/v5/repos/%s/%s/branches?page=%d&per_page=%d",
-		url.PathEscape(owner), url.PathEscape(repo), page, perPage)
+	apiURL := fmt.Sprintf("%s/api/v5/repos/%s/%s/branches?page=%d&per_page=%d",
+		baseURL, url.PathEscape(owner), url.PathEscape(repo), page, perPage)
 	if isOAuth {
 		apiURL += "&access_token=" + url.QueryEscape(token)
 	}
@@ -474,7 +474,7 @@ func (g *Gitee) Archive(ctx context.Context, opts *domain.ArchiveOptions) (*doma
 
 // Branches 实现 GitPlatformClient 接口
 func (g *Gitee) Branches(ctx context.Context, opts *domain.BranchesOptions) ([]*domain.BranchInfo, error) {
-	resp, err := ListBranches(ctx, opts.Token, opts.Owner, opts.Repo, opts.Page, opts.PerPage, opts.IsOAuth)
+	resp, err := ListBranches(ctx, g.baseURL, opts.Token, opts.Owner, opts.Repo, opts.Page, opts.PerPage, opts.IsOAuth)
 	if err != nil {
 		return nil, err
 	}
@@ -496,8 +496,8 @@ func (g *Gitee) DeleteWebhook(ctx context.Context, opts *domain.WebhookOptions) 
 
 	// 分页查找匹配的 webhook
 	for page := 1; ; page++ {
-		apiURL := fmt.Sprintf("https://gitee.com/api/v5/repos/%s/%s/hooks?page=%d&per_page=100",
-			url.PathEscape(owner), url.PathEscape(repo), page)
+		apiURL := fmt.Sprintf("%s/api/v5/repos/%s/%s/hooks?page=%d&per_page=100",
+			g.baseURL, url.PathEscape(owner), url.PathEscape(repo), page)
 		if opts.IsOAuth {
 			apiURL += "&access_token=" + url.QueryEscape(opts.Token)
 		}
@@ -530,8 +530,8 @@ func (g *Gitee) DeleteWebhook(ctx context.Context, opts *domain.WebhookOptions) 
 		}
 		for _, hook := range hooks {
 			if hook.URL == opts.WebhookURL {
-				deleteURL := fmt.Sprintf("https://gitee.com/api/v5/repos/%s/%s/hooks/%d",
-					url.PathEscape(owner), url.PathEscape(repo), hook.ID)
+				deleteURL := fmt.Sprintf("%s/api/v5/repos/%s/%s/hooks/%d",
+					g.baseURL, url.PathEscape(owner), url.PathEscape(repo), hook.ID)
 				if opts.IsOAuth {
 					deleteURL += "?access_token=" + url.QueryEscape(opts.Token)
 				}
@@ -565,8 +565,8 @@ func (g *Gitee) CreateWebhook(ctx context.Context, opts *domain.CreateWebhookOpt
 	}
 
 	client := &http.Client{Timeout: 30 * time.Second}
-	apiURL := fmt.Sprintf("https://gitee.com/api/v5/repos/%s/%s/hooks",
-		url.PathEscape(owner), url.PathEscape(repo))
+	apiURL := fmt.Sprintf("%s/api/v5/repos/%s/%s/hooks",
+		g.baseURL, url.PathEscape(owner), url.PathEscape(repo))
 
 	payload := map[string]any{
 		"url":                   opts.WebhookURL,

--- a/backend/pkg/git/oauth/refresh.go
+++ b/backend/pkg/git/oauth/refresh.go
@@ -248,15 +248,18 @@ func ExchangeCnbCode(webBaseURL, clientID, clientSecret, code, redirectURI strin
 }
 
 // RefreshGitee 刷新 Gitee OAuth access_token（无需 client 凭证）
-func RefreshGitee(refreshToken string) (*GiteeTokenResponse, error) {
+func RefreshGitee(baseURL, refreshToken string, proxies ...string) (*GiteeTokenResponse, error) {
+	if baseURL == "" {
+		baseURL = "https://gitee.com"
+	}
 	params := url.Values{}
 	params.Add("grant_type", "refresh_token")
 	params.Add("refresh_token", refreshToken)
 
 	result, err := fetchWithProxyAndBody[GiteeTokenResponse](
-		http.MethodPost, "https://gitee.com/oauth/token",
+		http.MethodPost, strings.TrimSuffix(baseURL, "/")+"/oauth/token",
 		map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
-		strings.NewReader(params.Encode()),
+		strings.NewReader(params.Encode()), proxies...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("refresh gitee token: %w", err)

--- a/backend/pkg/git/oauth/refresh_test.go
+++ b/backend/pkg/git/oauth/refresh_test.go
@@ -1,0 +1,36 @@
+package oauth
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRefreshGiteeUsesConfiguredHTTPBaseURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/oauth/token" {
+			t.Errorf("path = %s, want /oauth/token", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("ParseForm() error = %v", err)
+		}
+		if got := r.Form.Get("refresh_token"); got != "refresh-token" {
+			t.Errorf("refresh_token = %q, want refresh-token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"access-token","refresh_token":"next-token","expires_in":3600}`)
+	}))
+	defer server.Close()
+
+	resp, err := RefreshGitee(server.URL+"/", "refresh-token")
+	if err != nil {
+		t.Fatalf("RefreshGitee() error = %v", err)
+	}
+	if resp.AccessToken != "access-token" || resp.RefreshToken != "next-token" {
+		t.Fatalf("RefreshGitee() = %+v", resp)
+	}
+}


### PR DESCRIPTION
## 变更说明

- 解析 Gitee `baseURL` 中的协议和主机，保留显式配置的 HTTP 协议
- 用户、仓库、分支、代码归档及 Webhook 请求统一使用身份配置的 `baseURL`
- 项目代码操作改为按 Git 身份创建 Gitee 客户端，避免复用全局地址
- Gitee OAuth Token 刷新改用身份配置的地址
- 支持解析私有 Gitee 实例的仓库 URL

## 验证

- `go test ./pkg/git/... ./biz/git/... ./biz/project/usecase`