### PR TITLE
修复路径风格 OSS 域名误判

### DIFF
--- a/backend/pkg/oss/oss.go
+++ b/backend/pkg/oss/oss.go
@@ -208,7 +208,7 @@ func (c *Client) WithAccessEndpoint(endpoint string) *Client {
 }
 
 func (c *Client) GetURL(prefix, filename string) string {
-	base := objectAccessBase(c.cfg)
+	base := objectAccessBase(c.cfg, c.pathStyle)
 	return appendURLPath(base, objectKey(prefix, filename))
 }
 
@@ -337,7 +337,7 @@ func appendURLPath(base, key string) string {
 	return u.String()
 }
 
-func objectAccessBase(cfg config.ObjectStorageConfig) string {
+func objectAccessBase(cfg config.ObjectStorageConfig, pathStyle bool) string {
 	base := strings.TrimRight(strings.TrimSpace(cfg.AccessEndpoint), "/")
 	if base == "" {
 		base = strings.TrimRight(cfg.Endpoint, "/")
@@ -350,7 +350,7 @@ func objectAccessBase(cfg config.ObjectStorageConfig) string {
 	if err != nil {
 		return strings.TrimRight(base, "/") + "/" + bucket
 	}
-	if endpointHostHasBucket(u, bucket) {
+	if !pathStyle && endpointHostHasBucket(u, bucket) {
 		return u.String()
 	}
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
@@ -389,7 +389,7 @@ func presignSigningEndpoint(cfg config.ObjectStorageConfig) string {
 }
 
 func (c *Client) publicPresignURL(signedURL, key string) string {
-	publicURL := appendURLPath(objectAccessBase(c.cfg), key)
+	publicURL := appendURLPath(objectAccessBase(c.cfg, c.pathStyle), key)
 	public, err := url.Parse(publicURL)
 	if err != nil {
 		return signedURL

--- a/backend/pkg/oss/oss_test.go
+++ b/backend/pkg/oss/oss_test.go
@@ -235,6 +235,33 @@ func TestPresignWithAccessEndpointKeepsPathPrefixOutsideSignature(t *testing.T) 
 	}
 }
 
+func TestPresignPathStyleKeepsBucketWhenDomainStartsWithBucket(t *testing.T) {
+	client, err := NewS3Compatible(context.Background(), config.ObjectStorageConfig{
+		Endpoint:        "http://internal:9000",
+		AccessEndpoint:  "http://monkeycode.citicsinfo.com/oss",
+		AccessKey:       "ak",
+		AccessKeySecret: "sk",
+		Bucket:          "monkeycode",
+	}, S3Option{ForcePathStyle: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	presign, err := client.Presign(context.Background(), "temp", "a.txt", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPath := "/oss/monkeycode/temp/a.txt"
+	for _, raw := range []string{presign.UploadURL, presign.AccessURL} {
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if u.Path != wantPath {
+			t.Fatalf("presign path = %q, want %q", u.Path, wantPath)
+		}
+	}
+}
+
 func signatureValue(t *testing.T, raw string) string {
 	t.Helper()
 	u, err := url.Parse(raw)


### PR DESCRIPTION
## 问题

当 S3 使用 Path Style，且公网访问域名的首段与 bucket 同名时，后端会误判域名已包含 bucket，生成缺少 bucket 路径的预签名 URL。代理转发后实际请求路径与签名路径不一致，OSS 返回 `SignatureDoesNotMatch`。

## 修复

- 将 Path Style 信息传入对象访问地址构造逻辑
- Path Style 模式下不再通过域名前缀判断 bucket 是否已包含
- 保持虚拟主机模式原有行为不变
- 补充域名前缀与 bucket 同名的回归测试

## 验证

```bash
cd backend
go test ./pkg/oss ./biz/uploader/handler/http/v1
```