### PR TITLE
新增 MonkeyAI 首版数据库迁移

### DIFF
--- a/monkeyai/backend/AGENTS.md
+++ b/monkeyai/backend/AGENTS.md
@@ -4,7 +4,7 @@
 
 - 每个 AI 默认只负责一个业务能力目录，例如 `internal/model` 或 `internal/skill`。
 - 业务代码、Admin API、Agent API、SQL、sqlc 生成结果和测试都保存在对应业务目录。
-- OpenAPI 源文件放在 `api/<feature>`，迁移使用包含 feature 名称的唯一 UTC 毫秒时间戳。
+- OpenAPI 源文件放在 `api/<feature>`，迁移使用 `migrate create -ext sql -dir migrations -seq <feature>_<action>` 生成默认六位序号，名称必须包含 feature。
 
 ## 共享集成点
 

--- a/monkeyai/backend/README.md
+++ b/monkeyai/backend/README.md
@@ -107,7 +107,7 @@ migrations/<唯一版本>_<feature>_*.sql
 - 路由使用 `chi/v5` 组织版本、调用方和中间件，处理器保持标准 `http.Handler` 接口。
 - HTTP DTO 不直接充当业务对象。
 - 测试与对应 Go 源码放在同一目录；暂不创建独立测试树。
-- 迁移文件使用唯一 UTC 毫秒时间戳 `<YYYYMMDDHHMMSSmmm>_<feature>_<action>.{up,down}.sql` 命名，创建后先检查版本未被其他并行任务占用；已经发布的迁移不可改写。
+- 迁移文件使用 `migrate create -ext sql -dir migrations -seq <feature>_<action>` 生成，采用默认六位递增序号。合并前必须检查序号未被其他分支占用；如有冲突，重新生成序号。已经发布的迁移不可改写。
 - 不创建 `pkg`、`utils` 或 `common`；出现明确复用对象后再决定归属。
 
 ## Go 编码原则

--- a/monkeyai/backend/migrations/000001_initial_create_schema.down.sql
+++ b/monkeyai/backend/migrations/000001_initial_create_schema.down.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+DROP TABLE audits;
+DROP TABLE credit_ledger_entries;
+DROP TABLE credit_accounts;
+DROP TABLE billing_quotas;
+DROP TABLE mcp_tool_calls;
+DROP TABLE model_calls;
+DROP TABLE sessions;
+DROP TABLE expert_skills;
+DROP TABLE expert_rules;
+DROP TABLE expert_mcp_tools;
+DROP TABLE resource_tags;
+DROP TABLE resource_access_grants;
+DROP TABLE experts;
+DROP TABLE mcp_tools;
+DROP TABLE mcp_server_credentials;
+DROP TABLE mcp_servers;
+DROP TABLE rules;
+DROP TABLE skills;
+DROP TABLE tags;
+DROP TABLE models;
+DROP TABLE settings;
+DROP TABLE group_users;
+DROP TABLE groups;
+DROP TABLE user_identities;
+DROP TABLE users;
+
+COMMIT;

--- a/monkeyai/backend/migrations/000001_initial_create_schema.up.sql
+++ b/monkeyai/backend/migrations/000001_initial_create_schema.up.sql
@@ -1,0 +1,645 @@
+BEGIN;
+
+CREATE TABLE users (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    name text NOT NULL,
+    email text NOT NULL,
+    avatar_url text,
+    password_hash text,
+    role text NOT NULL DEFAULT 'user',
+    status text NOT NULL DEFAULT 'active',
+    joined_at timestamptz NOT NULL DEFAULT now(),
+    disabled_at timestamptz,
+    last_login_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz,
+    CONSTRAINT users_role_check CHECK (role IN ('admin', 'user')),
+    CONSTRAINT users_status_check CHECK (status IN ('active', 'disabled')),
+    CONSTRAINT users_disabled_at_check CHECK (
+        (status = 'active' AND disabled_at IS NULL)
+        OR status = 'disabled'
+    )
+);
+
+CREATE UNIQUE INDEX users_email_active_key
+    ON users (lower(email))
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX users_status_idx
+    ON users (status)
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE user_identities (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES users (id),
+    provider text NOT NULL,
+    issuer text NOT NULL,
+    provider_subject text NOT NULL,
+    username text,
+    email text,
+    avatar_url text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz,
+    CONSTRAINT user_identities_provider_check CHECK (
+        provider IN ('github', 'google', 'microsoft', 'gitlab', 'oidc')
+    )
+);
+
+CREATE UNIQUE INDEX user_identities_subject_active_key
+    ON user_identities (provider, issuer, provider_subject)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX user_identities_user_idx
+    ON user_identities (user_id)
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE groups (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    parent_id uuid REFERENCES groups (id),
+    name text NOT NULL,
+    created_by_user_id uuid REFERENCES users (id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz,
+    CONSTRAINT groups_not_own_parent_check CHECK (parent_id IS DISTINCT FROM id)
+);
+
+CREATE UNIQUE INDEX groups_one_active_root_key
+    ON groups ((true))
+    WHERE parent_id IS NULL AND deleted_at IS NULL;
+
+CREATE INDEX groups_parent_idx
+    ON groups (parent_id)
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE group_users (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    group_id uuid NOT NULL REFERENCES groups (id),
+    user_id uuid NOT NULL REFERENCES users (id),
+    assigned_by_user_id uuid NOT NULL REFERENCES users (id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    removed_at timestamptz
+);
+
+CREATE UNIQUE INDEX group_users_active_key
+    ON group_users (group_id, user_id)
+    WHERE removed_at IS NULL;
+
+CREATE INDEX group_users_user_idx
+    ON group_users (user_id)
+    WHERE removed_at IS NULL;
+
+CREATE TABLE settings (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    key text NOT NULL UNIQUE,
+    value jsonb NOT NULL DEFAULT '{}'::jsonb,
+    schema_version integer NOT NULL DEFAULT 1,
+    updated_by_user_id uuid NOT NULL REFERENCES users (id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT settings_key_check CHECK (
+        key IN ('branding', 'authentication', 'email', 'billing')
+    ),
+    CONSTRAINT settings_value_check CHECK (jsonb_typeof(value) = 'object'),
+    CONSTRAINT settings_schema_version_check CHECK (schema_version > 0)
+);
+
+CREATE TABLE models (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    ownership_type text NOT NULL,
+    owner_user_id uuid NOT NULL REFERENCES users (id),
+    model_id text NOT NULL,
+    display_name text NOT NULL,
+    protocol text NOT NULL,
+    base_url text NOT NULL,
+    api_key text NOT NULL,
+    advanced_config jsonb NOT NULL,
+    credit_multiplier numeric(12, 6) NOT NULL DEFAULT 1,
+    enabled boolean NOT NULL DEFAULT true,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz,
+    CONSTRAINT models_ownership_type_check CHECK (ownership_type IN ('system', 'user')),
+    CONSTRAINT models_protocol_check CHECK (
+        protocol IN ('openai_chat_completions', 'openai_responses', 'anthropic')
+    ),
+    CONSTRAINT models_advanced_config_check CHECK (jsonb_typeof(advanced_config) = 'object'),
+    CONSTRAINT models_credit_multiplier_check CHECK (credit_multiplier > 0)
+);
+
+CREATE INDEX models_owner_idx
+    ON models (owner_user_id)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX models_enabled_idx
+    ON models (enabled)
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE tags (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    name text NOT NULL,
+    created_by_user_id uuid NOT NULL REFERENCES users (id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz
+);
+
+CREATE UNIQUE INDEX tags_name_active_key
+    ON tags (lower(name))
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE skills (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    ownership_type text NOT NULL,
+    owner_user_id uuid NOT NULL REFERENCES users (id),
+    name text NOT NULL,
+    description text NOT NULL,
+    instructions text NOT NULL,
+    package_file_name text NOT NULL,
+    package_s3_key text NOT NULL,
+    package_size_bytes bigint NOT NULL,
+    package_sha256 text NOT NULL,
+    file_count integer NOT NULL DEFAULT 0,
+    enabled boolean NOT NULL DEFAULT true,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz,
+    CONSTRAINT skills_ownership_type_check CHECK (ownership_type IN ('system', 'user')),
+    CONSTRAINT skills_package_size_check CHECK (package_size_bytes >= 0),
+    CONSTRAINT skills_file_count_check CHECK (file_count >= 0)
+);
+
+CREATE INDEX skills_owner_idx
+    ON skills (owner_user_id)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX skills_enabled_idx
+    ON skills (enabled)
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE rules (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    ownership_type text NOT NULL,
+    owner_user_id uuid NOT NULL REFERENCES users (id),
+    name text NOT NULL,
+    content text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz,
+    CONSTRAINT rules_ownership_type_check CHECK (ownership_type IN ('system', 'user'))
+);
+
+CREATE INDEX rules_owner_idx
+    ON rules (owner_user_id)
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE mcp_servers (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    ownership_type text NOT NULL,
+    owner_user_id uuid NOT NULL REFERENCES users (id),
+    name text NOT NULL,
+    description text NOT NULL,
+    url text NOT NULL,
+    authorization_mode text NOT NULL,
+    authorization_method text,
+    connection_status text NOT NULL DEFAULT 'unknown',
+    last_checked_at timestamptz,
+    last_error text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz,
+    CONSTRAINT mcp_servers_ownership_type_check CHECK (ownership_type IN ('system', 'user')),
+    CONSTRAINT mcp_servers_authorization_check CHECK (
+        (authorization_mode = 'none' AND authorization_method IS NULL)
+        OR (
+            authorization_mode IN ('independent', 'centralized')
+            AND authorization_method IN ('oauth', 'http_header')
+        )
+    ),
+    CONSTRAINT mcp_servers_connection_status_check CHECK (
+        connection_status IN ('connected', 'error', 'unknown')
+    )
+);
+
+CREATE INDEX mcp_servers_owner_idx
+    ON mcp_servers (owner_user_id)
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE mcp_server_credentials (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    server_id uuid NOT NULL REFERENCES mcp_servers (id),
+    user_id uuid REFERENCES users (id),
+    method text NOT NULL,
+    http_headers jsonb,
+    oauth_access_token text,
+    oauth_refresh_token text,
+    oauth_token_type text,
+    oauth_scopes text,
+    oauth_expires_at timestamptz,
+    status text NOT NULL DEFAULT 'pending',
+    authorized_at timestamptz,
+    last_error text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    revoked_at timestamptz,
+    CONSTRAINT mcp_server_credentials_method_check CHECK (method IN ('oauth', 'http_header')),
+    CONSTRAINT mcp_server_credentials_headers_check CHECK (
+        http_headers IS NULL OR jsonb_typeof(http_headers) = 'object'
+    ),
+    CONSTRAINT mcp_server_credentials_status_check CHECK (
+        status IN ('pending', 'authorized', 'expired', 'revoked', 'error')
+    )
+);
+
+CREATE UNIQUE INDEX mcp_server_credentials_centralized_active_key
+    ON mcp_server_credentials (server_id)
+    WHERE user_id IS NULL AND revoked_at IS NULL;
+
+CREATE UNIQUE INDEX mcp_server_credentials_independent_active_key
+    ON mcp_server_credentials (server_id, user_id)
+    WHERE user_id IS NOT NULL AND revoked_at IS NULL;
+
+CREATE INDEX mcp_server_credentials_user_idx
+    ON mcp_server_credentials (user_id)
+    WHERE user_id IS NOT NULL AND revoked_at IS NULL;
+
+CREATE TABLE mcp_tools (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    server_id uuid NOT NULL REFERENCES mcp_servers (id),
+    name text NOT NULL,
+    description text NOT NULL,
+    input_schema jsonb,
+    enabled boolean NOT NULL DEFAULT true,
+    credits_per_call numeric(24, 6) NOT NULL DEFAULT 0,
+    discovered_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz,
+    CONSTRAINT mcp_tools_input_schema_check CHECK (
+        input_schema IS NULL OR jsonb_typeof(input_schema) = 'object'
+    ),
+    CONSTRAINT mcp_tools_credits_per_call_check CHECK (credits_per_call >= 0)
+);
+
+CREATE UNIQUE INDEX mcp_tools_name_active_key
+    ON mcp_tools (server_id, name)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX mcp_tools_enabled_idx
+    ON mcp_tools (server_id, enabled)
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE experts (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    name text NOT NULL,
+    description text NOT NULL,
+    prompt text NOT NULL,
+    enabled boolean NOT NULL DEFAULT true,
+    created_by_user_id uuid NOT NULL REFERENCES users (id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz
+);
+
+CREATE INDEX experts_enabled_idx
+    ON experts (enabled)
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE resource_access_grants (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    resource_type text NOT NULL,
+    resource_id uuid NOT NULL,
+    user_id uuid REFERENCES users (id),
+    group_id uuid REFERENCES groups (id),
+    access_level text NOT NULL,
+    usage_requirement text NOT NULL DEFAULT 'optional',
+    granted_by_user_id uuid NOT NULL REFERENCES users (id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT resource_access_grants_resource_type_check CHECK (
+        resource_type IN ('model', 'skill', 'rule', 'mcp_server', 'expert')
+    ),
+    CONSTRAINT resource_access_grants_subject_check CHECK (
+        (user_id IS NOT NULL)::integer + (group_id IS NOT NULL)::integer = 1
+    ),
+    CONSTRAINT resource_access_grants_access_level_check CHECK (
+        access_level IN ('read_only', 'read_write')
+    ),
+    CONSTRAINT resource_access_grants_usage_requirement_check CHECK (
+        usage_requirement IN ('optional', 'required')
+        AND (usage_requirement = 'optional' OR resource_type = 'rule')
+    )
+);
+
+CREATE UNIQUE INDEX resource_access_grants_user_key
+    ON resource_access_grants (resource_type, resource_id, user_id)
+    WHERE user_id IS NOT NULL;
+
+CREATE UNIQUE INDEX resource_access_grants_group_key
+    ON resource_access_grants (resource_type, resource_id, group_id)
+    WHERE group_id IS NOT NULL;
+
+CREATE INDEX resource_access_grants_user_idx
+    ON resource_access_grants (user_id, resource_type)
+    WHERE user_id IS NOT NULL;
+
+CREATE INDEX resource_access_grants_group_idx
+    ON resource_access_grants (group_id, resource_type)
+    WHERE group_id IS NOT NULL;
+
+CREATE TABLE resource_tags (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    resource_type text NOT NULL,
+    resource_id uuid NOT NULL,
+    tag_id uuid NOT NULL REFERENCES tags (id),
+    assigned_by_user_id uuid NOT NULL REFERENCES users (id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT resource_tags_resource_type_check CHECK (
+        resource_type IN ('model', 'skill', 'rule', 'mcp_server', 'expert')
+    ),
+    CONSTRAINT resource_tags_resource_key UNIQUE (resource_type, resource_id, tag_id)
+);
+
+CREATE INDEX resource_tags_tag_idx ON resource_tags (tag_id);
+
+CREATE TABLE expert_mcp_tools (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    expert_id uuid NOT NULL REFERENCES experts (id),
+    tool_id uuid NOT NULL REFERENCES mcp_tools (id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT expert_mcp_tools_key UNIQUE (expert_id, tool_id)
+);
+
+CREATE INDEX expert_mcp_tools_tool_idx ON expert_mcp_tools (tool_id);
+
+CREATE TABLE expert_rules (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    expert_id uuid NOT NULL REFERENCES experts (id),
+    rule_id uuid NOT NULL REFERENCES rules (id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT expert_rules_key UNIQUE (expert_id, rule_id)
+);
+
+CREATE INDEX expert_rules_rule_idx ON expert_rules (rule_id);
+
+CREATE TABLE expert_skills (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    expert_id uuid NOT NULL REFERENCES experts (id),
+    skill_id uuid NOT NULL REFERENCES skills (id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT expert_skills_key UNIQUE (expert_id, skill_id)
+);
+
+CREATE INDEX expert_skills_skill_idx ON expert_skills (skill_id);
+
+CREATE TABLE sessions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_user_id uuid NOT NULL REFERENCES users (id),
+    expert_id uuid REFERENCES experts (id),
+    title text NOT NULL,
+    session_type text NOT NULL,
+    client_type text NOT NULL,
+    client_name text NOT NULL,
+    device_id text,
+    turn_count integer NOT NULL DEFAULT 0,
+    failure_code text,
+    failure_message text,
+    started_at timestamptz NOT NULL,
+    last_active_at timestamptz NOT NULL,
+    ended_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz,
+    CONSTRAINT sessions_session_type_check CHECK (
+        session_type IN ('conversation', 'workflow', 'tool', 'scheduled')
+    ),
+    CONSTRAINT sessions_client_type_check CHECK (
+        client_type IN ('desktop', 'web', 'extension', 'mobile')
+    ),
+    CONSTRAINT sessions_turn_count_check CHECK (turn_count >= 0),
+    CONSTRAINT sessions_time_check CHECK (
+        last_active_at >= started_at
+        AND (ended_at IS NULL OR ended_at >= started_at)
+    )
+);
+
+CREATE INDEX sessions_owner_started_idx
+    ON sessions (owner_user_id, started_at DESC)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX sessions_active_idx
+    ON sessions (last_active_at DESC)
+    WHERE ended_at IS NULL AND deleted_at IS NULL;
+
+CREATE INDEX sessions_expert_idx
+    ON sessions (expert_id, started_at DESC)
+    WHERE expert_id IS NOT NULL AND deleted_at IS NULL;
+
+CREATE TABLE model_calls (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    session_id uuid NOT NULL REFERENCES sessions (id),
+    user_id uuid NOT NULL REFERENCES users (id),
+    model_id uuid NOT NULL REFERENCES models (id),
+    request_id text,
+    status text NOT NULL,
+    input_tokens bigint NOT NULL DEFAULT 0,
+    cached_input_tokens bigint NOT NULL DEFAULT 0,
+    output_tokens bigint NOT NULL DEFAULT 0,
+    cache_hit boolean NOT NULL DEFAULT false,
+    response_duration_ms integer,
+    error_code text,
+    error_message text,
+    started_at timestamptz NOT NULL,
+    completed_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT model_calls_status_check CHECK (
+        status IN ('running', 'succeeded', 'failed', 'cancelled')
+    ),
+    CONSTRAINT model_calls_token_count_check CHECK (
+        input_tokens >= 0
+        AND cached_input_tokens >= 0
+        AND cached_input_tokens <= input_tokens
+        AND output_tokens >= 0
+    ),
+    CONSTRAINT model_calls_duration_check CHECK (
+        response_duration_ms IS NULL OR response_duration_ms >= 0
+    ),
+    CONSTRAINT model_calls_time_check CHECK (
+        completed_at IS NULL OR completed_at >= started_at
+    )
+);
+
+CREATE INDEX model_calls_session_started_idx
+    ON model_calls (session_id, started_at);
+
+CREATE INDEX model_calls_model_started_idx
+    ON model_calls (model_id, started_at DESC);
+
+CREATE INDEX model_calls_user_started_idx
+    ON model_calls (user_id, started_at DESC);
+
+CREATE TABLE mcp_tool_calls (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    session_id uuid NOT NULL REFERENCES sessions (id),
+    user_id uuid NOT NULL REFERENCES users (id),
+    server_id uuid NOT NULL REFERENCES mcp_servers (id),
+    tool_id uuid NOT NULL REFERENCES mcp_tools (id),
+    request_id text,
+    status text NOT NULL,
+    duration_ms integer,
+    error_code text,
+    error_message text,
+    started_at timestamptz NOT NULL,
+    completed_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT mcp_tool_calls_status_check CHECK (
+        status IN ('running', 'succeeded', 'failed', 'cancelled')
+    ),
+    CONSTRAINT mcp_tool_calls_duration_check CHECK (
+        duration_ms IS NULL OR duration_ms >= 0
+    ),
+    CONSTRAINT mcp_tool_calls_time_check CHECK (
+        completed_at IS NULL OR completed_at >= started_at
+    )
+);
+
+CREATE INDEX mcp_tool_calls_session_started_idx
+    ON mcp_tool_calls (session_id, started_at);
+
+CREATE INDEX mcp_tool_calls_tool_started_idx
+    ON mcp_tool_calls (tool_id, started_at DESC);
+
+CREATE INDEX mcp_tool_calls_user_started_idx
+    ON mcp_tool_calls (user_id, started_at DESC);
+
+CREATE INDEX mcp_tool_calls_server_started_idx
+    ON mcp_tool_calls (server_id, started_at DESC);
+
+CREATE TABLE billing_quotas (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    subject_type text NOT NULL,
+    group_id uuid REFERENCES groups (id),
+    user_id uuid REFERENCES users (id),
+    credits_per_cycle numeric(24, 6) NOT NULL,
+    updated_by_user_id uuid NOT NULL REFERENCES users (id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz,
+    CONSTRAINT billing_quotas_subject_check CHECK (
+        (subject_type = 'group' AND group_id IS NOT NULL AND user_id IS NULL)
+        OR (subject_type = 'user' AND user_id IS NOT NULL AND group_id IS NULL)
+    ),
+    CONSTRAINT billing_quotas_credits_check CHECK (credits_per_cycle >= 0)
+);
+
+CREATE UNIQUE INDEX billing_quotas_group_active_key
+    ON billing_quotas (group_id)
+    WHERE subject_type = 'group' AND deleted_at IS NULL;
+
+CREATE UNIQUE INDEX billing_quotas_user_active_key
+    ON billing_quotas (user_id)
+    WHERE subject_type = 'user' AND deleted_at IS NULL;
+
+CREATE TABLE credit_accounts (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES users (id) UNIQUE,
+    balance numeric(24, 6) NOT NULL DEFAULT 0,
+    period_start_at timestamptz NOT NULL,
+    period_end_at timestamptz NOT NULL,
+    last_refreshed_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT credit_accounts_period_check CHECK (period_end_at > period_start_at)
+);
+
+CREATE TABLE credit_ledger_entries (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id uuid NOT NULL REFERENCES credit_accounts (id),
+    user_id uuid NOT NULL REFERENCES users (id),
+    session_id uuid REFERENCES sessions (id),
+    entry_type text NOT NULL,
+    category text NOT NULL,
+    source_type text,
+    source_id uuid,
+    resource_type text,
+    resource_id uuid,
+    item_name text NOT NULL,
+    quantity bigint,
+    usage_unit text,
+    unit_credits numeric(24, 6),
+    credit_delta numeric(24, 6) NOT NULL,
+    balance_after numeric(24, 6) NOT NULL,
+    external_reference text,
+    metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+    occurred_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT credit_ledger_entries_entry_type_check CHECK (
+        entry_type IN ('charge', 'grant', 'refund', 'reset', 'adjustment')
+    ),
+    CONSTRAINT credit_ledger_entries_category_check CHECK (
+        category IN ('model', 'tool', 'other')
+    ),
+    CONSTRAINT credit_ledger_entries_source_type_check CHECK (
+        source_type IS NULL
+        OR source_type IN ('model_call', 'mcp_tool_call', 'quota_refresh', 'manual')
+    ),
+    CONSTRAINT credit_ledger_entries_resource_type_check CHECK (
+        resource_type IS NULL OR resource_type IN ('model', 'mcp_tool')
+    ),
+    CONSTRAINT credit_ledger_entries_usage_unit_check CHECK (
+        usage_unit IS NULL OR usage_unit IN ('tokens', 'calls')
+    ),
+    CONSTRAINT credit_ledger_entries_quantity_check CHECK (
+        quantity IS NULL OR quantity >= 0
+    ),
+    CONSTRAINT credit_ledger_entries_unit_credits_check CHECK (
+        unit_credits IS NULL OR unit_credits >= 0
+    ),
+    CONSTRAINT credit_ledger_entries_metadata_check CHECK (jsonb_typeof(metadata) = 'object')
+);
+
+CREATE INDEX credit_ledger_entries_account_occurred_idx
+    ON credit_ledger_entries (account_id, occurred_at DESC);
+
+CREATE INDEX credit_ledger_entries_user_occurred_idx
+    ON credit_ledger_entries (user_id, occurred_at DESC);
+
+CREATE INDEX credit_ledger_entries_session_idx
+    ON credit_ledger_entries (session_id)
+    WHERE session_id IS NOT NULL;
+
+CREATE INDEX credit_ledger_entries_source_idx
+    ON credit_ledger_entries (source_type, source_id)
+    WHERE source_type IS NOT NULL AND source_id IS NOT NULL;
+
+CREATE TABLE audits (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    actor_type text NOT NULL,
+    actor_user_id uuid REFERENCES users (id) ON DELETE SET NULL,
+    actor_name text NOT NULL,
+    actor_email text,
+    action text NOT NULL,
+    category text NOT NULL,
+    target_type text,
+    target_id uuid,
+    request_params jsonb NOT NULL DEFAULT '{}'::jsonb,
+    source_ip inet,
+    user_agent text,
+    result text NOT NULL,
+    error_message text,
+    occurred_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT audits_actor_type_check CHECK (actor_type IN ('user', 'system')),
+    CONSTRAINT audits_result_check CHECK (result IN ('success', 'failed')),
+    CONSTRAINT audits_request_params_check CHECK (jsonb_typeof(request_params) = 'object')
+);
+
+CREATE INDEX audits_occurred_idx ON audits (occurred_at DESC);
+CREATE INDEX audits_actor_occurred_idx ON audits (actor_user_id, occurred_at DESC);
+CREATE INDEX audits_category_occurred_idx ON audits (category, occurred_at DESC);
+CREATE INDEX audits_target_idx
+    ON audits (target_type, target_id)
+    WHERE target_type IS NOT NULL AND target_id IS NOT NULL;
+
+COMMIT;

--- a/monkeyai/backend/migrations/README.md
+++ b/monkeyai/backend/migrations/README.md
@@ -1,3 +1,5 @@
 # Migrations
 
-存放 PostgreSQL 迁移。文件使用唯一 UTC 毫秒时间戳 `<YYYYMMDDHHMMSSmmm>_<feature>_<action>.{up,down}.sql` 命名；并行任务创建后必须检查版本未被占用，已经发布的迁移只追加、不改写。
+存放 PostgreSQL 迁移。使用 `migrate create -ext sql -dir migrations -seq <feature>_<action>` 创建文件，采用默认六位递增序号。合并前必须检查序号未被其他分支占用；如有冲突，重新生成序号。已经发布的迁移只追加、不改写。
+
+可变长度字符串统一使用 `text`，不使用 `varchar` 设置长度上限；固定候选值通过 `CHECK` 约束限制。

--- a/monkeyai/backend/migrations/migrations_test.go
+++ b/monkeyai/backend/migrations/migrations_test.go
@@ -1,0 +1,59 @@
+package migrations
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var migrationName = regexp.MustCompile(`^(\d{6})_([a-z0-9]+(?:_[a-z0-9]+)*)\.(up|down)\.sql$`)
+
+func TestMigrations(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	versions := make(map[string]string)
+	pairs := make(map[string]map[string]bool)
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".sql" {
+			continue
+		}
+
+		matches := migrationName.FindStringSubmatch(entry.Name())
+		if matches == nil {
+			t.Errorf("迁移文件名不符合约定: %s", entry.Name())
+			continue
+		}
+
+		version, name, direction := matches[1], matches[2], matches[3]
+		if existing, ok := versions[version]; ok && existing != name {
+			t.Errorf("迁移版本 %s 同时用于 %s 和 %s", version, existing, name)
+		}
+		versions[version] = name
+
+		key := version + "_" + name
+		if pairs[key] == nil {
+			pairs[key] = make(map[string]bool)
+		}
+		pairs[key][direction] = true
+
+		content, err := os.ReadFile(entry.Name())
+		if err != nil {
+			t.Errorf("读取 %s: %v", entry.Name(), err)
+			continue
+		}
+		if strings.Contains(strings.ToLower(string(content)), "varchar") {
+			t.Errorf("%s 使用了 varchar，应统一使用 text", entry.Name())
+		}
+	}
+
+	for key, directions := range pairs {
+		if !directions["up"] || !directions["down"] {
+			t.Errorf("迁移 %s 的 up/down 文件不完整", key)
+		}
+	}
+}

--- a/monkeyai/design/admin-data-model.md
+++ b/monkeyai/design/admin-data-model.md
@@ -1,6 +1,6 @@
 # MonkeyAI Admin 数据模型设计
 
-> 状态：草案
+> 状态：草案，已生成第一版 PostgreSQL migration
 >
 > 数据库语义：PostgreSQL
 >
@@ -8,21 +8,21 @@
 
 ## 1. 目标与范围
 
-本文档定义 MonkeyAI Admin 所需的领域实体、实体关系和字段。字段类型使用 PostgreSQL 类型表达，方便后续直接转换为迁移，但本文档不包含 SQL。
+本文档定义 MonkeyAI Admin 所需的领域实体、实体关系和字段。字段类型使用 PostgreSQL 类型表达，并已转换为第一版 migration；本文档本身不包含 SQL。
 
-本阶段只确定：
+当前版本确定：
 
 - 表及字段；
 - 字段含义、可空性、默认值和候选值；
 - 实体之间的逻辑关系；
+- 首版主键、外键、唯一约束、检查约束和查询索引；
 - 敏感字段和统计事实的存储边界。
 
-本阶段不确定：
+后续版本仍需确定：
 
-- 主键、外键、唯一约束和检查约束；
-- 普通索引、唯一索引和全文索引；
 - 分区、归档和冷热数据策略；
-- 数据库迁移及与现有后端表的兼容方案。
+- 全文检索索引；
+- 与现有 MonkeyCode 后端表的复用、改造和数据迁移方案。
 
 ## 2. 核心建模决策
 
@@ -117,6 +117,7 @@ flowchart LR
 | 约定 | 说明 |
 | --- | --- |
 | ID | 实体 ID 使用 `uuid`，默认由应用或 PostgreSQL 生成。 |
+| 字符串 | 可变长度字符串统一使用 `text`，不在数据库层设置长度上限。 |
 | 时间 | 业务时间统一使用 `timestamptz`，以 UTC 保存、按用户时区展示。 |
 | 金额/积分 | 积分使用 `numeric(24,6)`，避免浮点误差。 |
 | 计数 | Token、调用次数等可能持续增长的计数使用 `bigint`。 |
@@ -134,12 +135,12 @@ flowchart LR
 | 字段 | PostgreSQL 类型 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | 用户 ID。 |
-| `name` | `varchar(255)` | 是 | 无 | 用户显示名称。 |
-| `email` | `varchar(320)` | 是 | 无 | 用户主邮箱，也是默认登录标识。 |
+| `name` | `text` | 是 | 无 | 用户显示名称。 |
+| `email` | `text` | 是 | 无 | 用户主邮箱，也是默认登录标识。 |
 | `avatar_url` | `text` | 否 | `NULL` | 用户头像地址。 |
 | `password_hash` | `text` | 否 | `NULL` | 密码哈希；仅使用 OAuth 或邮箱验证码时可为空。 |
-| `role` | `varchar(32)` | 是 | `user` | 系统角色：`admin`、`user`。 |
-| `status` | `varchar(32)` | 是 | `active` | 用户状态：`active`、`disabled`。 |
+| `role` | `text` | 是 | `user` | 系统角色：`admin`、`user`。 |
+| `status` | `text` | 是 | `active` | 用户状态：`active`、`disabled`。 |
 | `joined_at` | `timestamptz` | 是 | 当前时间 | 成为系统用户的时间。 |
 | `disabled_at` | `timestamptz` | 否 | `NULL` | 被禁用时间。 |
 | `last_login_at` | `timestamptz` | 否 | `NULL` | 最近一次成功登录时间。 |
@@ -155,11 +156,11 @@ flowchart LR
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | 第三方身份 ID。 |
 | `user_id` | `uuid` | 是 | 无 | 对应用户 ID。 |
-| `provider` | `varchar(32)` | 是 | 无 | 提供方：`github`、`google`、`microsoft`、`gitlab`、`oidc`。 |
+| `provider` | `text` | 是 | 无 | 提供方：`github`、`google`、`microsoft`、`gitlab`、`oidc`。 |
 | `issuer` | `text` | 是 | 无 | 第三方身份的签发方或命名空间；OIDC 使用 `iss`，内置 OAuth 提供方使用系统定义的固定值。 |
 | `provider_subject` | `text` | 是 | 无 | 提供方返回的稳定用户标识，与 `issuer` 共同确定第三方身份。 |
-| `username` | `varchar(255)` | 否 | `NULL` | 提供方侧账号名称。 |
-| `email` | `varchar(320)` | 否 | `NULL` | 提供方返回的邮箱快照。 |
+| `username` | `text` | 否 | `NULL` | 提供方侧账号名称。 |
+| `email` | `text` | 否 | `NULL` | 提供方返回的邮箱快照。 |
 | `avatar_url` | `text` | 否 | `NULL` | 提供方返回的头像地址。 |
 | `created_at` | `timestamptz` | 是 | 当前时间 | 首次绑定时间。 |
 | `updated_at` | `timestamptz` | 是 | 当前时间 | 最近同步时间。 |
@@ -173,7 +174,7 @@ flowchart LR
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | 分组 ID；根分组和管理员分组使用系统预设 ID。 |
 | `parent_id` | `uuid` | 否 | `NULL` | 父分组 ID；唯一根分组为空，其他分组必须有父分组。 |
-| `name` | `varchar(255)` | 是 | 无 | 分组显示名称。 |
+| `name` | `text` | 是 | 无 | 分组显示名称。 |
 | `created_by_user_id` | `uuid` | 否 | `NULL` | 创建者用户 ID；系统初始化的根分组和管理员分组为空。 |
 | `created_at` | `timestamptz` | 是 | 当前时间 | 创建时间。 |
 | `updated_at` | `timestamptz` | 是 | 当前时间 | 名称或层级最近更新时间。 |
@@ -201,7 +202,7 @@ flowchart LR
 | 字段 | PostgreSQL 类型 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | 设置记录 ID。 |
-| `key` | `varchar(64)` | 是 | 无 | 配置域标识：`branding`、`authentication`、`email`、`billing`。 |
+| `key` | `text` | 是 | 无 | 配置域标识：`branding`、`authentication`、`email`、`billing`。 |
 | `value` | `jsonb` | 是 | 空对象 | 该配置域的完整明文配置，结构见下文。 |
 | `schema_version` | `integer` | 是 | `1` | `value` 的结构版本。 |
 | `updated_by_user_id` | `uuid` | 是 | 无 | 最近修改者用户 ID。 |
@@ -266,12 +267,12 @@ flowchart LR
 | 字段 | PostgreSQL 类型 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | 资源授权 ID。 |
-| `resource_type` | `varchar(32)` | 是 | 无 | 被授权资源类型：`model`、`skill`、`rule`、`mcp_server`、`expert`。 |
+| `resource_type` | `text` | 是 | 无 | 被授权资源类型：`model`、`skill`、`rule`、`mcp_server`、`expert`。 |
 | `resource_id` | `uuid` | 是 | 无 | 被授权资源 ID，与 `resource_type` 共同定位具体资源。 |
 | `user_id` | `uuid` | 否 | `NULL` | 被授权用户 ID；与 `group_id` 必须且只能填写一个。 |
 | `group_id` | `uuid` | 否 | `NULL` | 被授权分组 ID；与 `user_id` 必须且只能填写一个，并覆盖其所有后代分组用户。 |
-| `access_level` | `varchar(32)` | 是 | 无 | 访问级别：`read_only`、`read_write`。 |
-| `usage_requirement` | `varchar(32)` | 是 | `optional` | 使用要求：`optional`、`required`；`required` 仅用于系统规则，表示规则必须应用且被授权者不能自行移除。 |
+| `access_level` | `text` | 是 | 无 | 访问级别：`read_only`、`read_write`。 |
+| `usage_requirement` | `text` | 是 | `optional` | 使用要求：`optional`、`required`；`required` 仅用于系统规则，表示规则必须应用且被授权者不能自行移除。 |
 | `granted_by_user_id` | `uuid` | 是 | 无 | 执行分享的资源所有者或管理员用户 ID。 |
 | `created_at` | `timestamptz` | 是 | 当前时间 | 首次授权时间。 |
 | `updated_at` | `timestamptz` | 是 | 当前时间 | 访问级别最近更新时间。 |
@@ -283,11 +284,11 @@ flowchart LR
 | 字段 | PostgreSQL 类型 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | 模型配置 ID。 |
-| `ownership_type` | `varchar(32)` | 是 | 无 | 所有权：`system`、`user`。 |
+| `ownership_type` | `text` | 是 | 无 | 所有权：`system`、`user`。 |
 | `owner_user_id` | `uuid` | 是 | 无 | 关联用户 ID；系统模型记录创建它的管理员，个人模型记录当前所有者。 |
-| `model_id` | `varchar(255)` | 是 | 无 | 上游模型标识，例如 `gpt-5`。 |
-| `display_name` | `varchar(255)` | 是 | 无 | 管理端和客户端显示名称。 |
-| `protocol` | `varchar(64)` | 是 | 无 | 调用协议：`openai_chat_completions`、`openai_responses`、`anthropic`。 |
+| `model_id` | `text` | 是 | 无 | 上游模型标识，例如 `gpt-5`。 |
+| `display_name` | `text` | 是 | 无 | 管理端和客户端显示名称。 |
+| `protocol` | `text` | 是 | 无 | 调用协议：`openai_chat_completions`、`openai_responses`、`anthropic`。 |
 | `base_url` | `text` | 是 | 无 | 上游 API 基础地址。 |
 | `api_key` | `text` | 是 | 无 | 模型 API Key，明文保存。 |
 | `advanced_config` | `jsonb` | 是 | 无 | 模型能力和协议相关高级配置，当前结构见下文。 |
@@ -312,7 +313,7 @@ flowchart LR
 | 字段 | PostgreSQL 类型 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | 标签 ID。 |
-| `name` | `varchar(64)` | 是 | 无 | 标签名称。 |
+| `name` | `text` | 是 | 无 | 标签名称。 |
 | `created_by_user_id` | `uuid` | 是 | 无 | 创建者用户 ID。 |
 | `created_at` | `timestamptz` | 是 | 当前时间 | 创建时间。 |
 | `updated_at` | `timestamptz` | 是 | 当前时间 | 最近更新时间。 |
@@ -323,15 +324,15 @@ flowchart LR
 | 字段 | PostgreSQL 类型 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | 技能 ID。 |
-| `ownership_type` | `varchar(32)` | 是 | 无 | 所有权：`system`、`user`。 |
+| `ownership_type` | `text` | 是 | 无 | 所有权：`system`、`user`。 |
 | `owner_user_id` | `uuid` | 是 | 无 | 关联用户 ID；系统技能记录创建它的管理员，个人技能记录当前所有者。 |
-| `name` | `varchar(255)` | 是 | 无 | 技能名称，对应技能包中的规范名称。 |
+| `name` | `text` | 是 | 无 | 技能名称，对应技能包中的规范名称。 |
 | `description` | `text` | 是 | 无 | 技能用途说明。 |
 | `instructions` | `text` | 是 | 无 | 技能主指令内容。 |
-| `package_file_name` | `varchar(512)` | 是 | 无 | 导入时的技能包原始文件名。 |
+| `package_file_name` | `text` | 是 | 无 | 导入时的技能包原始文件名。 |
 | `package_s3_key` | `text` | 是 | 无 | 技能包在 S3 Bucket 中的 Object Key。 |
 | `package_size_bytes` | `bigint` | 是 | 无 | 技能包字节数。 |
-| `package_sha256` | `varchar(64)` | 是 | 无 | 技能包内容的 SHA-256 摘要。 |
+| `package_sha256` | `text` | 是 | 无 | 技能包内容的 SHA-256 摘要。 |
 | `file_count` | `integer` | 是 | `0` | 技能包内文件数量。 |
 | `enabled` | `boolean` | 是 | `true` | 是否可被 Agent 使用。 |
 | `created_at` | `timestamptz` | 是 | 当前时间 | 创建时间。 |
@@ -345,7 +346,7 @@ flowchart LR
 | 字段 | PostgreSQL 类型 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | 关系 ID。 |
-| `resource_type` | `varchar(32)` | 是 | 无 | 资源类型：`model`、`skill`、`rule`、`mcp_server`、`expert`。 |
+| `resource_type` | `text` | 是 | 无 | 资源类型：`model`、`skill`、`rule`、`mcp_server`、`expert`。 |
 | `resource_id` | `uuid` | 是 | 无 | 资源 ID，与 `resource_type` 共同定位具体资源。 |
 | `tag_id` | `uuid` | 是 | 无 | 标签 ID。 |
 | `assigned_by_user_id` | `uuid` | 是 | 无 | 执行标签关联的用户 ID。 |
@@ -356,9 +357,9 @@ flowchart LR
 | 字段 | PostgreSQL 类型 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | 规则 ID。 |
-| `ownership_type` | `varchar(32)` | 是 | 无 | 所有权：`system`、`user`。 |
+| `ownership_type` | `text` | 是 | 无 | 所有权：`system`、`user`。 |
 | `owner_user_id` | `uuid` | 是 | 无 | 关联用户 ID；系统规则记录创建它的管理员，个人规则记录当前所有者。 |
-| `name` | `varchar(255)` | 是 | 无 | 规则名称。 |
+| `name` | `text` | 是 | 无 | 规则名称。 |
 | `content` | `text` | 是 | 无 | 规则指令正文。 |
 | `created_at` | `timestamptz` | 是 | 当前时间 | 创建时间。 |
 | `updated_at` | `timestamptz` | 是 | 当前时间 | 最近更新时间。 |
@@ -369,14 +370,14 @@ flowchart LR
 | 字段 | PostgreSQL 类型 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | MCP 服务 ID。 |
-| `ownership_type` | `varchar(32)` | 是 | 无 | 所有权：`system`、`user`。 |
+| `ownership_type` | `text` | 是 | 无 | 所有权：`system`、`user`。 |
 | `owner_user_id` | `uuid` | 是 | 无 | 关联用户 ID；系统 MCP 服务记录创建它的管理员，个人 MCP 服务记录当前所有者。 |
-| `name` | `varchar(255)` | 是 | 无 | MCP 服务显示名称。 |
+| `name` | `text` | 是 | 无 | MCP 服务显示名称。 |
 | `description` | `text` | 是 | 无 | MCP 服务用途说明。 |
 | `url` | `text` | 是 | 无 | MCP 服务连接地址。 |
-| `authorization_mode` | `varchar(32)` | 是 | 无 | 授权模式：`none`、`independent`、`centralized`。 |
-| `authorization_method` | `varchar(32)` | 否 | `NULL` | 授权方式：`oauth`、`http_header`；无需授权时为空。 |
-| `connection_status` | `varchar(32)` | 是 | `unknown` | 最近检测状态：`connected`、`error`、`unknown`。 |
+| `authorization_mode` | `text` | 是 | 无 | 授权模式：`none`、`independent`、`centralized`。 |
+| `authorization_method` | `text` | 否 | `NULL` | 授权方式：`oauth`、`http_header`；无需授权时为空。 |
+| `connection_status` | `text` | 是 | `unknown` | 最近检测状态：`connected`、`error`、`unknown`。 |
 | `last_checked_at` | `timestamptz` | 否 | `NULL` | 最近一次连接检测时间。 |
 | `last_error` | `text` | 否 | `NULL` | 最近一次连接失败原因。 |
 | `created_at` | `timestamptz` | 是 | 当前时间 | 创建时间。 |
@@ -392,14 +393,14 @@ flowchart LR
 | `id` | `uuid` | 是 | 自动生成 | 凭据 ID。 |
 | `server_id` | `uuid` | 是 | 无 | MCP 服务 ID。 |
 | `user_id` | `uuid` | 否 | `NULL` | 独立授权的用户 ID；集中授权为空。 |
-| `method` | `varchar(32)` | 是 | 无 | 凭据类型：`oauth`、`http_header`。 |
+| `method` | `text` | 是 | 无 | 凭据类型：`oauth`、`http_header`。 |
 | `http_headers` | `jsonb` | 否 | `NULL` | HTTP Header 集合，包含的认证信息以明文保存。 |
 | `oauth_access_token` | `text` | 否 | `NULL` | OAuth Access Token，明文保存。 |
 | `oauth_refresh_token` | `text` | 否 | `NULL` | OAuth Refresh Token，明文保存。 |
-| `oauth_token_type` | `varchar(32)` | 否 | `NULL` | OAuth Token 类型，例如 `Bearer`。 |
+| `oauth_token_type` | `text` | 否 | `NULL` | OAuth Token 类型，例如 `Bearer`。 |
 | `oauth_scopes` | `text` | 否 | `NULL` | OAuth Scope 快照。 |
 | `oauth_expires_at` | `timestamptz` | 否 | `NULL` | Access Token 过期时间。 |
-| `status` | `varchar(32)` | 是 | `pending` | 状态：`pending`、`authorized`、`expired`、`revoked`、`error`。 |
+| `status` | `text` | 是 | `pending` | 状态：`pending`、`authorized`、`expired`、`revoked`、`error`。 |
 | `authorized_at` | `timestamptz` | 否 | `NULL` | 最近授权成功时间。 |
 | `last_error` | `text` | 否 | `NULL` | 最近授权失败原因。 |
 | `created_at` | `timestamptz` | 是 | 当前时间 | 创建时间。 |
@@ -412,7 +413,7 @@ flowchart LR
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | MCP 工具 ID。 |
 | `server_id` | `uuid` | 是 | 无 | 所属 MCP 服务 ID。 |
-| `name` | `varchar(255)` | 是 | 无 | MCP 服务声明的工具名称。 |
+| `name` | `text` | 是 | 无 | MCP 服务声明的工具名称。 |
 | `description` | `text` | 是 | 无 | MCP 服务声明的工具说明。 |
 | `input_schema` | `jsonb` | 否 | `NULL` | MCP 工具输入 JSON Schema。 |
 | `enabled` | `boolean` | 是 | `true` | 是否允许调用该工具。 |
@@ -426,7 +427,7 @@ flowchart LR
 | 字段 | PostgreSQL 类型 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | 专家 ID。 |
-| `name` | `varchar(255)` | 是 | 无 | 专家显示名称。 |
+| `name` | `text` | 是 | 无 | 专家显示名称。 |
 | `description` | `text` | 是 | 无 | 专家用途说明。 |
 | `prompt` | `text` | 是 | 无 | 专家角色和工作方式提示词。 |
 | `enabled` | `boolean` | 是 | `true` | 是否允许用户使用该专家。 |
@@ -474,12 +475,12 @@ flowchart LR
 | `owner_user_id` | `uuid` | 是 | 无 | 发起会话的用户 ID。 |
 | `expert_id` | `uuid` | 否 | `NULL` | 会话使用的专家 ID。 |
 | `title` | `text` | 是 | 无 | 会话标题。 |
-| `session_type` | `varchar(32)` | 是 | 无 | 类型：`conversation`、`workflow`、`tool`、`scheduled`。 |
-| `client_type` | `varchar(32)` | 是 | 无 | 客户端类型：`desktop`、`web`、`extension`、`mobile`。 |
-| `client_name` | `varchar(255)` | 是 | 无 | 客户端显示名称或版本名称。 |
-| `device_id` | `varchar(255)` | 否 | `NULL` | 发起会话的设备标识。 |
+| `session_type` | `text` | 是 | 无 | 类型：`conversation`、`workflow`、`tool`、`scheduled`。 |
+| `client_type` | `text` | 是 | 无 | 客户端类型：`desktop`、`web`、`extension`、`mobile`。 |
+| `client_name` | `text` | 是 | 无 | 客户端显示名称或版本名称。 |
+| `device_id` | `text` | 否 | `NULL` | 发起会话的设备标识。 |
 | `turn_count` | `integer` | 是 | `0` | 会话内已产生的对话轮次数。 |
-| `failure_code` | `varchar(128)` | 否 | `NULL` | 会话异常结束代码。 |
+| `failure_code` | `text` | 否 | `NULL` | 会话异常结束代码。 |
 | `failure_message` | `text` | 否 | `NULL` | 会话异常结束说明。 |
 | `started_at` | `timestamptz` | 是 | 无 | 会话开始时间。 |
 | `last_active_at` | `timestamptz` | 是 | 无 | 最近活动时间。 |
@@ -496,14 +497,14 @@ flowchart LR
 | `session_id` | `uuid` | 是 | 无 | 所属会话 ID。 |
 | `user_id` | `uuid` | 是 | 无 | 产生调用的用户 ID。 |
 | `model_id` | `uuid` | 是 | 无 | 被调用的模型配置 ID。 |
-| `request_id` | `varchar(255)` | 否 | `NULL` | 上游或链路请求 ID。 |
-| `status` | `varchar(32)` | 是 | 无 | 状态：`running`、`succeeded`、`failed`、`cancelled`。 |
+| `request_id` | `text` | 否 | `NULL` | 上游或链路请求 ID。 |
+| `status` | `text` | 是 | 无 | 状态：`running`、`succeeded`、`failed`、`cancelled`。 |
 | `input_tokens` | `bigint` | 是 | `0` | 输入 Token 数。 |
 | `cached_input_tokens` | `bigint` | 是 | `0` | 命中缓存的输入 Token 数。 |
 | `output_tokens` | `bigint` | 是 | `0` | 输出 Token 数。 |
 | `cache_hit` | `boolean` | 是 | `false` | 本次请求是否命中缓存。 |
 | `response_duration_ms` | `integer` | 否 | `NULL` | 请求总耗时，单位毫秒。 |
-| `error_code` | `varchar(128)` | 否 | `NULL` | 上游或内部错误代码。 |
+| `error_code` | `text` | 否 | `NULL` | 上游或内部错误代码。 |
 | `error_message` | `text` | 否 | `NULL` | 脱敏后的失败说明。 |
 | `started_at` | `timestamptz` | 是 | 无 | 调用开始时间。 |
 | `completed_at` | `timestamptz` | 否 | `NULL` | 调用结束时间。 |
@@ -518,10 +519,10 @@ flowchart LR
 | `user_id` | `uuid` | 是 | 无 | 产生调用的用户 ID。 |
 | `server_id` | `uuid` | 是 | 无 | MCP 服务 ID。 |
 | `tool_id` | `uuid` | 是 | 无 | MCP 工具 ID。 |
-| `request_id` | `varchar(255)` | 否 | `NULL` | 链路请求 ID。 |
-| `status` | `varchar(32)` | 是 | 无 | 状态：`running`、`succeeded`、`failed`、`cancelled`。 |
+| `request_id` | `text` | 否 | `NULL` | 链路请求 ID。 |
+| `status` | `text` | 是 | 无 | 状态：`running`、`succeeded`、`failed`、`cancelled`。 |
 | `duration_ms` | `integer` | 否 | `NULL` | 调用耗时，单位毫秒。 |
-| `error_code` | `varchar(128)` | 否 | `NULL` | MCP 或内部错误代码。 |
+| `error_code` | `text` | 否 | `NULL` | MCP 或内部错误代码。 |
 | `error_message` | `text` | 否 | `NULL` | 脱敏后的失败说明。 |
 | `started_at` | `timestamptz` | 是 | 无 | 调用开始时间。 |
 | `completed_at` | `timestamptz` | 否 | `NULL` | 调用结束时间。 |
@@ -536,7 +537,7 @@ flowchart LR
 | 字段 | PostgreSQL 类型 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | 额度设置 ID。 |
-| `subject_type` | `varchar(32)` | 是 | 无 | 设置对象：`group`、`user`。 |
+| `subject_type` | `text` | 是 | 无 | 设置对象：`group`、`user`。 |
 | `group_id` | `uuid` | 否 | `NULL` | 分组额度对应的分组 ID。 |
 | `user_id` | `uuid` | 否 | `NULL` | 用户额度对应的用户 ID。 |
 | `credits_per_cycle` | `numeric(24,6)` | 是 | 无 | 每个刷新周期分配的积分。 |
@@ -570,19 +571,19 @@ flowchart LR
 | `account_id` | `uuid` | 是 | 无 | 积分账户 ID。 |
 | `user_id` | `uuid` | 是 | 无 | 被计费用户 ID。 |
 | `session_id` | `uuid` | 否 | `NULL` | 与会话相关时对应的会话 ID。 |
-| `entry_type` | `varchar(32)` | 是 | 无 | 流水类型：`charge`、`grant`、`refund`、`reset`、`adjustment`。 |
-| `category` | `varchar(32)` | 是 | 无 | 费用分类：`model`、`tool`、`other`。 |
-| `source_type` | `varchar(32)` | 否 | `NULL` | 来源：`model_call`、`mcp_tool_call`、`quota_refresh`、`manual`。 |
+| `entry_type` | `text` | 是 | 无 | 流水类型：`charge`、`grant`、`refund`、`reset`、`adjustment`。 |
+| `category` | `text` | 是 | 无 | 费用分类：`model`、`tool`、`other`。 |
+| `source_type` | `text` | 否 | `NULL` | 来源：`model_call`、`mcp_tool_call`、`quota_refresh`、`manual`。 |
 | `source_id` | `uuid` | 否 | `NULL` | 来源事实记录 ID。 |
-| `resource_type` | `varchar(32)` | 否 | `NULL` | 被计价资源类型：`model`、`mcp_tool`。 |
+| `resource_type` | `text` | 否 | `NULL` | 被计价资源类型：`model`、`mcp_tool`。 |
 | `resource_id` | `uuid` | 否 | `NULL` | 被计价资源 ID。 |
-| `item_name` | `varchar(512)` | 是 | 无 | 计费项名称快照，例如“GPT-5 · Input”。 |
+| `item_name` | `text` | 是 | 无 | 计费项名称快照，例如“GPT-5 · Input”。 |
 | `quantity` | `bigint` | 否 | `NULL` | 计量数量。 |
-| `usage_unit` | `varchar(32)` | 否 | `NULL` | 计量单位：`tokens`、`calls`。 |
+| `usage_unit` | `text` | 否 | `NULL` | 计量单位：`tokens`、`calls`。 |
 | `unit_credits` | `numeric(24,6)` | 否 | `NULL` | 生成该流水时采用的单位积分价格。 |
 | `credit_delta` | `numeric(24,6)` | 是 | 无 | 积分变动量；扣费为负，发放或退款为正。 |
 | `balance_after` | `numeric(24,6)` | 是 | 无 | 该笔变动完成后的账户余额。 |
-| `external_reference` | `varchar(255)` | 否 | `NULL` | 远程计费平台返回的交易标识。 |
+| `external_reference` | `text` | 否 | `NULL` | 远程计费平台返回的交易标识。 |
 | `metadata` | `jsonb` | 是 | 空对象 | 不参与核心计算的扩展快照。 |
 | `occurred_at` | `timestamptz` | 是 | 无 | 业务变动发生时间。 |
 | `created_at` | `timestamptz` | 是 | 当前时间 | 流水写入时间。 |
@@ -596,18 +597,18 @@ flowchart LR
 | 字段 | PostgreSQL 类型 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
 | `id` | `uuid` | 是 | 自动生成 | 审计日志 ID。 |
-| `actor_type` | `varchar(32)` | 是 | 无 | 操作者类型：`user`、`system`。 |
+| `actor_type` | `text` | 是 | 无 | 操作者类型：`user`、`system`。 |
 | `actor_user_id` | `uuid` | 否 | `NULL` | 用户操作时的用户 ID。 |
-| `actor_name` | `varchar(255)` | 是 | 无 | 操作者名称快照。 |
-| `actor_email` | `varchar(320)` | 否 | `NULL` | 操作者邮箱快照。 |
-| `action` | `varchar(128)` | 是 | 无 | 操作标识，例如 `add_model`、`disable_user`。 |
-| `category` | `varchar(32)` | 是 | 无 | 分类：`model`、`user`、`security`、`settings`。 |
-| `target_type` | `varchar(64)` | 否 | `NULL` | 被操作对象类型。 |
+| `actor_name` | `text` | 是 | 无 | 操作者名称快照。 |
+| `actor_email` | `text` | 否 | `NULL` | 操作者邮箱快照。 |
+| `action` | `text` | 是 | 无 | 操作标识，例如 `add_model`、`disable_user`。 |
+| `category` | `text` | 是 | 无 | 分类：`model`、`user`、`security`、`settings`。 |
+| `target_type` | `text` | 否 | `NULL` | 被操作对象类型。 |
 | `target_id` | `uuid` | 否 | `NULL` | 被操作对象 ID。 |
 | `request_params` | `jsonb` | 是 | 空对象 | 脱敏后的请求参数。 |
 | `source_ip` | `inet` | 否 | `NULL` | 请求来源 IP。 |
 | `user_agent` | `text` | 否 | `NULL` | 请求 User-Agent。 |
-| `result` | `varchar(32)` | 是 | 无 | 执行结果：`success`、`failed`。 |
+| `result` | `text` | 是 | 无 | 执行结果：`success`、`failed`。 |
 | `error_message` | `text` | 否 | `NULL` | 脱敏后的失败原因。 |
 | `occurred_at` | `timestamptz` | 是 | 无 | 操作发生时间。 |
 | `created_at` | `timestamptz` | 是 | 当前时间 | 日志写入时间。 |
@@ -633,11 +634,10 @@ flowchart LR
 
 ## 13. 后续阶段
 
-下一阶段应在本文档评审通过后补充：
+第一版 migration 已按当前模型生成。后续评审与迭代应继续完成：
 
-1. 主键、外键、唯一约束和候选值检查约束；
-2. 结合管理端查询条件设计索引；
-3. 明确与现有 MonkeyCode 后端表的复用、改造和迁移关系；
-4. 明确高频事实表的保留周期、分区和聚合策略；
-5. 评估敏感信息加密、轮换和脱敏方案；
-6. 生成正式 PostgreSQL migration。
+1. 结合管理端实际查询继续校准索引；
+2. 明确与现有 MonkeyCode 后端表的复用、改造和迁移关系；
+3. 明确高频事实表的保留周期、分区和聚合策略；
+4. 评估敏感信息加密、轮换和脱敏方案；
+5. 根据评审结果追加 migration，不改写已发布版本。


### PR DESCRIPTION
## 概要

- 使用 migrate create -seq 生成 000001 首版迁移
- 创建 MonkeyAI Admin 第一期所需的 25 张 PostgreSQL 表、约束和查询索引
- 可变长度字符串统一使用 text，并同步数据模型和迁移规范
- 增加迁移命名、版本冲突、up/down 配对和 varchar 禁用检查

## 验证

- go test ./...
- go vet ./...
- PostgreSQL 17 实际执行 up：创建 25 张表，varchar 列为 0
- 超过旧长度上限的字符串写入成功
- PostgreSQL 17 实际执行 down：业务表数量恢复为 0