### PR TITLE
实现 MonkeyAI Agent 认证、用户设置与配置推送

### DIFF
--- a/monkeyai/admin/src/App.tsx
+++ b/monkeyai/admin/src/App.tsx
@@ -18,6 +18,7 @@ import { BillingSettingsPage } from "@/pages/billing-settings-page"
 import { ExpertsPage } from "@/pages/experts-page"
 import { KnowledgeBasesPage } from "@/pages/knowledge-bases-page"
 import { LoginPage } from "@/pages/login-page"
+import { ClientLoginPage } from "@/pages/client-login-page"
 import { MembersAndGroupsPage } from "@/pages/members-and-groups-page"
 import { ModelStatisticsPage } from "@/pages/model-statistics-page"
 import { ModelsPage } from "@/pages/models-page"
@@ -31,21 +32,25 @@ import { TaskStatisticsPage } from "@/pages/task-statistics-page"
 import { ToolsPage } from "@/pages/tools-page"
 
 function RootRedirect() {
-  const { isAuthenticated } = useAuth()
+  const { isLoading, user } = useAuth()
+
+  if (isLoading) return <PageLoading />
 
   return (
     <Navigate
-      to={isAuthenticated ? DEFAULT_CONSOLE_PATH : LOGIN_PATH}
+      to={user?.role === "admin" ? DEFAULT_CONSOLE_PATH : LOGIN_PATH}
       replace
     />
   )
 }
 
 function RequireAuth() {
-  const { isAuthenticated } = useAuth()
+  const { isLoading, user } = useAuth()
   const location = useLocation()
 
-  if (!isAuthenticated) {
+  if (isLoading) return <PageLoading />
+
+  if (user?.role !== "admin") {
     return (
       <Navigate
         to={LOGIN_PATH}
@@ -60,6 +65,17 @@ function RequireAuth() {
   return <Outlet />
 }
 
+function PageLoading() {
+  return (
+    <main
+      className="flex min-h-svh items-center justify-center bg-background text-sm text-muted-foreground"
+      role="status"
+    >
+      正在检查登录状态…
+    </main>
+  )
+}
+
 export function App() {
   const { i18n, t } = useTranslation()
 
@@ -72,6 +88,7 @@ export function App() {
       <Routes>
         <Route path="/" element={<RootRedirect />} />
         <Route path={LOGIN_PATH} element={<LoginPage />} />
+        <Route path="/client-login" element={<ClientLoginPage />} />
         <Route element={<RequireAuth />}>
           <Route path={CONSOLE_PATH} element={<Dashboard />}>
             <Route

--- a/monkeyai/admin/src/components/app-sidebar.tsx
+++ b/monkeyai/admin/src/components/app-sidebar.tsx
@@ -23,18 +23,14 @@ import {
   Wallet01Icon,
 } from "@hugeicons/core-free-icons"
 import { CONSOLE_ROUTES, DEFAULT_CONSOLE_PATH } from "@/lib/routes"
-
-const user = {
-  name: "MonkeyAI Admin",
-  email: "admin@monkeyai.local",
-  avatar: "/placeholder.svg",
-}
+import { useAuth } from "@/hooks/use-auth"
 
 export function AppSidebar({
   onLogout,
   ...props
 }: React.ComponentProps<typeof Sidebar> & { onLogout: () => void }) {
   const { i18n, t } = useTranslation()
+  const { user } = useAuth()
   const navMain = [
     {
       title: t("sections.statistics"),
@@ -166,7 +162,14 @@ export function AppSidebar({
         <NavMain items={navMain} />
       </SidebarContent>
       <SidebarFooter>
-        <NavUser user={user} onLogout={onLogout} />
+        <NavUser
+          user={{
+            name: user?.name ?? "MonkeyAI Admin",
+            email: user?.email ?? "",
+            avatar: user?.avatar_url ?? "/placeholder.svg",
+          }}
+          onLogout={onLogout}
+        />
       </SidebarFooter>
     </Sidebar>
   )

--- a/monkeyai/admin/src/components/auth-provider.tsx
+++ b/monkeyai/admin/src/components/auth-provider.tsx
@@ -1,27 +1,57 @@
-import { useCallback, useMemo, useState, type ReactNode } from "react"
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react"
 
-import { AuthContext } from "@/lib/auth-context"
-
-const AUTH_STORAGE_KEY = "monkeyai-admin-authenticated"
+import { api } from "@/lib/api"
+import { AuthContext, type AuthUser } from "@/lib/auth-context"
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [isAuthenticated, setIsAuthenticated] = useState(
-    () => localStorage.getItem(AUTH_STORAGE_KEY) === "true"
-  )
+  const [user, setUser] = useState<AuthUser | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
 
-  const login = useCallback(() => {
-    localStorage.setItem(AUTH_STORAGE_KEY, "true")
-    setIsAuthenticated(true)
+  const refresh = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const session = await api<{
+        authenticated: boolean
+        user: AuthUser | null
+      }>("/api/auth/v1/session")
+      setUser(session.authenticated ? session.user : null)
+    } catch {
+      setUser(null)
+    } finally {
+      setIsLoading(false)
+    }
   }, [])
 
-  const logout = useCallback(() => {
-    localStorage.removeItem(AUTH_STORAGE_KEY)
-    setIsAuthenticated(false)
+  useEffect(() => {
+    api<{
+      authenticated: boolean
+      user: AuthUser | null
+    }>("/api/auth/v1/session")
+      .then((session) => setUser(session.authenticated ? session.user : null))
+      .catch(() => setUser(null))
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  const logout = useCallback(async () => {
+    await api<void>("/api/auth/v1/logout", { method: "POST" })
+    setUser(null)
   }, [])
 
   const value = useMemo(
-    () => ({ isAuthenticated, login, logout }),
-    [isAuthenticated, login, logout]
+    () => ({
+      isAuthenticated: user !== null,
+      isLoading,
+      user,
+      refresh,
+      logout,
+    }),
+    [isLoading, logout, refresh, user]
   )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/monkeyai/admin/src/components/dashboard.tsx
+++ b/monkeyai/admin/src/components/dashboard.tsx
@@ -33,8 +33,8 @@ export function Dashboard() {
   const navigate = useNavigate()
   const currentPage = getConsolePage(location.pathname) ?? CONSOLE_PAGES[0]
 
-  const handleLogout = () => {
-    logout()
+  const handleLogout = async () => {
+    await logout()
     navigate(LOGIN_PATH, { replace: true })
   }
 

--- a/monkeyai/admin/src/lib/api.ts
+++ b/monkeyai/admin/src/lib/api.ts
@@ -1,0 +1,30 @@
+export class ApiError extends Error {
+  status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.status = status
+  }
+}
+
+export async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(path, {
+    credentials: "include",
+    ...init,
+    headers: {
+      ...(init?.body ? { "Content-Type": "application/json" } : {}),
+      ...init?.headers,
+    },
+  })
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null)
+    const message =
+      payload?.error?.message ?? payload?.error_description ?? "请求失败"
+    throw new ApiError(response.status, message)
+  }
+  if (response.status === 204) {
+    return undefined as T
+  }
+  return response.json() as Promise<T>
+}

--- a/monkeyai/admin/src/lib/auth-context.ts
+++ b/monkeyai/admin/src/lib/auth-context.ts
@@ -2,8 +2,19 @@ import { createContext } from "react"
 
 export type AuthContextValue = {
   isAuthenticated: boolean
-  login: () => void
-  logout: () => void
+  isLoading: boolean
+  user: AuthUser | null
+  refresh: () => Promise<void>
+  logout: () => Promise<void>
+}
+
+export type AuthUser = {
+  id: string
+  name: string
+  email: string
+  avatar_url?: string
+  role: "admin" | "user"
+  status: "active" | "disabled"
 }
 
 export const AuthContext = createContext<AuthContextValue | undefined>(

--- a/monkeyai/admin/src/pages/billing-settings-page.tsx
+++ b/monkeyai/admin/src/pages/billing-settings-page.tsx
@@ -6,7 +6,7 @@ import {
 } from "@hugeicons/core-free-icons"
 import { HugeiconsIcon } from "@hugeicons/react"
 import type { TFunction } from "i18next"
-import { useState, type FormEvent } from "react"
+import { useEffect, useState, type FormEvent } from "react"
 import { useTranslation } from "react-i18next"
 
 import { Badge } from "@/components/ui/badge"
@@ -61,6 +61,7 @@ import {
   AUTHORIZATION_MEMBERS,
   type AuthorizationGroupNode,
 } from "@/lib/authorization-groups"
+import { api } from "@/lib/api"
 
 type RefreshCycle = "daily" | "weekly" | "monthly"
 type ChargingMode = "local" | "remote"
@@ -135,7 +136,7 @@ function QuotaSummary({
   return (
     <div className="relative flex min-h-8 min-w-0 items-center justify-end">
       <span
-        className="w-full truncate text-end text-xs text-muted-foreground data-[inherited=true]:text-muted-foreground/40 group-hover/quota-row:opacity-0"
+        className="w-full truncate text-end text-xs text-muted-foreground group-hover/quota-row:opacity-0 data-[inherited=true]:text-muted-foreground/40"
         data-inherited={inherited}
       >
         {summary}
@@ -458,6 +459,7 @@ export function BillingSettingsPage() {
   )
   const [quotaSettingsSaved, setQuotaSettingsSaved] = useState(false)
   const [quotaTarget, setQuotaTarget] = useState<QuotaTarget | null>(null)
+  const [settingsError, setSettingsError] = useState("")
   const modelPricingDirty =
     JSON.stringify(modelPricing) !== JSON.stringify(savedModelPricing)
   const refreshSettingsDirty =
@@ -478,6 +480,91 @@ export function BillingSettingsPage() {
   const quotaCycleLabel = t(
     `pages.billingSettings.quotaRefresh.cycleLabels.${refreshSettings.refreshCycle}`
   )
+
+  useEffect(() => {
+    api<{
+      value: Record<string, unknown>
+    }>("/api/admin/v1/settings/billing")
+      .then(({ value }) => {
+        const pricing = {
+          inputTokenCredits: String(
+            value.input_credits_per_million_tokens ?? "100"
+          ),
+          cachedInputTokenCredits: String(
+            value.cached_input_credits_per_million_tokens ?? "20"
+          ),
+          outputTokenCredits: String(
+            value.output_credits_per_million_tokens ?? "400"
+          ),
+        }
+        const refresh = {
+          refreshCycle: String(
+            value.quota_refresh_cycle ?? "monthly"
+          ) as RefreshCycle,
+        }
+        const charging = {
+          mode: String(value.charging_mode ?? "local") as ChargingMode,
+          baizhiBaseUrl: String(value.remote_billing_base_url ?? ""),
+          baizhiApiKey: String(value.remote_billing_api_key ?? ""),
+        }
+        const quotas = {
+          rootCredits: String(value.root_credits ?? "15000"),
+          quotaOverrides:
+            (value.quota_overrides as Partial<Record<string, string>>) ?? {},
+        }
+        setModelPricing(pricing)
+        setSavedModelPricing(pricing)
+        setRefreshSettings(refresh)
+        setSavedRefreshSettings(refresh)
+        setChargingMethod(charging)
+        setSavedChargingMethod(charging)
+        setQuotaSettings(quotas)
+        setSavedQuotaSettings(quotas)
+      })
+      .catch((reason: { status?: number; message: string }) => {
+        if (reason.status !== 404) setSettingsError(reason.message)
+      })
+  }, [])
+
+  const saveBilling = async (values?: {
+    pricing?: ModelPricingSettings
+    refresh?: RefreshSettings
+    charging?: ChargingMethodSettings
+    quotas?: QuotaSettings
+  }) => {
+    const pricing = values?.pricing ?? modelPricing
+    const refresh = values?.refresh ?? refreshSettings
+    const charging = values?.charging ?? chargingMethod
+    const quotas = values?.quotas ?? quotaSettings
+    setSettingsError("")
+    try {
+      await api("/api/admin/v1/settings/billing", {
+        method: "PUT",
+        body: JSON.stringify({
+          schema_version: 1,
+          value: {
+            input_credits_per_million_tokens: Number(pricing.inputTokenCredits),
+            cached_input_credits_per_million_tokens: Number(
+              pricing.cachedInputTokenCredits
+            ),
+            output_credits_per_million_tokens: Number(
+              pricing.outputTokenCredits
+            ),
+            quota_refresh_cycle: refresh.refreshCycle,
+            charging_mode: charging.mode,
+            remote_billing_base_url: charging.baizhiBaseUrl || null,
+            remote_billing_api_key: charging.baizhiApiKey || null,
+            root_credits: Number(quotas.rootCredits),
+            quota_overrides: quotas.quotaOverrides,
+          },
+        }),
+      })
+      return true
+    } catch (reason) {
+      setSettingsError((reason as Error).message)
+      return false
+    }
+  }
 
   const updateModelPricing = <Key extends keyof ModelPricingSettings>(
     key: Key,
@@ -523,6 +610,14 @@ export function BillingSettingsPage() {
 
   return (
     <section className="grid flex-1 gap-4 p-4 pt-0 xl:grid-cols-2">
+      {settingsError && (
+        <p
+          className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive xl:col-span-2"
+          role="alert"
+        >
+          {settingsError}
+        </p>
+      )}
       <Card>
         <CardHeader>
           <CardTitle>{t("pages.billingSettings.groupQuota.title")}</CardTitle>
@@ -538,9 +633,11 @@ export function BillingSettingsPage() {
             <Button
               disabled={!quotaSettingsDirty || !quotaSettings.rootCredits}
               type="button"
-              onClick={() => {
-                setSavedQuotaSettings(quotaSettings)
-                setQuotaSettingsSaved(true)
+              onClick={async () => {
+                if (await saveBilling({ quotas: quotaSettings })) {
+                  setSavedQuotaSettings(quotaSettings)
+                  setQuotaSettingsSaved(true)
+                }
               }}
             >
               {t("pages.billingSettings.save")}
@@ -585,9 +682,11 @@ export function BillingSettingsPage() {
               <Button
                 disabled={!refreshSettingsDirty}
                 type="button"
-                onClick={() => {
-                  setSavedRefreshSettings(refreshSettings)
-                  setRefreshSettingsSaved(true)
+                onClick={async () => {
+                  if (await saveBilling({ refresh: refreshSettings })) {
+                    setSavedRefreshSettings(refreshSettings)
+                    setRefreshSettingsSaved(true)
+                  }
                 }}
               >
                 {t("pages.billingSettings.save")}
@@ -648,9 +747,11 @@ export function BillingSettingsPage() {
               <Button
                 disabled={!modelPricingDirty}
                 type="button"
-                onClick={() => {
-                  setSavedModelPricing(modelPricing)
-                  setModelPricingSaved(true)
+                onClick={async () => {
+                  if (await saveBilling({ pricing: modelPricing })) {
+                    setSavedModelPricing(modelPricing)
+                    setModelPricingSaved(true)
+                  }
                 }}
               >
                 {t("pages.billingSettings.save")}
@@ -742,9 +843,11 @@ export function BillingSettingsPage() {
                       !chargingMethod.baizhiApiKey))
                 }
                 type="button"
-                onClick={() => {
-                  setSavedChargingMethod(chargingMethod)
-                  setChargingMethodSaved(true)
+                onClick={async () => {
+                  if (await saveBilling({ charging: chargingMethod })) {
+                    setSavedChargingMethod(chargingMethod)
+                    setChargingMethodSaved(true)
+                  }
                 }}
               >
                 {t("pages.billingSettings.save")}
@@ -765,9 +868,7 @@ export function BillingSettingsPage() {
                   }}
                 >
                   <TabsList
-                    aria-label={t(
-                      "pages.billingSettings.chargingMethod.mode"
-                    )}
+                    aria-label={t("pages.billingSettings.chargingMethod.mode")}
                     className="w-full"
                   >
                     <TabsTrigger value="local">

--- a/monkeyai/admin/src/pages/client-login-page.tsx
+++ b/monkeyai/admin/src/pages/client-login-page.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useRef, useState } from "react"
+import {
+  ArrowRight01Icon,
+  CheckmarkCircle02Icon,
+  ComputerIcon,
+} from "@hugeicons/core-free-icons"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { useSearchParams } from "react-router-dom"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { api } from "@/lib/api"
+import type { AuthUser } from "@/lib/auth-context"
+
+type Provider = { id: string; provider: string; name: string }
+type ClientRequest = {
+  request_id: string
+  client: { client_id: string; name: string; redirect_uri: string }
+  authenticated: boolean
+  user: AuthUser | null
+  providers: Provider[]
+}
+
+const callbackErrorMessages: Record<string, string> = {
+  oauth_callback: "登录被取消或回调参数已经失效，请重新发起登录。",
+  provider_unavailable: "该登录方式当前不可用，请选择其他方式。",
+  oauth_exchange: "第三方身份验证失败，请重试。",
+  user_unavailable: "当前账号不能登录，请联系管理员。",
+  admin_password_required: "管理员账号只能使用密码登录管理后台。",
+  session_failed: "登录会话创建失败，请重试。",
+}
+
+export function ClientLoginPage() {
+  const [search] = useSearchParams()
+  const requestId = search.get("request_id") ?? ""
+  const callbackError = search.get("error") ?? ""
+  const [request, setRequest] = useState<ClientRequest | null>(null)
+  const [launchURL, setLaunchURL] = useState("")
+  const [error, setError] = useState("")
+  const completionStarted = useRef(false)
+  const requestError = !requestId
+    ? callbackErrorMessages[callbackError] ?? "缺少授权请求参数。"
+    : callbackError
+      ? callbackErrorMessages[callbackError] ?? "登录失败，请重试。"
+      : error
+
+  useEffect(() => {
+    if (!requestId) return
+    api<ClientRequest>(
+      `/api/auth/v1/client-requests/${encodeURIComponent(requestId)}`
+    )
+      .then(setRequest)
+      .catch((reason: Error) => setError(reason.message))
+  }, [requestId])
+
+  useEffect(() => {
+    if (!request?.authenticated || completionStarted.current) return
+    completionStarted.current = true
+    api<{ launch_url: string }>(
+      `/api/auth/v1/client-requests/${encodeURIComponent(requestId)}/complete`,
+      { method: "POST" }
+    )
+      .then(({ launch_url }) => {
+        setLaunchURL(launch_url)
+        window.location.assign(launch_url)
+      })
+      .catch((reason: Error) => setError(reason.message))
+  }, [request, requestId])
+
+  const startLogin = (provider: Provider) => {
+    const query = new URLSearchParams({ request_id: requestId })
+    window.location.assign(
+      `/api/auth/v1/oauth/${encodeURIComponent(provider.id)}/start?${query}`
+    )
+  }
+
+  return (
+    <main className="relative flex min-h-svh items-center justify-center overflow-hidden bg-background px-4 py-12">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_10%,hsl(var(--primary)/0.14),transparent_48%)]" />
+      <Card className="relative w-full max-w-md border-border/80 bg-card/95 shadow-2xl shadow-black/5 backdrop-blur">
+        <CardHeader className="items-center text-center">
+          <div className="mb-3 flex size-12 items-center justify-center rounded-2xl bg-primary text-primary-foreground">
+            <HugeiconsIcon
+              icon={launchURL ? CheckmarkCircle02Icon : ComputerIcon}
+              strokeWidth={2}
+            />
+          </div>
+          <CardTitle className="text-2xl">
+            {launchURL
+              ? "登录成功"
+              : `登录 ${request?.client.name ?? "MonkeyAI"}`}
+          </CardTitle>
+          <CardDescription>
+            {launchURL
+              ? "正在返回应用，你可以关闭此页面。"
+              : "浏览器只负责验证身份，授权结果会安全返回应用。"}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {!request && !requestError && (
+            <p
+              className="py-5 text-center text-sm text-muted-foreground"
+              role="status"
+            >
+              正在检查登录状态…
+            </p>
+          )}
+          {requestError && (
+            <p
+              className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+              role="alert"
+            >
+              {requestError}
+            </p>
+          )}
+          {request &&
+            !request.authenticated &&
+            request.providers.map((provider) => (
+              <Button
+                key={provider.id}
+                type="button"
+                variant="outline"
+                size="lg"
+                className="min-h-11 w-full cursor-pointer justify-between transition-colors duration-200"
+                onClick={() => startLogin(provider)}
+              >
+                <span>使用 {provider.name} 登录</span>
+                <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} />
+              </Button>
+            ))}
+          {request &&
+            !request.authenticated &&
+            request.providers.length === 0 && (
+              <p className="rounded-lg border border-dashed p-4 text-center text-sm text-muted-foreground">
+                当前没有可用的登录方式，请联系管理员。
+              </p>
+            )}
+          {request?.authenticated && !launchURL && !requestError && (
+            <p
+              className="py-5 text-center text-sm text-muted-foreground"
+              role="status"
+            >
+              身份已确认，正在生成一次性授权码…
+            </p>
+          )}
+          {launchURL && (
+            <Button
+              render={<a href={launchURL} />}
+              size="lg"
+              className="w-full cursor-pointer"
+            >
+              打开 {request?.client.name ?? "MonkeyAI"}
+            </Button>
+          )}
+          <p className="pt-3 text-center text-xs text-muted-foreground">
+            授权码仅可使用一次，并将在 2 分钟后失效。
+          </p>
+        </CardContent>
+      </Card>
+    </main>
+  )
+}

--- a/monkeyai/admin/src/pages/login-page.tsx
+++ b/monkeyai/admin/src/pages/login-page.tsx
@@ -1,37 +1,126 @@
+import { useState, type FormEvent } from "react"
+import { LockKeyIcon } from "@hugeicons/core-free-icons"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { useTranslation } from "react-i18next"
 import { Navigate, useLocation, useNavigate } from "react-router-dom"
 
 import { LanguageToggle } from "@/components/language-toggle"
-import { LoginForm } from "@/components/login-form"
 import { ThemeToggle } from "@/components/theme-toggle"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
 import { useAuth } from "@/hooks/use-auth"
+import { api } from "@/lib/api"
+import type { AuthUser } from "@/lib/auth-context"
 import { DEFAULT_CONSOLE_PATH } from "@/lib/routes"
 
 export function LoginPage() {
-  const { isAuthenticated, login } = useAuth()
+  const { t } = useTranslation()
+  const { isLoading, refresh, user } = useAuth()
   const location = useLocation()
   const navigate = useNavigate()
-
-  if (isAuthenticated) {
-    return <Navigate to={DEFAULT_CONSOLE_PATH} replace />
-  }
-
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState("")
   const destination =
     (location.state as { from?: string } | null)?.from ?? DEFAULT_CONSOLE_PATH
 
+  if (!isLoading && user?.role === "admin") {
+    return <Navigate to={destination} replace />
+  }
+
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setSubmitting(true)
+    setError("")
+    try {
+      await api<AuthUser>("/api/auth/v1/admin/login", {
+        method: "POST",
+        body: JSON.stringify({ email, password }),
+      })
+      await refresh()
+      navigate(destination, { replace: true })
+    } catch (reason) {
+      setError((reason as Error).message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
   return (
-    <main className="flex min-h-svh flex-col items-center justify-center bg-muted p-4">
+    <main className="relative flex min-h-svh items-center justify-center overflow-hidden bg-background px-4 py-12">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,hsl(var(--primary)/0.12),transparent_46%)]" />
       <div className="absolute end-4 top-4 flex items-center gap-2">
         <LanguageToggle />
         <ThemeToggle />
       </div>
-      <div className="w-full max-w-sm md:max-w-4xl">
-        <LoginForm
-          onLogin={() => {
-            login()
-            navigate(destination, { replace: true })
-          }}
-        />
-      </div>
+      <Card className="relative w-full max-w-md border-border/80 bg-card/95 shadow-2xl shadow-black/5 backdrop-blur">
+        <CardHeader className="items-center pb-2 text-center">
+          <div className="mb-3 flex size-12 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-sm">
+            <HugeiconsIcon icon={LockKeyIcon} strokeWidth={2} />
+          </div>
+          <CardTitle className="text-2xl">{t("login.title")}</CardTitle>
+          <CardDescription>{t("login.subtitle")}</CardDescription>
+        </CardHeader>
+        <CardContent className="pt-5">
+          <form onSubmit={submit} noValidate>
+            <FieldGroup>
+              <Field>
+                <FieldLabel htmlFor="admin-email">
+                  {t("login.email")}
+                </FieldLabel>
+                <Input
+                  id="admin-email"
+                  type="email"
+                  autoComplete="username"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  required
+                  autoFocus
+                />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="admin-password">
+                  {t("login.password")}
+                </FieldLabel>
+                <Input
+                  id="admin-password"
+                  type="password"
+                  autoComplete="current-password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  required
+                />
+              </Field>
+              {error && (
+                <p
+                  className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+                  role="alert"
+                >
+                  {error}
+                </p>
+              )}
+              <Button
+                type="submit"
+                size="lg"
+                className="w-full cursor-pointer"
+                disabled={submitting || !email.trim() || !password}
+                aria-busy={submitting}
+              >
+                {submitting ? `${t("login.submit")}…` : t("login.submit")}
+              </Button>
+            </FieldGroup>
+          </form>
+        </CardContent>
+      </Card>
     </main>
   )
 }

--- a/monkeyai/admin/src/pages/members-and-groups-page.tsx
+++ b/monkeyai/admin/src/pages/members-and-groups-page.tsx
@@ -1,1049 +1,457 @@
-import {
-  Add01Icon,
-  Delete02Icon,
-  Edit02Icon,
-  Folder02Icon,
-  FolderIcon,
-  MoreHorizontalIcon,
-  MoveIcon,
-  UserMultiple02Icon,
-} from "@hugeicons/core-free-icons"
+import { useEffect, useState, type FormEvent } from "react"
+import { Add01Icon, UserMultiple02Icon } from "@hugeicons/core-free-icons"
 import { HugeiconsIcon } from "@hugeicons/react"
-import type { TFunction } from "i18next"
-import {
-  useState,
-  type Dispatch,
-  type FormEvent,
-  type SetStateAction,
-} from "react"
 import { useTranslation } from "react-i18next"
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Checkbox } from "@/components/ui/checkbox"
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible"
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
 import {
   Dialog,
-  DialogClose,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
+import { useAuth } from "@/hooks/use-auth"
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
-import {
-  Field,
-  FieldDescription,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSet,
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
-import {
-  Item,
-  ItemActions,
-  ItemContent,
-  ItemDescription,
-  ItemFooter,
-  ItemGroup,
-  ItemMedia,
-  ItemSeparator,
-  ItemTitle,
-} from "@/components/ui/item"
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
-import { cn } from "@/lib/utils"
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { api } from "@/lib/api"
 
-type GroupNode = {
-  id: string
-  labelKey: string
-  count: number
-  children?: GroupNode[]
-}
-
-type Member = {
+type User = {
   id: string
   name: string
   email: string
-  joinedAt: string
-  remainingCredits: number
-  groupId: string
-}
-
-type GroupAction =
-  "add-subgroup" | "rename" | "adjust-members" | "move" | "delete"
-
-type ActiveGroupAction = {
-  action: GroupAction
-  groupId: string
-}
-
-const MEMBERS: Member[] = [
-  {
-    id: "member-01",
-    name: "陈晨",
-    email: "chen.chen@example.com",
-    joinedAt: "2024-03-18",
-    remainingCredits: 12840,
-    groupId: "administrators",
-  },
-  {
-    id: "member-02",
-    name: "Alice Zhang",
-    email: "alice.zhang@example.com",
-    joinedAt: "2024-05-06",
-    remainingCredits: 9320,
-    groupId: "administrators",
-  },
-  {
-    id: "member-03",
-    name: "Omar Hassan",
-    email: "omar.hassan@example.com",
-    joinedAt: "2024-07-22",
-    remainingCredits: 7650,
-    groupId: "administrators",
-  },
-  {
-    id: "member-04",
-    name: "林玫",
-    email: "lin.mei@example.com",
-    joinedAt: "2024-08-14",
-    remainingCredits: 11460,
-    groupId: "product",
-  },
-  {
-    id: "member-05",
-    name: "Sophia Chen",
-    email: "sophia.chen@example.com",
-    joinedAt: "2024-09-03",
-    remainingCredits: 6890,
-    groupId: "product",
-  },
-  {
-    id: "member-06",
-    name: "Lucas Martin",
-    email: "lucas.martin@example.com",
-    joinedAt: "2024-10-19",
-    remainingCredits: 10230,
-    groupId: "product",
-  },
-  {
-    id: "member-07",
-    name: "Priya Patel",
-    email: "priya.patel@example.com",
-    joinedAt: "2024-11-08",
-    remainingCredits: 5480,
-    groupId: "product",
-  },
-  {
-    id: "member-08",
-    name: "Carlos Silva",
-    email: "carlos.silva@example.com",
-    joinedAt: "2024-12-16",
-    remainingCredits: 8770,
-    groupId: "product",
-  },
-  {
-    id: "member-09",
-    name: "王伟",
-    email: "wang.wei@example.com",
-    joinedAt: "2025-01-09",
-    remainingCredits: 14320,
-    groupId: "engineering",
-  },
-  {
-    id: "member-10",
-    name: "Alex Kim",
-    email: "alex.kim@example.com",
-    joinedAt: "2025-01-27",
-    remainingCredits: 7280,
-    groupId: "engineering",
-  },
-  {
-    id: "member-11",
-    name: "Daniel Weber",
-    email: "daniel.weber@example.com",
-    joinedAt: "2025-02-11",
-    remainingCredits: 4160,
-    groupId: "engineering",
-  },
-  {
-    id: "member-12",
-    name: "Elena Petrova",
-    email: "elena.petrova@example.com",
-    joinedAt: "2025-03-05",
-    remainingCredits: 9860,
-    groupId: "engineering",
-  },
-  {
-    id: "member-13",
-    name: "Yuki Tanaka",
-    email: "yuki.tanaka@example.com",
-    joinedAt: "2025-03-24",
-    remainingCredits: 6310,
-    groupId: "engineering",
-  },
-  {
-    id: "member-14",
-    name: "Minh Nguyen",
-    email: "minh.nguyen@example.com",
-    joinedAt: "2025-04-17",
-    remainingCredits: 11940,
-    groupId: "engineering",
-  },
-  {
-    id: "member-15",
-    name: "Ahmed Saleh",
-    email: "ahmed.saleh@example.com",
-    joinedAt: "2025-05-02",
-    remainingCredits: 3520,
-    groupId: "engineering",
-  },
-  {
-    id: "member-16",
-    name: "María García",
-    email: "maria.garcia@example.com",
-    joinedAt: "2025-05-28",
-    remainingCredits: 8240,
-    groupId: "engineering",
-  },
-  {
-    id: "member-17",
-    name: "Ethan Brown",
-    email: "ethan.brown@example.com",
-    joinedAt: "2025-06-13",
-    remainingCredits: 13570,
-    groupId: "engineering",
-  },
-  {
-    id: "member-18",
-    name: "李娜",
-    email: "li.na@example.com",
-    joinedAt: "2025-07-01",
-    remainingCredits: 5970,
-    groupId: "operations",
-  },
-  {
-    id: "member-19",
-    name: "Emma Wilson",
-    email: "emma.wilson@example.com",
-    joinedAt: "2025-07-21",
-    remainingCredits: 10880,
-    groupId: "operations",
-  },
-  {
-    id: "member-20",
-    name: "João Santos",
-    email: "joao.santos@example.com",
-    joinedAt: "2025-08-08",
-    remainingCredits: 4710,
-    groupId: "operations",
-  },
-  {
-    id: "member-21",
-    name: "Fatima Zahra",
-    email: "fatima.zahra@example.com",
-    joinedAt: "2025-09-15",
-    remainingCredits: 7960,
-    groupId: "operations",
-  },
-  {
-    id: "member-22",
-    name: "박지훈",
-    email: "jihoon.park@example.com",
-    joinedAt: "2025-10-06",
-    remainingCredits: 12450,
-    groupId: "operations",
-  },
-  {
-    id: "member-23",
-    name: "Ivan Smirnov",
-    email: "ivan.smirnov@example.com",
-    joinedAt: "2025-11-18",
-    remainingCredits: 2890,
-    groupId: "operations",
-  },
-  {
-    id: "member-24",
-    name: "Ana López",
-    email: "ana.lopez@example.com",
-    joinedAt: "2025-12-04",
-    remainingCredits: 9150,
-    groupId: "operations",
-  },
-]
-
-const GROUP_TREE: GroupNode[] = [
-  {
-    id: "all-members",
-    labelKey: "rootGroup",
-    count: 24,
-    children: [
-      {
-        id: "administrators",
-        labelKey: "administrators",
-        count: 3,
-      },
-      {
-        id: "product-and-engineering",
-        labelKey: "productAndEngineering",
-        count: 14,
-        children: [
-          {
-            id: "product",
-            labelKey: "product",
-            count: 5,
-          },
-          {
-            id: "engineering",
-            labelKey: "engineering",
-            count: 9,
-          },
-        ],
-      },
-      {
-        id: "operations",
-        labelKey: "operations",
-        count: 7,
-      },
-    ],
-  },
-]
-
-function getGroupAndDescendantIds(group: GroupNode): string[] {
-  return [
-    group.id,
-    ...(group.children?.flatMap(getGroupAndDescendantIds) ?? []),
-  ]
-}
-
-function findGroup(
-  groups: GroupNode[],
-  groupId: string
-): GroupNode | undefined {
-  for (const group of groups) {
-    if (group.id === groupId) {
-      return group
-    }
-
-    const childGroup = findGroup(group.children ?? [], groupId)
-    if (childGroup) {
-      return childGroup
-    }
-  }
-
-  return undefined
-}
-
-function getAvailableMoveTargetTree(
-  groups: GroupNode[],
-  excludedGroupIds: Set<string>
-): GroupNode[] {
-  return groups.flatMap((group) => {
-    if (excludedGroupIds.has(group.id)) {
-      return []
-    }
-
-    return [
-      {
-        ...group,
-        children: getAvailableMoveTargetTree(
-          group.children ?? [],
-          excludedGroupIds
-        ),
-      },
-    ]
-  })
-}
-
-function getGroupLabel(group: GroupNode, t: TFunction) {
-  return t(`pages.membersAndGroups.groupNames.${group.labelKey}`)
-}
-
-function GroupActions({
-  group,
-  onAction,
-  t,
-}: {
-  group: GroupNode
-  onAction: (action: GroupAction, groupId: string) => void
-  t: TFunction
-}) {
-  return (
-    <div className="group/actions relative ms-auto size-8 shrink-0">
-      <span className="pointer-events-none absolute inset-0 hidden items-center justify-center text-xs text-muted-foreground tabular-nums transition-opacity md:flex md:group-focus-within/actions:opacity-0 md:group-hover/group-row:opacity-0">
-        {group.count}
-      </span>
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              className="absolute inset-0 aria-expanded:opacity-100 md:opacity-0 md:group-focus-within/actions:opacity-100 md:group-hover/group-row:opacity-100"
-              aria-label={t("pages.membersAndGroups.groupActions")}
-              onClick={(event) => event.stopPropagation()}
-            />
-          }
-        >
-          <HugeiconsIcon icon={MoreHorizontalIcon} strokeWidth={2} />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuGroup>
-            <DropdownMenuItem
-              onClick={() => onAction("add-subgroup", group.id)}
-            >
-              <HugeiconsIcon icon={Add01Icon} strokeWidth={2} />
-              {t("pages.membersAndGroups.addSubgroup")}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => onAction("rename", group.id)}>
-              <HugeiconsIcon icon={Edit02Icon} strokeWidth={2} />
-              {t("pages.membersAndGroups.renameGroup")}
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => onAction("adjust-members", group.id)}
-            >
-              <HugeiconsIcon icon={UserMultiple02Icon} strokeWidth={2} />
-              {t("pages.membersAndGroups.adjustMembers")}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => onAction("move", group.id)}>
-              <HugeiconsIcon icon={MoveIcon} strokeWidth={2} />
-              {t("pages.membersAndGroups.moveGroup")}
-            </DropdownMenuItem>
-          </DropdownMenuGroup>
-          <DropdownMenuSeparator />
-          <DropdownMenuGroup>
-            <DropdownMenuItem
-              variant="destructive"
-              onClick={() => onAction("delete", group.id)}
-            >
-              <HugeiconsIcon icon={Delete02Icon} strokeWidth={2} />
-              {t("pages.membersAndGroups.deleteGroup")}
-            </DropdownMenuItem>
-          </DropdownMenuGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
-  )
-}
-
-function MemberActions({
-  isAdministrator,
-  isEnabled,
-  member,
-  onToggleAdministrator,
-  onToggleEnabled,
-  t,
-}: {
-  isAdministrator: boolean
-  isEnabled: boolean
-  member: Member
-  onToggleAdministrator: (memberId: string) => void
-  onToggleEnabled: (memberId: string) => void
-  t: TFunction
-}) {
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        render={
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label={t("pages.membersAndGroups.memberActions", {
-              member: member.name,
-            })}
-          />
-        }
-      >
-        <HugeiconsIcon icon={MoreHorizontalIcon} strokeWidth={2} />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuGroup>
-          <DropdownMenuItem onClick={() => onToggleEnabled(member.id)}>
-            {t(
-              isEnabled
-                ? "pages.membersAndGroups.disableMember"
-                : "pages.membersAndGroups.enableMember"
-            )}
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => onToggleAdministrator(member.id)}>
-            {t(
-              isAdministrator
-                ? "pages.membersAndGroups.removeAdministrator"
-                : "pages.membersAndGroups.makeAdministrator"
-            )}
-          </DropdownMenuItem>
-        </DropdownMenuGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  )
-}
-
-const ACTION_TITLE_KEYS: Record<GroupAction, string> = {
-  "add-subgroup": "pages.membersAndGroups.addSubgroup",
-  rename: "pages.membersAndGroups.renameGroup",
-  "adjust-members": "pages.membersAndGroups.adjustMembers",
-  move: "pages.membersAndGroups.moveGroup",
-  delete: "pages.membersAndGroups.deleteGroup",
-}
-
-const ACTION_SUBMIT_KEYS: Record<GroupAction, string> = {
-  "add-subgroup": "pages.membersAndGroups.createGroup",
-  rename: "pages.membersAndGroups.saveChanges",
-  "adjust-members": "pages.membersAndGroups.applyChanges",
-  move: "pages.membersAndGroups.moveAction",
-  delete: "pages.membersAndGroups.deleteAction",
-}
-
-function MoveTargetTree({
-  groups,
-  level = 0,
-  selectedGroupId,
-  t,
-}: {
-  groups: GroupNode[]
-  level?: number
-  selectedGroupId: string
-  t: TFunction
-}) {
-  return (
-    <ul className="flex flex-col gap-1">
-      {groups.map((candidate) => {
-        const radioId = `move-target-${candidate.id}`
-        const hasChildren = Boolean(candidate.children?.length)
-        const isSelected = selectedGroupId === candidate.id
-
-        return (
-          <li key={candidate.id}>
-            <Field
-              className={cn(
-                "min-w-0 gap-0 rounded-md hover:bg-muted has-[:focus-visible]:ring-3 has-[:focus-visible]:ring-ring/50",
-                isSelected && "bg-muted"
-              )}
-              orientation="horizontal"
-            >
-              <RadioGroupItem
-                className="sr-only"
-                id={radioId}
-                value={candidate.id}
-              />
-              <FieldLabel
-                className="h-8 w-full min-w-0 cursor-pointer justify-start px-2 font-normal [&_svg]:size-4 [&_svg]:shrink-0"
-                htmlFor={radioId}
-                style={{ paddingInlineStart: `${level * 1.25 + 0.5}rem` }}
-              >
-                <HugeiconsIcon
-                  icon={hasChildren ? Folder02Icon : FolderIcon}
-                  strokeWidth={2}
-                />
-                <span className="truncate">{getGroupLabel(candidate, t)}</span>
-              </FieldLabel>
-            </Field>
-            {hasChildren && (
-              <MoveTargetTree
-                groups={candidate.children ?? []}
-                level={level + 1}
-                selectedGroupId={selectedGroupId}
-                t={t}
-              />
-            )}
-          </li>
-        )
-      })}
-    </ul>
-  )
-}
-
-function GroupActionDialog({
-  action,
-  group,
-  groups,
-  members,
-  onOpenChange,
-  t,
-}: {
-  action: GroupAction
-  group: GroupNode
-  groups: GroupNode[]
-  members: Member[]
-  onOpenChange: (open: boolean) => void
-  t: TFunction
-}) {
-  const groupName = getGroupLabel(group, t)
-  const groupIds = new Set(getGroupAndDescendantIds(group))
-  const [selectedMemberIds, setSelectedMemberIds] = useState(() =>
-    members
-      .filter((member) => groupIds.has(member.groupId))
-      .map((member) => member.id)
-  )
-  const [memberQuery, setMemberQuery] = useState("")
-  const [moveTarget, setMoveTarget] = useState("")
-  const moveTargetTree = getAvailableMoveTargetTree(groups, groupIds)
-  const normalizedMemberQuery = memberQuery.trim().toLocaleLowerCase()
-  const visibleMembers = members.filter(
-    (member) =>
-      normalizedMemberQuery.length === 0 ||
-      member.name.toLocaleLowerCase().includes(normalizedMemberQuery) ||
-      member.email.toLocaleLowerCase().includes(normalizedMemberQuery)
-  )
-
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    onOpenChange(false)
-  }
-
-  if (action === "delete") {
-    return (
-      <AlertDialog open onOpenChange={onOpenChange}>
-        <AlertDialogContent size="sm">
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t(ACTION_TITLE_KEYS[action])}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t("pages.membersAndGroups.deleteGroupDialogDescription", {
-                group: groupName,
-              })}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>
-              {t("pages.membersAndGroups.cancelAction")}
-            </AlertDialogCancel>
-            <AlertDialogAction
-              variant="destructive"
-              onClick={() => onOpenChange(false)}
-            >
-              {t(ACTION_SUBMIT_KEYS[action])}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    )
-  }
-
-  return (
-    <Dialog open onOpenChange={onOpenChange}>
-      <DialogContent
-        className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-lg"
-        closeLabel={t("common.close")}
-      >
-        <form className="flex flex-col gap-6" onSubmit={handleSubmit}>
-          <DialogHeader>
-            <DialogTitle>{t(ACTION_TITLE_KEYS[action])}</DialogTitle>
-          </DialogHeader>
-
-          {action === "add-subgroup" && (
-            <FieldGroup>
-              <Field>
-                <FieldLabel htmlFor="subgroup-name">
-                  {t("pages.membersAndGroups.groupName")}
-                </FieldLabel>
-                <Input
-                  autoFocus
-                  id="subgroup-name"
-                  name="groupName"
-                  placeholder={t("pages.membersAndGroups.groupNamePlaceholder")}
-                  required
-                />
-              </Field>
-            </FieldGroup>
-          )}
-
-          {action === "rename" && (
-            <FieldGroup>
-              <Field>
-                <FieldLabel htmlFor="group-name">
-                  {t("pages.membersAndGroups.groupName")}
-                </FieldLabel>
-                <Input
-                  autoFocus
-                  defaultValue={groupName}
-                  id="group-name"
-                  name="groupName"
-                  required
-                />
-              </Field>
-            </FieldGroup>
-          )}
-
-          {action === "adjust-members" && (
-            <FieldSet>
-              <FieldLegend variant="label">
-                {t("pages.membersAndGroups.selectMembers")}
-              </FieldLegend>
-              <Field>
-                <FieldLabel className="sr-only" htmlFor="member-search">
-                  {t("pages.membersAndGroups.searchMembers")}
-                </FieldLabel>
-                <Input
-                  autoFocus
-                  id="member-search"
-                  placeholder={t(
-                    "pages.membersAndGroups.searchMembersPlaceholder"
-                  )}
-                  type="search"
-                  value={memberQuery}
-                  onChange={(event) => setMemberQuery(event.target.value)}
-                />
-              </Field>
-              <div
-                className="flex max-h-80 flex-col gap-2 overflow-y-auto pe-1"
-                data-slot="checkbox-group"
-              >
-                {visibleMembers.map((member) => {
-                  const checkboxId = `member-${group.id}-${member.id}`
-                  const checked = selectedMemberIds.includes(member.id)
-
-                  return (
-                    <FieldLabel htmlFor={checkboxId} key={member.id}>
-                      <Field className="min-w-0" orientation="horizontal">
-                        <Checkbox
-                          checked={checked}
-                          id={checkboxId}
-                          onCheckedChange={(nextChecked) => {
-                            setSelectedMemberIds((currentIds) =>
-                              nextChecked
-                                ? [...currentIds, member.id]
-                                : currentIds.filter(
-                                    (memberId) => memberId !== member.id
-                                  )
-                            )
-                          }}
-                        />
-                        <span className="min-w-0 truncate text-sm">
-                          <span className="font-medium">{member.name}</span>
-                          <span className="ms-2 text-muted-foreground">
-                            {member.email}
-                          </span>
-                        </span>
-                      </Field>
-                    </FieldLabel>
-                  )
-                })}
-                {visibleMembers.length === 0 && (
-                  <p className="py-6 text-center text-sm text-muted-foreground">
-                    {t("pages.membersAndGroups.noMembersFound")}
-                  </p>
-                )}
-              </div>
-            </FieldSet>
-          )}
-
-          {action === "move" && (
-            <Field>
-              <FieldLabel>
-                {t("pages.membersAndGroups.targetParentGroup")}
-              </FieldLabel>
-              {moveTargetTree.length > 0 ? (
-                <RadioGroup
-                  aria-label={t("pages.membersAndGroups.targetParentGroup")}
-                  className="max-h-72 overflow-y-auto pe-1"
-                  value={moveTarget}
-                  onValueChange={setMoveTarget}
-                >
-                  <MoveTargetTree
-                    groups={moveTargetTree}
-                    selectedGroupId={moveTarget}
-                    t={t}
-                  />
-                </RadioGroup>
-              ) : (
-                <FieldDescription>
-                  {t("pages.membersAndGroups.noMoveTargets")}
-                </FieldDescription>
-              )}
-            </Field>
-          )}
-
-          <DialogFooter>
-            <DialogClose render={<Button type="button" variant="outline" />}>
-              {t("pages.membersAndGroups.cancelAction")}
-            </DialogClose>
-            <Button disabled={action === "move" && !moveTarget} type="submit">
-              {t(ACTION_SUBMIT_KEYS[action])}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
-function GroupTreeItem({
-  group,
-  level,
-  selectedGroupId,
-  onSelect,
-  onGroupAction,
-  t,
-}: {
-  group: GroupNode
-  level: number
-  selectedGroupId: string
-  onSelect: (groupId: string) => void
-  onGroupAction: (action: GroupAction, groupId: string) => void
-  t: TFunction
-}) {
-  const [isOpen, setIsOpen] = useState(level === 0)
-  const isSelected = selectedGroupId === group.id
-  const rowStyle = {
-    paddingInlineStart: `${level * 1.25 + 0.5}rem`,
-  }
-  const label = t(`pages.membersAndGroups.groupNames.${group.labelKey}`)
-
-  return (
-    <li>
-      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <div
-          className={cn(
-            "group/group-row flex items-center rounded-md hover:bg-muted",
-            isSelected && "bg-muted"
-          )}
-        >
-          <CollapsibleTrigger
-            render={
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                aria-pressed={isSelected}
-                className="min-w-0 flex-1 justify-start pe-2 font-normal hover:bg-transparent! aria-expanded:bg-transparent!"
-                style={rowStyle}
-                onClick={() => onSelect(group.id)}
-              />
-            }
-          >
-            <HugeiconsIcon
-              icon={isOpen ? Folder02Icon : FolderIcon}
-              strokeWidth={2}
-              data-icon="inline-start"
-            />
-            <span className="truncate">{label}</span>
-          </CollapsibleTrigger>
-          <GroupActions group={group} onAction={onGroupAction} t={t} />
-        </div>
-        <CollapsibleContent>
-          <ul className="flex flex-col gap-1">
-            {group.children?.map((child) => (
-              <GroupTreeItem
-                key={child.id}
-                group={child}
-                level={level + 1}
-                selectedGroupId={selectedGroupId}
-                onSelect={onSelect}
-                onGroupAction={onGroupAction}
-                t={t}
-              />
-            ))}
-          </ul>
-        </CollapsibleContent>
-      </Collapsible>
-    </li>
-  )
+  avatar_url?: string
+  role: "admin" | "user"
+  status: "active" | "disabled"
+  joined_at: string
+  last_login_at?: string
 }
 
 export function MembersAndGroupsPage() {
-  const { i18n, t } = useTranslation()
-  const [selectedGroupId, setSelectedGroupId] = useState(GROUP_TREE[0].id)
-  const [activeGroupAction, setActiveGroupAction] =
-    useState<ActiveGroupAction | null>(null)
-  const [disabledMemberIds, setDisabledMemberIds] = useState(
-    () => new Set<string>()
-  )
-  const [administratorMemberIds, setAdministratorMemberIds] = useState(
-    () =>
-      new Set(
-        MEMBERS.filter((member) => member.groupId === "administrators").map(
-          (member) => member.id
-        )
-      )
-  )
-  const selectedGroup = findGroup(GROUP_TREE, selectedGroupId)
-  const actionGroup = activeGroupAction
-    ? findGroup(GROUP_TREE, activeGroupAction.groupId)
-    : undefined
-  const selectedGroupIds = new Set(
-    selectedGroup ? getGroupAndDescendantIds(selectedGroup) : []
-  )
-  const visibleMembers = MEMBERS.filter((member) =>
-    selectedGroupIds.has(member.groupId)
-  )
-  const numberFormatter = new Intl.NumberFormat(
-    i18n.resolvedLanguage ?? i18n.language
-  )
-  const dateFormatter = new Intl.DateTimeFormat(
-    i18n.resolvedLanguage ?? i18n.language,
-    { dateStyle: "medium" }
-  )
+  const { t } = useTranslation()
+  const { user: currentUser } = useAuth()
+  const [users, setUsers] = useState<User[]>([])
+  const [query, setQuery] = useState("")
+  const [error, setError] = useState("")
+  const [savingID, setSavingID] = useState("")
+  const [createOpen, setCreateOpen] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [roleTarget, setRoleTarget] = useState<User | null>(null)
+  const [rolePassword, setRolePassword] = useState("")
+  const [newUser, setNewUser] = useState({
+    name: "",
+    email: "",
+    role: "user" as User["role"],
+    password: "",
+  })
 
-  const toggleSetValue = (
-    setValues: Dispatch<SetStateAction<Set<string>>>,
-    value: string
+  const load = () => {
+    api<{ users: User[] }>("/api/admin/v1/users")
+      .then((result) => setUsers(result.users))
+      .catch((reason: Error) => setError(reason.message))
+  }
+
+  useEffect(load, [])
+
+  const updateUser = async (
+    user: User,
+    patch: Partial<Pick<User, "name" | "role" | "status">> & {
+      password?: string
+    }
   ) => {
-    setValues((currentValues) => {
-      const nextValues = new Set(currentValues)
+    setSavingID(user.id)
+    setError("")
+    try {
+      const updated = await api<User>(`/api/admin/v1/users/${user.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({
+          name: patch.name ?? user.name,
+          role: patch.role ?? user.role,
+          status: patch.status ?? user.status,
+          password: patch.password,
+        }),
+      })
+      setUsers((current) =>
+        current.map((item) => (item.id === updated.id ? updated : item))
+      )
+      return true
+    } catch (reason) {
+      setError((reason as Error).message)
+      return false
+    } finally {
+      setSavingID("")
+    }
+  }
 
-      if (nextValues.has(value)) {
-        nextValues.delete(value)
-      } else {
-        nextValues.add(value)
-      }
+  const normalizedQuery = query.trim().toLocaleLowerCase()
+  const visibleUsers = users.filter(
+    (user) =>
+      !normalizedQuery ||
+      user.name.toLocaleLowerCase().includes(normalizedQuery) ||
+      user.email.toLocaleLowerCase().includes(normalizedQuery)
+  )
 
-      return nextValues
-    })
+  const createUser = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setCreating(true)
+    setError("")
+    try {
+      const created = await api<User>("/api/admin/v1/users", {
+        method: "POST",
+        body: JSON.stringify(newUser),
+      })
+      setUsers((current) => [created, ...current])
+      setNewUser({ name: "", email: "", role: "user", password: "" })
+      setCreateOpen(false)
+    } catch (reason) {
+      setError((reason as Error).message)
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const promoteUser = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!roleTarget || rolePassword.length < 12) return
+    if (
+      await updateUser(roleTarget, {
+        role: "admin",
+        password: rolePassword,
+      })
+    ) {
+      setRoleTarget(null)
+      setRolePassword("")
+    }
   }
 
   return (
-    <section className="flex flex-1 flex-col p-4 pt-px md:h-[calc(100svh-4rem)] md:min-h-0 md:flex-none md:overflow-hidden">
-      <div className="grid flex-1 gap-4 md:min-h-0 md:grid-cols-[minmax(14rem,1fr)_minmax(0,2fr)]">
-        <Card className="min-h-96 md:min-h-0">
-          <CardHeader>
-            <CardTitle>{t("pages.membersAndGroups.groupsTitle")}</CardTitle>
-          </CardHeader>
-          <CardContent className="min-h-0 flex-1 overflow-y-auto">
-            <ul
-              className="flex flex-col gap-1"
-              aria-label={t("pages.membersAndGroups.groupsTitle")}
-            >
-              {GROUP_TREE.map((group) => (
-                <GroupTreeItem
-                  key={group.id}
-                  group={group}
-                  level={0}
-                  selectedGroupId={selectedGroupId}
-                  onSelect={setSelectedGroupId}
-                  onGroupAction={(action, groupId) =>
-                    setActiveGroupAction({ action, groupId })
-                  }
-                  t={t}
-                />
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
-
-        <Card className="min-h-96 md:min-h-0">
-          <CardHeader>
-            <CardTitle>{t("pages.membersAndGroups.membersTitle")}</CardTitle>
-          </CardHeader>
-          <CardContent className="min-h-0 flex-1 overflow-y-auto">
-            <ItemGroup className="gap-2">
-              {visibleMembers.map((member) => {
-                const isDisabled = disabledMemberIds.has(member.id)
-                const joinedAt = new Date(`${member.joinedAt}T00:00:00`)
-
-                return (
-                  <Item
-                    key={member.id}
-                    role="listitem"
-                    size="sm"
-                    variant={isDisabled ? "muted" : "outline"}
-                  >
-                    <ItemMedia>
-                      <Avatar size="lg">
-                        <AvatarFallback>
-                          {member.name.slice(0, 2)}
-                        </AvatarFallback>
-                      </Avatar>
-                    </ItemMedia>
-                    <ItemContent className="min-w-0">
-                      <ItemTitle className="max-w-full min-w-0">
-                        <span className="truncate font-medium">
-                          {member.name}
-                        </span>
-                        {isDisabled && (
-                          <Badge variant="outline">
-                            {t("pages.membersAndGroups.memberDisabled")}
-                          </Badge>
-                        )}
-                      </ItemTitle>
-                      <ItemDescription className="line-clamp-1 text-xs">
-                        {member.email}
-                      </ItemDescription>
-                    </ItemContent>
-                    <ItemActions className="ms-auto shrink-0">
-                      <Badge variant="secondary">
-                        {t("pages.membersAndGroups.remainingCredits", {
-                          count: numberFormatter.format(
-                            member.remainingCredits
-                          ),
-                        })}
-                      </Badge>
-                      <MemberActions
-                        isAdministrator={administratorMemberIds.has(member.id)}
-                        isEnabled={!isDisabled}
-                        member={member}
-                        onToggleAdministrator={(memberId) =>
-                          toggleSetValue(setAdministratorMemberIds, memberId)
-                        }
-                        onToggleEnabled={(memberId) =>
-                          toggleSetValue(setDisabledMemberIds, memberId)
-                        }
-                        t={t}
-                      />
-                    </ItemActions>
-                    <ItemSeparator className="my-0" />
-                    <ItemFooter className="text-xs text-muted-foreground">
-                      <span>
-                        {t("pages.membersAndGroups.joinedAt", {
-                          date: dateFormatter.format(joinedAt),
-                          day: joinedAt.getDate(),
-                          month: joinedAt.getMonth() + 1,
-                          year: joinedAt.getFullYear(),
-                        })}
-                      </span>
-                      <Badge variant="outline">
-                        {t(
-                          `pages.membersAndGroups.groupNames.${findGroup(GROUP_TREE, member.groupId)?.labelKey}`
-                        )}
-                      </Badge>
-                    </ItemFooter>
-                  </Item>
-                )
-              })}
-            </ItemGroup>
-          </CardContent>
-        </Card>
+    <main className="flex flex-1 flex-col gap-6 p-4 pt-0 md:p-6 md:pt-0">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {t("pages.membersAndGroups.title")}
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {t("pages.membersAndGroups.description")}
+        </p>
       </div>
-      {activeGroupAction && actionGroup && (
-        <GroupActionDialog
-          key={`${activeGroupAction.action}-${actionGroup.id}`}
-          action={activeGroupAction.action}
-          group={actionGroup}
-          groups={GROUP_TREE}
-          members={MEMBERS}
-          onOpenChange={(open) => {
-            if (!open) {
-              setActiveGroupAction(null)
-            }
-          }}
-          t={t}
-        />
-      )}
-    </section>
+
+      <Card>
+        <CardHeader className="gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <HugeiconsIcon icon={UserMultiple02Icon} strokeWidth={2} />
+              {t("pages.membersAndGroups.membersTitle")}
+            </CardTitle>
+            <CardDescription className="mt-1">
+              {t("pages.membersAndGroups.membersDescription")}
+            </CardDescription>
+          </div>
+          <div className="flex w-full gap-2 sm:w-auto">
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={t("pages.membersAndGroups.searchMembersPlaceholder")}
+              aria-label={t("pages.membersAndGroups.searchMembers")}
+              className="min-w-0 flex-1 sm:w-64"
+            />
+            <Button
+              type="button"
+              className="cursor-pointer"
+              onClick={() => setCreateOpen(true)}
+            >
+              <HugeiconsIcon icon={Add01Icon} strokeWidth={2} />
+              添加成员
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <p
+              className="mb-4 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+              role="alert"
+            >
+              {error}
+            </p>
+          )}
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>成员</TableHead>
+                <TableHead>角色</TableHead>
+                <TableHead>状态</TableHead>
+                <TableHead>最近登录</TableHead>
+                <TableHead className="text-end">操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {visibleUsers.map((user) => (
+                <TableRow key={user.id}>
+                  <TableCell>
+                    <div className="flex items-center gap-3">
+                      <Avatar>
+                        <AvatarImage src={user.avatar_url} alt={user.name} />
+                        <AvatarFallback>{user.name.slice(0, 2)}</AvatarFallback>
+                      </Avatar>
+                      <div className="min-w-0">
+                        <p className="truncate font-medium">{user.name}</p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {user.email}
+                        </p>
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="outline">
+                      {user.role === "admin" ? "管理员" : "成员"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={
+                        user.status === "active" ? "secondary" : "outline"
+                      }
+                    >
+                      {user.status === "active" ? "已启用" : "已停用"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {user.last_login_at
+                      ? new Intl.DateTimeFormat(undefined, {
+                          dateStyle: "medium",
+                          timeStyle: "short",
+                        }).format(new Date(user.last_login_at))
+                      : "—"}
+                  </TableCell>
+                  <TableCell className="text-end">
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className="cursor-pointer"
+                        disabled={
+                          savingID === user.id || user.id === currentUser?.id
+                        }
+                        onClick={() => {
+                          if (user.role === "admin") {
+                            void updateUser(user, { role: "user" })
+                            return
+                          }
+                          setRolePassword("")
+                          setRoleTarget(user)
+                        }}
+                      >
+                        {user.role === "admin" ? "取消管理员" : "设为管理员"}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="cursor-pointer"
+                        disabled={
+                          savingID === user.id || user.id === currentUser?.id
+                        }
+                        onClick={() =>
+                          void updateUser(user, {
+                            status:
+                              user.status === "active" ? "disabled" : "active",
+                          })
+                        }
+                      >
+                        {user.status === "active"
+                          ? t("pages.membersAndGroups.disableMember")
+                          : t("pages.membersAndGroups.enableMember")}
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {visibleUsers.length === 0 && (
+                <TableRow>
+                  <TableCell
+                    colSpan={5}
+                    className="py-12 text-center text-muted-foreground"
+                  >
+                    {t("pages.membersAndGroups.noMembersFound")}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <form className="flex flex-col gap-6" onSubmit={createUser}>
+            <DialogHeader>
+              <DialogTitle>添加成员</DialogTitle>
+              <DialogDescription>
+                普通成员通过 OAuth 绑定该邮箱；管理员使用设置的密码登录后台。
+              </DialogDescription>
+            </DialogHeader>
+            <FieldGroup>
+              <Field>
+                <FieldLabel htmlFor="new-user-name">姓名</FieldLabel>
+                <Input
+                  id="new-user-name"
+                  value={newUser.name}
+                  onChange={(event) =>
+                    setNewUser((current) => ({
+                      ...current,
+                      name: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="new-user-email">邮箱</FieldLabel>
+                <Input
+                  id="new-user-email"
+                  type="email"
+                  value={newUser.email}
+                  onChange={(event) =>
+                    setNewUser((current) => ({
+                      ...current,
+                      email: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="new-user-role">角色</FieldLabel>
+                <select
+                  id="new-user-role"
+                  value={newUser.role}
+                  onChange={(event) =>
+                    setNewUser((current) => ({
+                      ...current,
+                      role: event.target.value as User["role"],
+                      password:
+                        event.target.value === "admin" ? current.password : "",
+                    }))
+                  }
+                  className="h-9 cursor-pointer rounded-md border border-input bg-background px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <option value="user">成员</option>
+                  <option value="admin">管理员</option>
+                </select>
+              </Field>
+              {newUser.role === "admin" && (
+                <Field>
+                  <FieldLabel htmlFor="new-user-password">初始密码</FieldLabel>
+                  <Input
+                    id="new-user-password"
+                    type="password"
+                    autoComplete="new-password"
+                    minLength={12}
+                    value={newUser.password}
+                    onChange={(event) =>
+                      setNewUser((current) => ({
+                        ...current,
+                        password: event.target.value,
+                      }))
+                    }
+                    required
+                  />
+                </Field>
+              )}
+            </FieldGroup>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setCreateOpen(false)}
+              >
+                取消
+              </Button>
+              <Button
+                type="submit"
+                disabled={
+                  creating ||
+                  !newUser.name.trim() ||
+                  !newUser.email.trim() ||
+                  (newUser.role === "admin" && newUser.password.length < 12)
+                }
+              >
+                {creating ? "正在创建…" : "创建"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={roleTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRoleTarget(null)
+            setRolePassword("")
+          }
+        }}
+      >
+        <DialogContent>
+          <form className="flex flex-col gap-6" onSubmit={promoteUser}>
+            <DialogHeader>
+              <DialogTitle>设为管理员</DialogTitle>
+              <DialogDescription>
+                为 {roleTarget?.email} 设置管理后台初始密码。
+              </DialogDescription>
+            </DialogHeader>
+            <Field>
+              <FieldLabel htmlFor="promote-user-password">初始密码</FieldLabel>
+              <Input
+                id="promote-user-password"
+                type="password"
+                autoComplete="new-password"
+                minLength={12}
+                value={rolePassword}
+                onChange={(event) => setRolePassword(event.target.value)}
+                required
+                autoFocus
+              />
+              <p className="text-xs text-muted-foreground">至少 12 个字符</p>
+            </Field>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setRoleTarget(null)}
+              >
+                取消
+              </Button>
+              <Button
+                type="submit"
+                disabled={
+                  !roleTarget ||
+                  rolePassword.length < 12 ||
+                  savingID === roleTarget.id
+                }
+              >
+                确认
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </main>
   )
 }

--- a/monkeyai/admin/src/pages/other-settings-page.tsx
+++ b/monkeyai/admin/src/pages/other-settings-page.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react"
+import { useEffect, useState, type FormEvent } from "react"
 import {
   Delete02Icon,
   Edit02Icon,
@@ -51,12 +51,10 @@ import {
 } from "@/components/ui/dropdown-menu"
 import {
   Field,
-  FieldContent,
   FieldDescription,
   FieldError,
   FieldGroup,
   FieldLabel,
-  FieldTitle,
 } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import {
@@ -76,9 +74,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
 import { useSkillTags } from "@/hooks/use-skill-tags"
+import { api } from "@/lib/api"
 
 const OAUTH_PROVIDERS = [
   { value: "github", labelKey: "pages.otherSettings.oauth.providers.github" },
@@ -127,13 +125,9 @@ type OAuthConnection = {
   provider: OAuthProvider
   name: string
   clientId: string
+  clientSecret: string
   issuerUrl?: string
   enabled: boolean
-}
-
-type LoginMethodSettings = {
-  passwordEnabled: boolean
-  emailCodeEnabled: boolean
 }
 
 type EmailSettings = {
@@ -177,27 +171,7 @@ type KnowledgeBaseSettings = {
 
 type KnowledgeModelKind = "embeddingModel" | "rerankerModel"
 
-const INITIAL_OAUTH_CONNECTIONS: OAuthConnection[] = [
-  {
-    id: "oauth-github-company",
-    provider: "github",
-    name: "GitHub",
-    clientId: "Iv1.8c91••••••••",
-    enabled: true,
-  },
-  {
-    id: "oauth-google-workspace",
-    provider: "google",
-    name: "Google Workspace",
-    clientId: "827540••••••••.apps.googleusercontent.com",
-    enabled: false,
-  },
-]
-
-const INITIAL_LOGIN_METHOD_SETTINGS: LoginMethodSettings = {
-  passwordEnabled: true,
-  emailCodeEnabled: false,
-}
+const INITIAL_OAUTH_CONNECTIONS: OAuthConnection[] = []
 
 const INITIAL_EMAIL_SETTINGS: EmailSettings = {
   registrationEnabled: false,
@@ -225,14 +199,12 @@ export function OtherSettingsPage() {
   const [toolName, setToolName] = useState("MonkeyAI")
   const [savedToolName, setSavedToolName] = useState("MonkeyAI")
   const [brandInfoSaved, setBrandInfoSaved] = useState(false)
+  const [settingsError, setSettingsError] = useState("")
   const [oauthConnections, setOauthConnections] = useState(
     INITIAL_OAUTH_CONNECTIONS
   )
   const [oauthDialogOpen, setOauthDialogOpen] = useState(false)
   const [oauthProvider, setOauthProvider] = useState<OAuthProvider>("github")
-  const [loginMethodSettings, setLoginMethodSettings] = useState(
-    INITIAL_LOGIN_METHOD_SETTINGS
-  )
   const [emailSettings, setEmailSettings] = useState(INITIAL_EMAIL_SETTINGS)
   const [savedEmailSettings, setSavedEmailSettings] = useState(
     INITIAL_EMAIL_SETTINGS
@@ -263,6 +235,109 @@ export function OtherSettingsPage() {
   const emailSettingsDirty =
     JSON.stringify(emailSettings) !== JSON.stringify(savedEmailSettings)
 
+  useEffect(() => {
+    api<{
+      settings: Array<{
+        key: string
+        value: Record<string, unknown>
+      }>
+    }>("/api/admin/v1/settings")
+      .then(({ settings }) => {
+        for (const setting of settings) {
+          if (setting.key === "branding") {
+            const workspaceName = String(
+              setting.value.workspace_name ?? "Monkey AI"
+            )
+            const productName = String(setting.value.product_name ?? "MonkeyAI")
+            setTeamName(workspaceName)
+            setSavedTeamName(workspaceName)
+            setToolName(productName)
+            setSavedToolName(productName)
+          }
+          if (setting.key === "authentication") {
+            const connections = Array.isArray(setting.value.oauth_connections)
+              ? setting.value.oauth_connections
+              : []
+            setOauthConnections(
+              connections.map((item) => {
+                const connection = item as Record<string, unknown>
+                return {
+                  id: String(connection.id),
+                  provider: String(connection.provider) as OAuthProvider,
+                  name: String(connection.name),
+                  clientId: String(connection.client_id),
+                  clientSecret: String(connection.client_secret ?? ""),
+                  issuerUrl: connection.issuer_url
+                    ? String(connection.issuer_url)
+                    : undefined,
+                  enabled: Boolean(connection.enabled),
+                }
+              })
+            )
+            const registrationEnabled = Boolean(
+              setting.value.registration_enabled
+            )
+            setEmailSettings((current) => ({
+              ...current,
+              registrationEnabled,
+            }))
+            setSavedEmailSettings((current) => ({
+              ...current,
+              registrationEnabled,
+            }))
+          }
+          if (setting.key === "email") {
+            const applyEmail = (current: EmailSettings): EmailSettings => ({
+              registrationEnabled: current.registrationEnabled,
+              senderName: String(setting.value.sender_name ?? ""),
+              senderEmail: String(setting.value.sender_email ?? ""),
+              smtpHost: String(setting.value.smtp_host ?? ""),
+              smtpPort: String(setting.value.smtp_port ?? "587"),
+              smtpUsername: String(setting.value.smtp_username ?? ""),
+              smtpPassword: String(setting.value.smtp_password ?? ""),
+              encryption: String(
+                setting.value.smtp_encryption ?? "starttls"
+              ) as Encryption,
+            })
+            setEmailSettings(applyEmail)
+            setSavedEmailSettings(applyEmail)
+          }
+        }
+      })
+      .catch((reason: Error) => setSettingsError(reason.message))
+  }, [])
+
+  const saveSetting = async (key: string, value: Record<string, unknown>) => {
+    setSettingsError("")
+    try {
+      await api(`/api/admin/v1/settings/${key}`, {
+        method: "PUT",
+        body: JSON.stringify({ value, schema_version: 1 }),
+      })
+      return true
+    } catch (reason) {
+      setSettingsError((reason as Error).message)
+      return false
+    }
+  }
+
+  const saveAuthentication = async (
+    connections: OAuthConnection[],
+    registrationEnabled = savedEmailSettings.registrationEnabled
+  ) =>
+    saveSetting("authentication", {
+      registration_enabled: registrationEnabled,
+      oauth_connections: connections.map((connection) => ({
+        id: connection.id,
+        provider: connection.provider,
+        name: connection.name,
+        client_id: connection.clientId,
+        client_secret: connection.clientSecret,
+        issuer_url: connection.issuerUrl ?? null,
+        enabled: connection.enabled,
+      })),
+    })
+
   const providerItems = OAUTH_PROVIDERS.map((provider) => ({
     value: provider.value,
     label: t(provider.labelKey),
@@ -286,7 +361,7 @@ export function OtherSettingsPage() {
     }
   }
 
-  const handleAddOauth = (event: FormEvent<HTMLFormElement>) => {
+  const handleAddOauth = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const form = event.currentTarget
     const formData = new FormData(form)
@@ -304,27 +379,41 @@ export function OtherSettingsPage() {
       return
     }
 
-    setOauthConnections((connections) => [
-      ...connections,
+    const connections = [
+      ...oauthConnections,
       {
-        id: `oauth-${oauthProvider}-${Date.now()}`,
+        id: crypto.randomUUID(),
         provider: oauthProvider,
         name,
         clientId,
+        clientSecret,
         issuerUrl: issuerUrl || undefined,
         enabled: true,
       },
-    ])
-    form.reset()
-    handleOauthDialogOpenChange(false)
+    ]
+    if (await saveAuthentication(connections)) {
+      setOauthConnections(connections)
+      form.reset()
+      handleOauthDialogOpenChange(false)
+    }
   }
 
-  const setOauthEnabled = (id: string, enabled: boolean) => {
-    setOauthConnections((connections) =>
-      connections.map((connection) =>
-        connection.id === id ? { ...connection, enabled } : connection
-      )
+  const setOauthEnabled = async (id: string, enabled: boolean) => {
+    const connections = oauthConnections.map((connection) =>
+      connection.id === id ? { ...connection, enabled } : connection
     )
+    if (await saveAuthentication(connections)) {
+      setOauthConnections(connections)
+    }
+  }
+
+  const removeOauthConnection = async (id: string) => {
+    const connections = oauthConnections.filter(
+      (connection) => connection.id !== id
+    )
+    if (await saveAuthentication(connections)) {
+      setOauthConnections(connections)
+    }
   }
 
   const updateEmailSetting = <Key extends keyof EmailSettings>(
@@ -343,10 +432,24 @@ export function OtherSettingsPage() {
     }
   }
 
-  const handleEmailSettingsSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleEmailSettingsSubmit = async (
+    event: FormEvent<HTMLFormElement>
+  ) => {
     event.preventDefault()
-    setSavedEmailSettings(emailSettings)
-    setEmailDialogOpen(false)
+    const saved = await saveSetting("email", {
+      registration_enabled: emailSettings.registrationEnabled,
+      sender_name: emailSettings.senderName,
+      sender_email: emailSettings.senderEmail,
+      smtp_host: emailSettings.smtpHost,
+      smtp_port: Number(emailSettings.smtpPort),
+      smtp_username: emailSettings.smtpUsername,
+      smtp_password: emailSettings.smtpPassword,
+      smtp_encryption: emailSettings.encryption,
+    })
+    if (saved) {
+      setSavedEmailSettings(emailSettings)
+      setEmailDialogOpen(false)
+    }
   }
 
   const handleKnowledgeModelSubmit = (
@@ -498,6 +601,14 @@ export function OtherSettingsPage() {
 
   return (
     <section className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      {settingsError && (
+        <p
+          className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+          role="alert"
+        >
+          {settingsError}
+        </p>
+      )}
       <Card>
         <CardHeader>
           <CardTitle>{t("pages.otherSettings.brandInfo.title")}</CardTitle>
@@ -515,10 +626,16 @@ export function OtherSettingsPage() {
                 <Button
                   type="button"
                   disabled={!teamName.trim() || !toolName.trim()}
-                  onClick={() => {
-                    setSavedTeamName(teamName)
-                    setSavedToolName(toolName)
-                    setBrandInfoSaved(true)
+                  onClick={async () => {
+                    const saved = await saveSetting("branding", {
+                      workspace_name: teamName.trim(),
+                      product_name: toolName.trim(),
+                    })
+                    if (saved) {
+                      setSavedTeamName(teamName)
+                      setSavedToolName(toolName)
+                      setBrandInfoSaved(true)
+                    }
                   }}
                 >
                   {t("pages.otherSettings.brandInfo.save")}
@@ -1377,51 +1494,6 @@ export function OtherSettingsPage() {
           </CardAction>
         </CardHeader>
         <CardContent className="gap-6">
-          <FieldGroup className="gap-4">
-            <Field orientation="horizontal">
-              <FieldContent>
-                <FieldTitle>
-                  {t("pages.otherSettings.loginMethods.password")}
-                </FieldTitle>
-                <FieldDescription>
-                  {t("pages.otherSettings.loginMethods.passwordDescription")}
-                </FieldDescription>
-              </FieldContent>
-              <Switch
-                checked={loginMethodSettings.passwordEnabled}
-                onCheckedChange={(enabled) =>
-                  setLoginMethodSettings((settings) => ({
-                    ...settings,
-                    passwordEnabled: enabled,
-                  }))
-                }
-                aria-label={t("pages.otherSettings.loginMethods.password")}
-              />
-            </Field>
-            <Field orientation="horizontal">
-              <FieldContent>
-                <FieldTitle>
-                  {t("pages.otherSettings.loginMethods.emailCode")}
-                </FieldTitle>
-                <FieldDescription>
-                  {t("pages.otherSettings.loginMethods.emailCodeDescription")}
-                </FieldDescription>
-              </FieldContent>
-              <Switch
-                checked={loginMethodSettings.emailCodeEnabled}
-                onCheckedChange={(enabled) =>
-                  setLoginMethodSettings((settings) => ({
-                    ...settings,
-                    emailCodeEnabled: enabled,
-                  }))
-                }
-                aria-label={t("pages.otherSettings.loginMethods.emailCode")}
-              />
-            </Field>
-          </FieldGroup>
-
-          <Separator />
-
           <div className="flex flex-col gap-3">
             {oauthConnections.map((connection) => (
               <div
@@ -1447,12 +1519,22 @@ export function OtherSettingsPage() {
                 <Switch
                   checked={connection.enabled}
                   onCheckedChange={(enabled) =>
-                    setOauthEnabled(connection.id, enabled)
+                    void setOauthEnabled(connection.id, enabled)
                   }
                   aria-label={t("pages.otherSettings.oauth.toggle", {
                     name: connection.name,
                   })}
                 />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="cursor-pointer text-destructive"
+                  aria-label={`删除 ${connection.name}`}
+                  onClick={() => void removeOauthConnection(connection.id)}
+                >
+                  <HugeiconsIcon icon={Delete02Icon} strokeWidth={2} />
+                </Button>
               </div>
             ))}
           </div>
@@ -1744,21 +1826,28 @@ export function OtherSettingsPage() {
               {t("pages.otherSettings.email.cancel")}
             </AlertDialogCancel>
             <AlertDialogAction
-              onClick={() => {
+              onClick={async () => {
                 if (registrationPendingValue === null) {
                   return
                 }
 
                 const registrationEnabled = registrationPendingValue
-                setSavedEmailSettings((settings) => ({
-                  ...settings,
-                  registrationEnabled,
-                }))
-                setEmailSettings((settings) => ({
-                  ...settings,
-                  registrationEnabled,
-                }))
-                setRegistrationPendingValue(null)
+                if (
+                  await saveAuthentication(
+                    oauthConnections,
+                    registrationEnabled
+                  )
+                ) {
+                  setSavedEmailSettings((settings) => ({
+                    ...settings,
+                    registrationEnabled,
+                  }))
+                  setEmailSettings((settings) => ({
+                    ...settings,
+                    registrationEnabled,
+                  }))
+                  setRegistrationPendingValue(null)
+                }
               }}
             >
               {t(

--- a/monkeyai/admin/vite.config.ts
+++ b/monkeyai/admin/vite.config.ts
@@ -6,6 +6,12 @@ import { defineConfig } from "vite"
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      "/api": "http://localhost:8080",
+      "/oauth": "http://localhost:8080",
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(import.meta.dirname, "./src"),

--- a/monkeyai/backend/README.md
+++ b/monkeyai/backend/README.md
@@ -133,4 +133,8 @@ export MONKEYAI_DATABASE_URL='postgres://monkeyai:password@127.0.0.1:5432/monkey
 go run ./cmd/server
 ```
 
-可选环境变量为 `MONKEYAI_HTTP_ADDR`、`MONKEYAI_PPROF_ADDR`、`MONKEYAI_SHUTDOWN_TIMEOUT` 和 `MONKEYAI_LOG_LEVEL`，对应命令行参数可通过 `go run ./cmd/server -h` 查看。服务提供 `/healthz` 存活检查和 `/readyz` 数据库就绪检查。pprof 默认单独监听 `127.0.0.1:6060`，入口为 `/debug/pprof/`，不对业务端口暴露。
+可选环境变量为 `MONKEYAI_HTTP_ADDR`、`MONKEYAI_PPROF_ADDR`、`MONKEYAI_SHUTDOWN_TIMEOUT`、`MONKEYAI_LOG_LEVEL`、`MONKEYAI_PUBLIC_URL` 和 `MONKEYAI_ADMIN_URL`，对应命令行参数可通过 `go run ./cmd/server -h` 查看。`MONKEYAI_PUBLIC_URL` 是上游 OAuth 回调和 OAuth 元数据使用的服务地址，`MONKEYAI_ADMIN_URL` 是登录完成后返回的页面地址；两者必须使用相同协议和主机名，开发环境可以使用不同端口，正式环境应使用 HTTPS。
+
+空数据库首次启动时，必须通过 `MONKEYAI_INITIAL_ADMIN_EMAIL` 和 `MONKEYAI_INITIAL_ADMIN_PASSWORD` 创建管理员账号，可选 `MONKEYAI_INITIAL_ADMIN_NAME` 设置显示名称。密码至少 12 个字符；未配置时服务会拒绝启动，避免产生无法管理的实例。服务只在用户表为空时创建账号，不会在后续启动时重置密码。创建完成后应移除密码环境变量。完整登录流程见 [`../design/agent-auth-settings.md`](../design/agent-auth-settings.md)。
+
+服务提供 `/healthz` 存活检查和 `/readyz` 数据库就绪检查。pprof 默认单独监听 `127.0.0.1:6060`，入口为 `/debug/pprof/`，不对业务端口暴露。

--- a/monkeyai/backend/internal/app/app.go
+++ b/monkeyai/backend/internal/app/app.go
@@ -15,7 +15,9 @@ import (
 	"github.com/chaitin/MonkeyCode/monkeyai/backend/internal/config"
 	"github.com/chaitin/MonkeyCode/monkeyai/backend/internal/database"
 	"github.com/chaitin/MonkeyCode/monkeyai/backend/internal/httpapi"
+	"github.com/chaitin/MonkeyCode/monkeyai/backend/internal/identity"
 	"github.com/chaitin/MonkeyCode/monkeyai/backend/internal/proxy"
+	"github.com/chaitin/MonkeyCode/monkeyai/backend/internal/setting"
 )
 
 type App struct {
@@ -29,12 +31,17 @@ func New(ctx context.Context, cfg config.Config, logger *slog.Logger) (*App, err
 	if err != nil {
 		return nil, err
 	}
+	handler, err := newApplicationHandler(ctx, logger, pool, cfg)
+	if err != nil {
+		pool.Close()
+		return nil, err
+	}
 
 	return &App{
 		servers: []*http.Server{
 			{
 				Addr:              cfg.Addr,
-				Handler:           newHandler(logger, pool),
+				Handler:           handler,
 				ReadHeaderTimeout: 5 * time.Second,
 				IdleTimeout:       2 * time.Minute,
 				MaxHeaderBytes:    1 << 20,
@@ -57,10 +64,48 @@ func New(ctx context.Context, cfg config.Config, logger *slog.Logger) (*App, err
 func newHandler(logger *slog.Logger, database httpapi.Pinger) http.Handler {
 	admin := chi.NewRouter()
 	agent := chi.NewRouter()
+	auth := chi.NewRouter()
 	router := chi.NewRouter()
 	proxy.NewProxy(nil, logger).Register(router)
-	router.Mount("/", httpapi.New(logger, database, admin, agent))
+	router.Mount("/", httpapi.New(logger, database, admin, agent, auth))
 	return router
+}
+
+func newApplicationHandler(ctx context.Context, logger *slog.Logger, pool *pgxpool.Pool, cfg config.Config) (http.Handler, error) {
+	broker := setting.NewBroker()
+	settings := setting.NewService(setting.NewPostgres(pool), broker)
+	identities := identity.NewService(pool, settings, cfg.PublicURL, cfg.AdminURL)
+	if err := identities.EnsureInitialAdmin(ctx, cfg.InitialAdminName, cfg.InitialAdminEmail, cfg.InitialAdminPassword); err != nil {
+		return nil, fmt.Errorf("初始化管理员: %w", err)
+	}
+	go func() {
+		for ctx.Err() == nil {
+			if err := settings.Listen(ctx); err != nil && ctx.Err() == nil {
+				logger.Error("监听设置变更失败", "error", err)
+			}
+			select {
+			case <-ctx.Done():
+			case <-time.After(time.Second):
+			}
+		}
+	}()
+
+	admin := chi.NewRouter()
+	admin.Use(identities.RequireAdmin)
+	identities.RegisterAdmin(admin)
+	settings.RegisterAdmin(admin)
+
+	agent := chi.NewRouter()
+	agent.Use(identities.RequireAgent)
+	identities.RegisterAgent(agent)
+	settings.RegisterAgent(agent)
+
+	router := chi.NewRouter()
+	proxy.NewProxy(nil, logger).Register(router)
+	router.Get("/.well-known/oauth-authorization-server", identities.OAuthMetadata)
+	router.Mount("/oauth", identities.OAuthRouter())
+	router.Mount("/", httpapi.New(logger, pool, admin, agent, identities.AuthRouter()))
+	return router, nil
 }
 
 func (a *App) Run(ctx context.Context) error {

--- a/monkeyai/backend/internal/config/config.go
+++ b/monkeyai/backend/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -23,7 +24,12 @@ type Database struct {
 type Config struct {
 	HTTP
 	Database
-	LogLevel slog.Level
+	PublicURL            string
+	AdminURL             string
+	InitialAdminName     string
+	InitialAdminEmail    string
+	InitialAdminPassword string
+	LogLevel             slog.Level
 }
 
 func Load(args []string) (Config, error) {
@@ -51,10 +57,15 @@ func Load(args []string) (Config, error) {
 	}
 
 	cfg := Config{
-		Addr:            addr,
-		PprofAddr:       pprofAddr,
-		ShutdownTimeout: shutdownTimeout,
-		URL:             os.Getenv("MONKEYAI_DATABASE_URL"),
+		Addr:                 addr,
+		PprofAddr:            pprofAddr,
+		ShutdownTimeout:      shutdownTimeout,
+		URL:                  os.Getenv("MONKEYAI_DATABASE_URL"),
+		PublicURL:            envOr("MONKEYAI_PUBLIC_URL", "http://localhost:8080"),
+		AdminURL:             envOr("MONKEYAI_ADMIN_URL", "http://localhost:5173"),
+		InitialAdminName:     envOr("MONKEYAI_INITIAL_ADMIN_NAME", "MonkeyAI Admin"),
+		InitialAdminEmail:    strings.TrimSpace(os.Getenv("MONKEYAI_INITIAL_ADMIN_EMAIL")),
+		InitialAdminPassword: os.Getenv("MONKEYAI_INITIAL_ADMIN_PASSWORD"),
 	}
 
 	flags := flag.NewFlagSet("monkeyai-server", flag.ContinueOnError)
@@ -62,6 +73,8 @@ func Load(args []string) (Config, error) {
 	flags.StringVar(&cfg.PprofAddr, "pprof-addr", cfg.PprofAddr, "pprof 监听地址")
 	flags.DurationVar(&cfg.ShutdownTimeout, "shutdown-timeout", cfg.ShutdownTimeout, "优雅退出超时时间")
 	flags.StringVar(&cfg.URL, "database-url", cfg.URL, "PostgreSQL 连接地址")
+	flags.StringVar(&cfg.PublicURL, "public-url", cfg.PublicURL, "服务端公网地址")
+	flags.StringVar(&cfg.AdminURL, "admin-url", cfg.AdminURL, "管理端页面地址")
 	flags.StringVar(&logLevel, "log-level", logLevel, "日志级别")
 	if err := flags.Parse(args); err != nil {
 		return Config{}, fmt.Errorf("解析启动参数: %w", err)
@@ -82,6 +95,32 @@ func Load(args []string) (Config, error) {
 	if cfg.URL == "" {
 		return Config{}, errors.New("MONKEYAI_DATABASE_URL 或 -database-url 不能为空")
 	}
+	cfg.PublicURL = strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/")
+	if cfg.PublicURL == "" {
+		return Config{}, errors.New("服务端公网地址不能为空")
+	}
+	cfg.AdminURL = strings.TrimRight(strings.TrimSpace(cfg.AdminURL), "/")
+	if cfg.AdminURL == "" {
+		return Config{}, errors.New("管理端页面地址不能为空")
+	}
+	urls := make(map[string]*url.URL, 2)
+	for name, value := range map[string]string{"public-url": cfg.PublicURL, "admin-url": cfg.AdminURL} {
+		parsed, err := url.Parse(value)
+		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+			return Config{}, fmt.Errorf("%s 必须是绝对 HTTP(S) 地址", name)
+		}
+		urls[name] = parsed
+	}
+	if urls["public-url"].Scheme != urls["admin-url"].Scheme ||
+		!strings.EqualFold(urls["public-url"].Hostname(), urls["admin-url"].Hostname()) {
+		return Config{}, errors.New("public-url 与 admin-url 必须使用相同协议和主机名")
+	}
+	if (cfg.InitialAdminEmail == "") != (cfg.InitialAdminPassword == "") {
+		return Config{}, errors.New("首次管理员邮箱和密码必须同时配置")
+	}
+	if cfg.InitialAdminPassword != "" && len(cfg.InitialAdminPassword) < 12 {
+		return Config{}, errors.New("首次管理员密码不能少于 12 个字符")
+	}
 	if cfg.ShutdownTimeout <= 0 {
 		return Config{}, errors.New("优雅退出超时时间必须大于 0")
 	}
@@ -90,4 +129,11 @@ func Load(args []string) (Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func envOr(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
 }

--- a/monkeyai/backend/internal/config/config_test.go
+++ b/monkeyai/backend/internal/config/config_test.go
@@ -63,3 +63,33 @@ func TestLoadRequiresPprofAddr(t *testing.T) {
 		t.Fatal("期望 pprof 监听地址为空时返回错误")
 	}
 }
+
+func TestLoadRejectsInvalidPublicURL(t *testing.T) {
+	t.Setenv("MONKEYAI_DATABASE_URL", "postgres://localhost/monkeyai")
+	t.Setenv("MONKEYAI_PUBLIC_URL", "javascript:alert(1)")
+
+	if _, err := Load(nil); err == nil {
+		t.Fatal("期望公网地址非法时返回错误")
+	}
+}
+
+func TestLoadRequiresPublicAndAdminURLOnSameHost(t *testing.T) {
+	t.Setenv("MONKEYAI_DATABASE_URL", "postgres://localhost/monkeyai")
+	t.Setenv("MONKEYAI_PUBLIC_URL", "https://api.example.com")
+	t.Setenv("MONKEYAI_ADMIN_URL", "https://admin.example.com")
+
+	if _, err := Load(nil); err == nil {
+		t.Fatal("期望公网地址与管理端地址主机名不同时返回错误")
+	}
+}
+
+func TestLoadRejectsIncompleteInitialAdmin(t *testing.T) {
+	t.Setenv("MONKEYAI_DATABASE_URL", "postgres://localhost/monkeyai")
+	t.Setenv("MONKEYAI_PUBLIC_URL", "http://localhost:8080")
+	t.Setenv("MONKEYAI_INITIAL_ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("MONKEYAI_INITIAL_ADMIN_PASSWORD", "")
+
+	if _, err := Load(nil); err == nil {
+		t.Fatal("期望首次管理员配置不完整时返回错误")
+	}
+}

--- a/monkeyai/backend/internal/httpapi/router.go
+++ b/monkeyai/backend/internal/httpapi/router.go
@@ -14,7 +14,7 @@ type Pinger interface {
 	Ping(context.Context) error
 }
 
-func New(logger *slog.Logger, database Pinger, admin, agent http.Handler) http.Handler {
+func New(logger *slog.Logger, database Pinger, admin, agent, auth http.Handler) http.Handler {
 	router := chi.NewRouter()
 	router.Use(middleware.RequestID)
 	router.Use(middleware.Recoverer)
@@ -36,6 +36,7 @@ func New(logger *slog.Logger, database Pinger, admin, agent http.Handler) http.H
 
 	router.Mount("/api/admin/v1", admin)
 	router.Mount("/api/agent/v1", agent)
+	router.Mount("/api/auth/v1", auth)
 
 	return router
 }

--- a/monkeyai/backend/internal/httpapi/router_test.go
+++ b/monkeyai/backend/internal/httpapi/router_test.go
@@ -25,6 +25,7 @@ func TestHealth(t *testing.T) {
 		stubPinger{},
 		http.NotFoundHandler(),
 		http.NotFoundHandler(),
+		http.NotFoundHandler(),
 	).
 		ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/healthz", nil))
 
@@ -43,6 +44,7 @@ func TestReadyWhenDatabaseUnavailable(t *testing.T) {
 		stubPinger{err: errors.New("unavailable")},
 		http.NotFoundHandler(),
 		http.NotFoundHandler(),
+		http.NotFoundHandler(),
 	).
 		ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/readyz", nil))
 
@@ -56,6 +58,7 @@ func TestPprofNotExposed(t *testing.T) {
 	New(
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
 		stubPinger{},
+		http.NotFoundHandler(),
 		http.NotFoundHandler(),
 		http.NotFoundHandler(),
 	).
@@ -76,6 +79,9 @@ func TestAPIRoutes(t *testing.T) {
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = io.WriteString(w, "agent")
 		}),
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, "auth")
+		}),
 	)
 
 	tests := []struct {
@@ -84,6 +90,7 @@ func TestAPIRoutes(t *testing.T) {
 	}{
 		{path: "/api/admin/v1/status", want: "admin"},
 		{path: "/api/agent/v1/status", want: "agent"},
+		{path: "/api/auth/v1/status", want: "auth"},
 	}
 	for _, test := range tests {
 		t.Run(test.want, func(t *testing.T) {

--- a/monkeyai/backend/internal/identity/admin.go
+++ b/monkeyai/backend/internal/identity/admin.go
@@ -1,0 +1,117 @@
+package identity
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func (s *Service) RegisterAdmin(router chi.Router) {
+	router.Get("/me", func(w http.ResponseWriter, r *http.Request) {
+		user, _ := UserFromContext(r.Context())
+		writeJSON(w, http.StatusOK, user)
+	})
+	router.Get("/users", func(w http.ResponseWriter, r *http.Request) {
+		users, err := s.listUsers(r.Context())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "server_error", "读取用户失败")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"users": users})
+	})
+	router.Post("/users", s.createUser)
+	router.Patch("/users/{userID}", s.patchUser)
+}
+
+func (s *Service) RegisterAgent(router chi.Router) {
+	router.Get("/me", func(w http.ResponseWriter, r *http.Request) {
+		user, _ := UserFromContext(r.Context())
+		writeJSON(w, http.StatusOK, user)
+	})
+}
+
+func (s *Service) patchUser(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Name     string `json:"name"`
+		Role     string `json:"role"`
+		Status   string `json:"status"`
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&input); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "请求格式无效")
+		return
+	}
+	input.Name = strings.TrimSpace(input.Name)
+	if input.Name == "" || (input.Role != "admin" && input.Role != "user") || (input.Status != "active" && input.Status != "disabled") {
+		writeError(w, http.StatusBadRequest, "invalid_request", "name、role 或 status 无效")
+		return
+	}
+	current, _ := UserFromContext(r.Context())
+	if current.ID == chi.URLParam(r, "userID") && (input.Role != "admin" || input.Status != "active") {
+		writeError(w, http.StatusConflict, "cannot_disable_self", "不能停用自己或移除自己的管理员角色")
+		return
+	}
+	target, err := s.userByID(r.Context(), chi.URLParam(r, "userID"))
+	if err != nil {
+		writeError(w, http.StatusNotFound, "user_not_found", "用户不存在")
+		return
+	}
+	passwordHash := ""
+	if target.Role != "admin" && input.Role == "admin" {
+		if len(input.Password) < 12 {
+			writeError(w, http.StatusBadRequest, "password_required", "提升为管理员时必须设置至少 12 个字符的密码")
+			return
+		}
+		passwordHash, err = hashPassword(input.Password)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "server_error", "更新用户失败")
+			return
+		}
+	}
+	user, err := s.updateUser(r.Context(), chi.URLParam(r, "userID"), input.Name, input.Role, input.Status, passwordHash)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "user_not_found", "用户不存在")
+		return
+	}
+	writeJSON(w, http.StatusOK, user)
+}
+
+func (s *Service) createUser(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Name     string `json:"name"`
+		Email    string `json:"email"`
+		Role     string `json:"role"`
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&input); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "请求格式无效")
+		return
+	}
+	input.Name = strings.TrimSpace(input.Name)
+	input.Email = strings.ToLower(strings.TrimSpace(input.Email))
+	if input.Name == "" || !validEmail(input.Email) || (input.Role != "admin" && input.Role != "user") {
+		writeError(w, http.StatusBadRequest, "invalid_request", "姓名、邮箱或角色无效")
+		return
+	}
+	passwordHash := ""
+	if input.Role == "admin" {
+		if len(input.Password) < 12 {
+			writeError(w, http.StatusBadRequest, "invalid_request", "管理员密码不能少于 12 个字符")
+			return
+		}
+		var err error
+		passwordHash, err = hashPassword(input.Password)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "server_error", "创建用户失败")
+			return
+		}
+	}
+	user, err := s.insertUser(r.Context(), input.Name, input.Email, input.Role, passwordHash)
+	if err != nil {
+		writeError(w, http.StatusConflict, "user_exists", "该邮箱已存在")
+		return
+	}
+	writeJSON(w, http.StatusCreated, user)
+}

--- a/monkeyai/backend/internal/identity/doc.go
+++ b/monkeyai/backend/internal/identity/doc.go
@@ -1,2 +1,2 @@
-// Package identity 管理登录、用户、第三方身份、角色和分组。
+// Package identity 管理登录、用户、第三方身份、角色和 Agent OAuth 授权。
 package identity

--- a/monkeyai/backend/internal/identity/middleware.go
+++ b/monkeyai/backend/internal/identity/middleware.go
@@ -1,0 +1,83 @@
+package identity
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+type userContextKey struct{}
+
+func UserFromContext(ctx context.Context) (User, bool) {
+	user, ok := ctx.Value(userContextKey{}).(User)
+	return user, ok
+}
+
+func (s *Service) BrowserUser(r *http.Request) (User, bool) {
+	cookie, err := r.Cookie(sessionCookie)
+	if err != nil || cookie.Value == "" {
+		return User{}, false
+	}
+	user, _, err := s.userByBrowserToken(r.Context(), tokenHash(cookie.Value))
+	return user, err == nil
+}
+
+func (s *Service) RequireAdmin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookie, err := r.Cookie(sessionCookie)
+		if err != nil || cookie.Value == "" {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "请先登录")
+			return
+		}
+		user, authenticationMethod, err := s.userByBrowserToken(r.Context(), tokenHash(cookie.Value))
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "请先登录")
+			return
+		}
+		if user.Role != "admin" || authenticationMethod != "password" {
+			writeError(w, http.StatusForbidden, "forbidden", "需要管理员权限")
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), userContextKey{}, user)))
+	})
+}
+
+func (s *Service) RequireBrowser(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, ok := s.BrowserUser(r)
+		if !ok {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "请先登录")
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), userContextKey{}, user)))
+	})
+}
+
+func (s *Service) RequireAgent(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization := strings.TrimSpace(r.Header.Get("Authorization"))
+		if len(authorization) < 8 || !strings.EqualFold(authorization[:7], "Bearer ") {
+			writeError(w, http.StatusUnauthorized, "invalid_token", "缺少 Bearer access token")
+			return
+		}
+		user, err := s.userByAccessToken(r.Context(), tokenHash(strings.TrimSpace(authorization[7:])))
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "invalid_token", "access token 无效或已过期")
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), userContextKey{}, user)))
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	writeJSON(w, status, map[string]any{
+		"error": map[string]string{"code": code, "message": message},
+	})
+}

--- a/monkeyai/backend/internal/identity/oauth.go
+++ b/monkeyai/backend/internal/identity/oauth.go
@@ -1,0 +1,253 @@
+package identity
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func (s *Service) OAuthRouter() http.Handler {
+	router := chi.NewRouter()
+	router.Get("/authorize", s.authorize)
+	router.Post("/token", s.token)
+	router.Post("/revoke", s.revoke)
+	return router
+}
+
+func (s *Service) AuthRouter() http.Handler {
+	router := chi.NewRouter()
+	router.Get("/clients", s.clients)
+	router.Get("/providers", s.providers)
+	router.Post("/admin/login", s.passwordLogin)
+	router.Get("/session", s.session)
+	router.Post("/logout", s.logout)
+	router.Get("/client-requests/{requestID}", s.clientRequest)
+	router.With(s.RequireBrowser).Post("/client-requests/{requestID}/complete", s.completeClientRequest)
+	router.Get("/oauth/{connectionID}/start", s.startUpstream)
+	router.Get("/oauth/callback", s.upstreamCallback)
+	return router
+}
+
+func (s *Service) OAuthMetadata(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"issuer":                                s.publicURL,
+		"authorization_endpoint":                s.publicURL + "/oauth/authorize",
+		"token_endpoint":                        s.publicURL + "/oauth/token",
+		"revocation_endpoint":                   s.publicURL + "/oauth/revoke",
+		"response_types_supported":              []string{"code"},
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+		"code_challenge_methods_supported":      []string{"S256"},
+		"token_endpoint_auth_methods_supported": []string{"none"},
+	})
+}
+
+func (s *Service) clients(w http.ResponseWriter, _ *http.Request) {
+	clients := []Client{Clients["monkeyai-desktop"], Clients["monkeyai-mobile"]}
+	writeJSON(w, http.StatusOK, map[string]any{"clients": clients})
+}
+
+func (s *Service) authorize(w http.ResponseWriter, r *http.Request) {
+	request, err := s.BeginAuthorization(r.Context(), r.URL.Query())
+	if err != nil {
+		s.writeOAuthError(w, err)
+		return
+	}
+	target := s.adminURL + "/client-login?request_id=" + url.QueryEscape(request.ID)
+	http.Redirect(w, r, target, http.StatusFound)
+}
+
+func (s *Service) token(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+	if err := r.ParseForm(); err != nil {
+		s.writeOAuthError(w, oauthError("invalid_request", "请求格式无效"))
+		return
+	}
+	var token Token
+	var err error
+	switch r.Form.Get("grant_type") {
+	case "authorization_code":
+		token, err = s.ExchangeCode(r.Context(), r.Form.Get("client_id"), r.Form.Get("redirect_uri"), r.Form.Get("code"), r.Form.Get("code_verifier"))
+	case "refresh_token":
+		token, err = s.Refresh(r.Context(), r.Form.Get("client_id"), r.Form.Get("refresh_token"))
+	default:
+		err = oauthError("unsupported_grant_type", "不支持的 grant_type")
+	}
+	if err != nil {
+		s.writeOAuthError(w, err)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, token)
+}
+
+func (s *Service) revoke(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+	if err := r.ParseForm(); err == nil {
+		_ = s.revokeToken(r.Context(), tokenHash(r.Form.Get("token")), r.Form.Get("client_id"))
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Service) writeOAuthError(w http.ResponseWriter, err error) {
+	var protocol protocolError
+	if !errors.As(err, &protocol) {
+		protocol = protocolError{Code: "server_error", Description: "服务暂时不可用"}
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusBadRequest, protocol)
+}
+
+func (s *Service) providers(w http.ResponseWriter, r *http.Request) {
+	connections, err := s.connections(r.Context())
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "settings_unavailable", "认证配置不可用")
+		return
+	}
+	type provider struct {
+		ID       string `json:"id"`
+		Provider string `json:"provider"`
+		Name     string `json:"name"`
+	}
+	result := make([]provider, 0, len(connections))
+	for _, connection := range connections {
+		result = append(result, provider{ID: connection.ID, Provider: connection.Provider, Name: connection.Name})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"providers": result})
+}
+
+func (s *Service) session(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.BrowserUser(r)
+	writeJSON(w, http.StatusOK, map[string]any{"authenticated": ok, "user": nullableUser(user, ok)})
+}
+
+func nullableUser(user User, ok bool) any {
+	if !ok {
+		return nil
+	}
+	return user
+}
+
+func (s *Service) logout(w http.ResponseWriter, r *http.Request) {
+	if cookie, err := r.Cookie(sessionCookie); err == nil {
+		_ = s.revokeBrowserSession(r.Context(), tokenHash(cookie.Value))
+	}
+	http.SetCookie(w, &http.Cookie{Name: sessionCookie, Value: "", Path: "/", MaxAge: -1, HttpOnly: true, Secure: s.secureCookie, SameSite: http.SameSiteLaxMode})
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Service) clientRequest(w http.ResponseWriter, r *http.Request) {
+	request, err := s.authorizationRequest(r.Context(), chi.URLParam(r, "requestID"))
+	if err != nil || request.CompletedAt != nil || !s.now().Before(request.ExpiresAt) {
+		writeError(w, http.StatusNotFound, "request_not_found", "授权请求不存在、已完成或已过期")
+		return
+	}
+	connections, _ := s.connections(r.Context())
+	user, authenticated := s.BrowserUser(r)
+	client := Clients[request.ClientID]
+	writeJSON(w, http.StatusOK, map[string]any{
+		"request_id":    request.ID,
+		"client":        client,
+		"authenticated": authenticated,
+		"user":          nullableUser(user, authenticated),
+		"providers":     publicConnections(connections),
+	})
+}
+
+func publicConnections(connections []OAuthConnection) []map[string]string {
+	result := make([]map[string]string, 0, len(connections))
+	for _, connection := range connections {
+		result = append(result, map[string]string{"id": connection.ID, "provider": connection.Provider, "name": connection.Name})
+	}
+	return result
+}
+
+func (s *Service) completeClientRequest(w http.ResponseWriter, r *http.Request) {
+	user, _ := UserFromContext(r.Context())
+	launchURL, err := s.CompleteAuthorization(r.Context(), chi.URLParam(r, "requestID"), user.ID)
+	if err != nil {
+		writeError(w, http.StatusConflict, "request_unavailable", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"launch_url": launchURL})
+}
+
+func (s *Service) startUpstream(w http.ResponseWriter, r *http.Request) {
+	requestID := r.URL.Query().Get("request_id")
+	if requestID == "" {
+		writeError(w, http.StatusBadRequest, "request_required", "缺少客户端授权请求")
+		return
+	}
+	connectionID := chi.URLParam(r, "connectionID")
+	connection, err := s.connection(r.Context(), connectionID)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "provider_not_found", "登录方式不存在")
+		return
+	}
+	request, err := s.authorizationRequest(r.Context(), requestID)
+	if err != nil || request.CompletedAt != nil || !s.now().Before(request.ExpiresAt) {
+		writeError(w, http.StatusBadRequest, "request_unavailable", "授权请求无效")
+		return
+	}
+	state, err := randomToken(32)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server_error", "无法发起登录")
+		return
+	}
+	if err := s.createLoginState(r.Context(), tokenHash(state), connectionID, requestID, s.now().Add(s.requestTTL)); err != nil {
+		writeError(w, http.StatusInternalServerError, "server_error", "无法发起登录")
+		return
+	}
+	target, err := s.upstreamAuthorizeURL(r.Context(), connection, state)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "provider_unavailable", err.Error())
+		return
+	}
+	http.Redirect(w, r, target, http.StatusFound)
+}
+
+func (s *Service) upstreamCallback(w http.ResponseWriter, r *http.Request) {
+	state, err := s.consumeLoginState(r.Context(), tokenHash(r.URL.Query().Get("state")))
+	if err != nil || r.URL.Query().Get("code") == "" {
+		http.Redirect(w, r, s.clientLoginURL("", "oauth_callback"), http.StatusFound)
+		return
+	}
+	connection, err := s.connection(r.Context(), state.ConnectionID)
+	if err != nil {
+		http.Redirect(w, r, s.clientLoginURL(state.AuthorizationRequestID, "provider_unavailable"), http.StatusFound)
+		return
+	}
+	profile, err := s.exchangeUpstream(r.Context(), connection, r.URL.Query().Get("code"))
+	if err != nil {
+		http.Redirect(w, r, s.clientLoginURL(state.AuthorizationRequestID, "oauth_exchange"), http.StatusFound)
+		return
+	}
+	user, err := s.upsertIdentity(r.Context(), profile)
+	if err != nil {
+		code := "user_unavailable"
+		if errors.Is(err, ErrAdminPasswordRequired) {
+			code = "admin_password_required"
+		}
+		http.Redirect(w, r, s.clientLoginURL(state.AuthorizationRequestID, code), http.StatusFound)
+		return
+	}
+	token, err := randomToken(32)
+	if err != nil || s.createBrowserSession(r.Context(), user.ID, tokenHash(token), "oauth", s.now().Add(s.sessionTTL)) != nil {
+		http.Redirect(w, r, s.clientLoginURL(state.AuthorizationRequestID, "session_failed"), http.StatusFound)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{Name: sessionCookie, Value: token, Path: "/", HttpOnly: true, Secure: s.secureCookie, SameSite: http.SameSiteLaxMode, MaxAge: int(s.sessionTTL.Seconds())})
+	http.Redirect(w, r, s.clientLoginURL(state.AuthorizationRequestID, ""), http.StatusFound)
+}
+
+func (s *Service) clientLoginURL(requestID, errorCode string) string {
+	query := url.Values{}
+	if requestID != "" {
+		query.Set("request_id", requestID)
+	}
+	if errorCode != "" {
+		query.Set("error", errorCode)
+	}
+	return s.adminURL + "/client-login?" + query.Encode()
+}

--- a/monkeyai/backend/internal/identity/password.go
+++ b/monkeyai/backend/internal/identity/password.go
@@ -1,0 +1,142 @@
+package identity
+
+import (
+	"context"
+	"crypto/pbkdf2"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/mail"
+	"strconv"
+	"strings"
+)
+
+const (
+	passwordIterations = 600_000
+	dummyPasswordHash  = "$pbkdf2-sha256$600000$AAAAAAAAAAAAAAAAAAAAAA$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+)
+
+func (s *Service) EnsureInitialAdmin(ctx context.Context, name, email, password string) error {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext('monkeyai:initial-admin'))`); err != nil {
+		return err
+	}
+	var count int
+	if err := tx.QueryRow(ctx, `SELECT count(*) FROM users WHERE deleted_at IS NULL`).Scan(&count); err != nil {
+		return err
+	}
+	if count > 0 {
+		return tx.Commit(ctx)
+	}
+	email = strings.ToLower(strings.TrimSpace(email))
+	name = strings.TrimSpace(name)
+	if name == "" || !validEmail(email) || len(password) < 12 {
+		return errors.New("用户表为空，必须配置有效的首次管理员姓名、邮箱和密码")
+	}
+	hash, err := hashPassword(password)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `
+		INSERT INTO users (name, email, password_hash, role, status)
+		VALUES ($1, $2, $3, 'admin', 'active')
+	`, name, email, hash)
+	if err != nil {
+		return fmt.Errorf("创建首次管理员: %w", err)
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *Service) passwordLogin(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&input); err != nil || len(input.Password) > 1024 {
+		writeError(w, http.StatusBadRequest, "invalid_request", "请求格式无效")
+		return
+	}
+	input.Email = strings.ToLower(strings.TrimSpace(input.Email))
+	var user User
+	var passwordHash string
+	err := s.db.QueryRow(r.Context(), `
+		SELECT id, name, email, coalesce(avatar_url, ''), role, status,
+			joined_at, last_login_at, password_hash
+		FROM users
+		WHERE lower(email) = $1 AND role = 'admin' AND status = 'active'
+			AND deleted_at IS NULL AND password_hash IS NOT NULL
+	`, input.Email).Scan(
+		&user.ID, &user.Name, &user.Email, &user.AvatarURL, &user.Role,
+		&user.Status, &user.JoinedAt, &user.LastLoginAt, &passwordHash,
+	)
+	if err != nil {
+		passwordHash = dummyPasswordHash
+	}
+	valid := verifyPassword(input.Password, passwordHash)
+	if err != nil || !valid {
+		writeError(w, http.StatusUnauthorized, "invalid_credentials", "邮箱或密码错误")
+		return
+	}
+	if _, err := s.db.Exec(r.Context(), `UPDATE users SET last_login_at = now(), updated_at = now() WHERE id = $1`, user.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, "server_error", "登录失败")
+		return
+	}
+	token, err := randomToken(32)
+	if err != nil || s.createBrowserSession(r.Context(), user.ID, tokenHash(token), "password", s.now().Add(s.sessionTTL)) != nil {
+		writeError(w, http.StatusInternalServerError, "server_error", "登录失败")
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name: sessionCookie, Value: token, Path: "/", HttpOnly: true,
+		Secure: s.secureCookie, SameSite: http.SameSiteLaxMode,
+		MaxAge: int(s.sessionTTL.Seconds()),
+	})
+	writeJSON(w, http.StatusOK, user)
+}
+
+func hashPassword(password string) (string, error) {
+	salt := make([]byte, 16)
+	if _, err := rand.Read(salt); err != nil {
+		return "", err
+	}
+	key, err := pbkdf2.Key(sha256.New, password, salt, passwordIterations, 32)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("$pbkdf2-sha256$%d$%s$%s", passwordIterations, base64.RawStdEncoding.EncodeToString(salt), base64.RawStdEncoding.EncodeToString(key)), nil
+}
+
+func verifyPassword(password, encoded string) bool {
+	parts := strings.Split(encoded, "$")
+	if len(parts) != 5 || parts[1] != "pbkdf2-sha256" {
+		return false
+	}
+	iterations, err := strconv.Atoi(parts[2])
+	if err != nil || iterations < 100_000 || iterations > 2_000_000 {
+		return false
+	}
+	salt, err := base64.RawStdEncoding.DecodeString(parts[3])
+	if err != nil || len(salt) < 16 {
+		return false
+	}
+	expected, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil || len(expected) != 32 {
+		return false
+	}
+	actual, err := pbkdf2.Key(sha256.New, password, salt, iterations, len(expected))
+	return err == nil && subtle.ConstantTimeCompare(actual, expected) == 1
+}
+
+func validEmail(value string) bool {
+	address, err := mail.ParseAddress(value)
+	return err == nil && strings.EqualFold(address.Address, value)
+}

--- a/monkeyai/backend/internal/identity/password_test.go
+++ b/monkeyai/backend/internal/identity/password_test.go
@@ -1,0 +1,24 @@
+package identity
+
+import "testing"
+
+func TestPasswordHash(t *testing.T) {
+	encoded, err := hashPassword("correct horse battery staple")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verifyPassword("correct horse battery staple", encoded) {
+		t.Fatal("正确密码未通过校验")
+	}
+	if verifyPassword("wrong password", encoded) {
+		t.Fatal("错误密码通过了校验")
+	}
+}
+
+func TestVerifyPasswordRejectsInvalidHash(t *testing.T) {
+	for _, encoded := range []string{"", "$bcrypt$hash", "$pbkdf2-sha256$1$bad$bad"} {
+		if verifyPassword("password", encoded) {
+			t.Fatalf("非法密码摘要通过校验: %q", encoded)
+		}
+	}
+}

--- a/monkeyai/backend/internal/identity/postgres.go
+++ b/monkeyai/backend/internal/identity/postgres.go
@@ -1,0 +1,368 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func (s *Service) createAuthorizationRequest(ctx context.Context, request *AuthorizationRequest) error {
+	return s.db.QueryRow(ctx, `
+		INSERT INTO oauth_authorization_requests (
+			client_id, redirect_uri, state, code_challenge, code_challenge_method, expires_at
+		) VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id
+	`, request.ClientID, request.RedirectURI, request.State, request.CodeChallenge, request.CodeChallengeMethod, request.ExpiresAt).Scan(&request.ID)
+}
+
+func (s *Service) authorizationRequest(ctx context.Context, id string) (AuthorizationRequest, error) {
+	var request AuthorizationRequest
+	err := s.db.QueryRow(ctx, `
+		SELECT id, client_id, redirect_uri, state, code_challenge,
+			code_challenge_method, expires_at, completed_at
+		FROM oauth_authorization_requests
+		WHERE id = $1
+	`, id).Scan(
+		&request.ID, &request.ClientID, &request.RedirectURI, &request.State,
+		&request.CodeChallenge, &request.CodeChallengeMethod, &request.ExpiresAt,
+		&request.CompletedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return AuthorizationRequest{}, ErrNotFound
+	}
+	return request, err
+}
+
+func (s *Service) storeAuthorizationCode(ctx context.Context, request AuthorizationRequest, userID, codeHash string, expiresAt time.Time) error {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	result, err := tx.Exec(ctx, `
+		UPDATE oauth_authorization_requests
+		SET completed_at = now()
+		WHERE id = $1 AND completed_at IS NULL AND expires_at > now()
+	`, request.ID)
+	if err != nil || result.RowsAffected() != 1 {
+		return errors.New("授权请求已完成或已过期")
+	}
+	_, err = tx.Exec(ctx, `
+		INSERT INTO oauth_authorization_codes (
+			code_hash, authorization_request_id, user_id, client_id,
+			redirect_uri, code_challenge, expires_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, codeHash, request.ID, userID, request.ClientID, request.RedirectURI, request.CodeChallenge, expiresAt)
+	if err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *Service) authorizationCode(ctx context.Context, hash string) (AuthorizationCode, error) {
+	var code AuthorizationCode
+	err := s.db.QueryRow(ctx, `
+		SELECT id, user_id, client_id, redirect_uri, code_challenge, expires_at, redeemed_at
+		FROM oauth_authorization_codes
+		WHERE code_hash = $1
+	`, hash).Scan(&code.ID, &code.UserID, &code.ClientID, &code.RedirectURI, &code.CodeChallenge, &code.ExpiresAt, &code.RedeemedAt)
+	return code, err
+}
+
+func (s *Service) redeemCodeAndStoreToken(ctx context.Context, codeID, userID, clientID, accessHash, refreshHash string, accessExpiry, refreshExpiry time.Time) error {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	result, err := tx.Exec(ctx, `
+		UPDATE oauth_authorization_codes
+		SET redeemed_at = now()
+		WHERE id = $1 AND redeemed_at IS NULL AND expires_at > now()
+	`, codeID)
+	if err != nil || result.RowsAffected() != 1 {
+		return errors.New("授权码已被使用")
+	}
+	_, err = tx.Exec(ctx, `
+		INSERT INTO oauth_tokens (
+			user_id, client_id, access_token_hash, refresh_token_hash,
+			access_expires_at, refresh_expires_at
+		) VALUES ($1, $2, $3, $4, $5, $6)
+	`, userID, clientID, accessHash, refreshHash, accessExpiry, refreshExpiry)
+	if err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *Service) rotateToken(ctx context.Context, oldRefreshHash, clientID, accessHash, refreshHash string, accessExpiry, refreshExpiry time.Time) error {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var userID string
+	err = tx.QueryRow(ctx, `
+		UPDATE oauth_tokens
+		SET revoked_at = now()
+		WHERE refresh_token_hash = $1 AND client_id = $2
+			AND revoked_at IS NULL AND refresh_expires_at > now()
+		RETURNING user_id
+	`, oldRefreshHash, clientID).Scan(&userID)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `
+		INSERT INTO oauth_tokens (
+			user_id, client_id, access_token_hash, refresh_token_hash,
+			access_expires_at, refresh_expires_at
+		) VALUES ($1, $2, $3, $4, $5, $6)
+	`, userID, clientID, accessHash, refreshHash, accessExpiry, refreshExpiry)
+	if err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *Service) createLoginState(ctx context.Context, stateHash, connectionID, requestID string, expiresAt time.Time) error {
+	_, err := s.db.Exec(ctx, `
+		INSERT INTO oauth_login_states (
+			state_hash, connection_id, authorization_request_id, expires_at
+		) VALUES ($1, $2, $3, $4)
+	`, stateHash, connectionID, requestID, expiresAt)
+	return err
+}
+
+func (s *Service) consumeLoginState(ctx context.Context, stateHash string) (LoginState, error) {
+	var state LoginState
+	err := s.db.QueryRow(ctx, `
+		UPDATE oauth_login_states
+		SET consumed_at = now()
+		WHERE state_hash = $1 AND consumed_at IS NULL AND expires_at > now()
+		RETURNING connection_id, authorization_request_id
+	`, stateHash).Scan(&state.ConnectionID, &state.AuthorizationRequestID)
+	return state, err
+}
+
+func (s *Service) createBrowserSession(ctx context.Context, userID, hash, authenticationMethod string, expiresAt time.Time) error {
+	_, err := s.db.Exec(ctx, `
+		INSERT INTO browser_sessions (token_hash, user_id, authentication_method, expires_at)
+		VALUES ($1, $2, $3, $4)
+	`, hash, userID, authenticationMethod, expiresAt)
+	return err
+}
+
+func (s *Service) userByBrowserToken(ctx context.Context, hash string) (User, string, error) {
+	var user User
+	var authenticationMethod string
+	err := s.db.QueryRow(ctx, `
+		SELECT u.id, u.name, u.email, coalesce(u.avatar_url, ''), u.role,
+			u.status, u.joined_at, u.last_login_at, s.authentication_method
+		FROM browser_sessions s
+		JOIN users u ON u.id = s.user_id
+		WHERE s.token_hash = $1 AND s.revoked_at IS NULL AND s.expires_at > now()
+			AND u.status = 'active' AND u.deleted_at IS NULL
+	`, hash).Scan(
+		&user.ID, &user.Name, &user.Email, &user.AvatarURL, &user.Role,
+		&user.Status, &user.JoinedAt, &user.LastLoginAt, &authenticationMethod,
+	)
+	return user, authenticationMethod, err
+}
+
+func (s *Service) userByAccessToken(ctx context.Context, hash string) (User, error) {
+	return scanUser(s.db.QueryRow(ctx, `
+		SELECT u.id, u.name, u.email, coalesce(u.avatar_url, ''), u.role,
+			u.status, u.joined_at, u.last_login_at
+		FROM oauth_tokens t
+		JOIN users u ON u.id = t.user_id
+		WHERE t.access_token_hash = $1 AND t.revoked_at IS NULL
+			AND t.access_expires_at > now() AND u.status = 'active' AND u.deleted_at IS NULL
+	`, hash))
+}
+
+func (s *Service) revokeBrowserSession(ctx context.Context, hash string) error {
+	_, err := s.db.Exec(ctx, `UPDATE browser_sessions SET revoked_at = now() WHERE token_hash = $1 AND revoked_at IS NULL`, hash)
+	return err
+}
+
+func (s *Service) revokeToken(ctx context.Context, hash, clientID string) error {
+	_, err := s.db.Exec(ctx, `
+		UPDATE oauth_tokens SET revoked_at = now()
+		WHERE client_id = $2 AND revoked_at IS NULL
+			AND (access_token_hash = $1 OR refresh_token_hash = $1)
+	`, hash, clientID)
+	return err
+}
+
+func (s *Service) listUsers(ctx context.Context) ([]User, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT id, name, email, coalesce(avatar_url, ''), role, status, joined_at, last_login_at
+		FROM users WHERE deleted_at IS NULL ORDER BY joined_at DESC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	users := make([]User, 0)
+	for rows.Next() {
+		user, err := scanUser(rows)
+		if err != nil {
+			return nil, err
+		}
+		users = append(users, user)
+	}
+	return users, rows.Err()
+}
+
+func (s *Service) insertUser(ctx context.Context, name, email, role, passwordHash string) (User, error) {
+	var password any
+	if passwordHash != "" {
+		password = passwordHash
+	}
+	return scanUser(s.db.QueryRow(ctx, `
+		INSERT INTO users (name, email, role, password_hash)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, name, email, coalesce(avatar_url, ''), role, status, joined_at, last_login_at
+	`, name, email, role, password))
+}
+
+func (s *Service) userByID(ctx context.Context, id string) (User, error) {
+	return scanUser(s.db.QueryRow(ctx, `
+		SELECT id, name, email, coalesce(avatar_url, ''), role, status, joined_at, last_login_at
+		FROM users WHERE id = $1 AND deleted_at IS NULL
+	`, id))
+}
+
+func (s *Service) updateUser(ctx context.Context, id, name, role, status, passwordHash string) (User, error) {
+	var disabledAt any
+	if status == "disabled" {
+		disabledAt = s.now()
+	}
+	user, err := scanUser(s.db.QueryRow(ctx, `
+		UPDATE users SET name = $2, role = $3, status = $4, disabled_at = $5,
+			password_hash = CASE WHEN $6 = '' THEN password_hash ELSE $6 END,
+			updated_at = now()
+		WHERE id = $1 AND deleted_at IS NULL
+		RETURNING id, name, email, coalesce(avatar_url, ''), role, status, joined_at, last_login_at
+	`, id, name, role, status, disabledAt, passwordHash))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return User{}, ErrNotFound
+	}
+	return user, err
+}
+
+type rowScanner interface {
+	Scan(...any) error
+}
+
+func scanUser(row rowScanner) (User, error) {
+	var user User
+	if err := row.Scan(&user.ID, &user.Name, &user.Email, &user.AvatarURL, &user.Role, &user.Status, &user.JoinedAt, &user.LastLoginAt); err != nil {
+		return User{}, err
+	}
+	return user, nil
+}
+
+func (s *Service) upsertIdentity(ctx context.Context, profile upstreamProfile) (User, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return User{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	user, err := scanUser(tx.QueryRow(ctx, `
+		SELECT u.id, u.name, u.email, coalesce(u.avatar_url, ''), u.role, u.status, u.joined_at, u.last_login_at
+		FROM user_identities i JOIN users u ON u.id = i.user_id
+		WHERE i.provider = $1 AND i.issuer = $2 AND i.provider_subject = $3
+			AND i.deleted_at IS NULL AND u.deleted_at IS NULL
+	`, profile.Provider, profile.Issuer, profile.Subject))
+	if err == nil {
+		if user.Role == "admin" {
+			return User{}, ErrAdminPasswordRequired
+		}
+		if user.Status != "active" {
+			return User{}, ErrUserDisabled
+		}
+		err = tx.QueryRow(ctx, `
+			UPDATE users SET name = $2, avatar_url = nullif($3, ''), last_login_at = now(), updated_at = now()
+			WHERE id = $1
+			RETURNING id, name, email, coalesce(avatar_url, ''), role, status, joined_at, last_login_at
+		`, user.ID, profile.Name, profile.AvatarURL).Scan(&user.ID, &user.Name, &user.Email, &user.AvatarURL, &user.Role, &user.Status, &user.JoinedAt, &user.LastLoginAt)
+		if err != nil {
+			return User{}, err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return User{}, err
+		}
+		return user, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return User{}, err
+	}
+
+	if profile.Email == "" {
+		profile.Email = fmt.Sprintf("%s@%s.oauth.local", profile.Subject, profile.Provider)
+	}
+	if profile.Name == "" {
+		profile.Name = profile.Username
+	}
+	if profile.Name == "" {
+		profile.Name = profile.Email
+	}
+	var existingRole, existingStatus string
+	err = tx.QueryRow(ctx, `
+		SELECT role, status FROM users
+		WHERE lower(email) = lower($1) AND deleted_at IS NULL
+	`, profile.Email).Scan(&existingRole, &existingStatus)
+	switch {
+	case err == nil && existingRole == "admin":
+		return User{}, ErrAdminPasswordRequired
+	case err == nil && existingStatus != "active":
+		return User{}, ErrUserDisabled
+	case errors.Is(err, pgx.ErrNoRows):
+		if !s.registrationEnabled(ctx) {
+			return User{}, ErrRegistrationDisabled
+		}
+	case err != nil:
+		return User{}, err
+	}
+	err = tx.QueryRow(ctx, `
+		INSERT INTO users (name, email, avatar_url, role, last_login_at)
+		VALUES ($1, $2, nullif($3, ''), 'user', now())
+		ON CONFLICT (lower(email)) WHERE deleted_at IS NULL DO UPDATE SET
+			name = EXCLUDED.name, avatar_url = EXCLUDED.avatar_url,
+			last_login_at = now(), updated_at = now()
+		WHERE users.role = 'user' AND users.status = 'active'
+		RETURNING id, name, email, coalesce(avatar_url, ''), role, status, joined_at, last_login_at
+	`, profile.Name, profile.Email, profile.AvatarURL).Scan(&user.ID, &user.Name, &user.Email, &user.AvatarURL, &user.Role, &user.Status, &user.JoinedAt, &user.LastLoginAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return User{}, ErrAdminPasswordRequired
+	}
+	if err != nil {
+		return User{}, err
+	}
+	_, err = tx.Exec(ctx, `
+		INSERT INTO user_identities (user_id, provider, issuer, provider_subject, username, email, avatar_url)
+		VALUES ($1, $2, $3, $4, nullif($5, ''), nullif($6, ''), nullif($7, ''))
+	`, user.ID, profile.Provider, profile.Issuer, profile.Subject, profile.Username, profile.Email, profile.AvatarURL)
+	if err != nil {
+		return User{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return User{}, err
+	}
+	return user, nil
+}
+
+var (
+	ErrNotFound              = errors.New("记录不存在")
+	ErrUserDisabled          = errors.New("用户已停用")
+	ErrRegistrationDisabled  = errors.New("未开放新用户注册")
+	ErrAdminPasswordRequired = errors.New("管理员必须使用密码登录")
+)

--- a/monkeyai/backend/internal/identity/service.go
+++ b/monkeyai/backend/internal/identity/service.go
@@ -1,0 +1,265 @@
+package identity
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const sessionCookie = "monkeyai_session"
+
+var verifierPattern = regexp.MustCompile(`^[A-Za-z0-9._~-]{43,128}$`)
+
+type Client struct {
+	ID          string `json:"client_id"`
+	Name        string `json:"name"`
+	RedirectURI string `json:"redirect_uri"`
+}
+
+var Clients = map[string]Client{
+	"monkeyai-desktop": {
+		ID:          "monkeyai-desktop",
+		Name:        "MonkeyAI Desktop",
+		RedirectURI: "monkeyai-desktop://oauth/callback",
+	},
+	"monkeyai-mobile": {
+		ID:          "monkeyai-mobile",
+		Name:        "MonkeyAI Mobile",
+		RedirectURI: "monkeyai-mobile://oauth/callback",
+	},
+}
+
+type User struct {
+	ID          string     `json:"id"`
+	Name        string     `json:"name"`
+	Email       string     `json:"email"`
+	AvatarURL   string     `json:"avatar_url,omitempty"`
+	Role        string     `json:"role"`
+	Status      string     `json:"status"`
+	JoinedAt    time.Time  `json:"joined_at"`
+	LastLoginAt *time.Time `json:"last_login_at,omitempty"`
+}
+
+type AuthorizationRequest struct {
+	ID                  string
+	ClientID            string
+	RedirectURI         string
+	State               string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	ExpiresAt           time.Time
+	CompletedAt         *time.Time
+}
+
+type AuthorizationCode struct {
+	ID            string
+	UserID        string
+	ClientID      string
+	RedirectURI   string
+	CodeChallenge string
+	ExpiresAt     time.Time
+	RedeemedAt    *time.Time
+}
+
+type LoginState struct {
+	ConnectionID           string
+	AuthorizationRequestID string
+}
+
+type Token struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	TokenType    string    `json:"token_type"`
+	ExpiresIn    int64     `json:"expires_in"`
+	ExpiresAt    time.Time `json:"-"`
+}
+
+type SettingReader interface {
+	GetValue(context.Context, string) (json.RawMessage, error)
+}
+
+type Service struct {
+	db           *pgxpool.Pool
+	settings     SettingReader
+	client       *http.Client
+	publicURL    string
+	adminURL     string
+	secureCookie bool
+	now          func() time.Time
+	sessionTTL   time.Duration
+	requestTTL   time.Duration
+	codeTTL      time.Duration
+	accessTTL    time.Duration
+	refreshTTL   time.Duration
+}
+
+func NewService(db *pgxpool.Pool, settings SettingReader, publicURL, adminURL string) *Service {
+	return &Service{
+		db:           db,
+		settings:     settings,
+		client:       &http.Client{Timeout: 15 * time.Second},
+		publicURL:    strings.TrimRight(publicURL, "/"),
+		adminURL:     strings.TrimRight(adminURL, "/"),
+		secureCookie: strings.HasPrefix(publicURL, "https://"),
+		now:          time.Now,
+		sessionTTL:   7 * 24 * time.Hour,
+		requestTTL:   10 * time.Minute,
+		codeTTL:      2 * time.Minute,
+		accessTTL:    time.Hour,
+		refreshTTL:   30 * 24 * time.Hour,
+	}
+}
+
+func (s *Service) BeginAuthorization(ctx context.Context, values url.Values) (AuthorizationRequest, error) {
+	if values.Get("response_type") != "code" {
+		return AuthorizationRequest{}, oauthError("unsupported_response_type", "仅支持 authorization code")
+	}
+	client, ok := Clients[values.Get("client_id")]
+	if !ok || values.Get("redirect_uri") != client.RedirectURI {
+		return AuthorizationRequest{}, oauthError("invalid_request", "client_id 或 redirect_uri 无效")
+	}
+	state := values.Get("state")
+	if state == "" {
+		return AuthorizationRequest{}, oauthError("invalid_request", "state 不能为空")
+	}
+	challenge := values.Get("code_challenge")
+	if values.Get("code_challenge_method") != "S256" || !validChallenge(challenge) {
+		return AuthorizationRequest{}, oauthError("invalid_request", "必须使用有效的 PKCE S256")
+	}
+
+	request := AuthorizationRequest{
+		ClientID:            client.ID,
+		RedirectURI:         client.RedirectURI,
+		State:               state,
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+		ExpiresAt:           s.now().Add(s.requestTTL),
+	}
+	if err := s.createAuthorizationRequest(ctx, &request); err != nil {
+		return AuthorizationRequest{}, err
+	}
+	return request, nil
+}
+
+func (s *Service) CompleteAuthorization(ctx context.Context, requestID, userID string) (string, error) {
+	request, err := s.authorizationRequest(ctx, requestID)
+	if err != nil {
+		return "", err
+	}
+	if request.CompletedAt != nil || !s.now().Before(request.ExpiresAt) {
+		return "", errors.New("授权请求已完成或已过期")
+	}
+	code, err := randomToken(32)
+	if err != nil {
+		return "", err
+	}
+	if err := s.storeAuthorizationCode(ctx, request, userID, tokenHash(code), s.now().Add(s.codeTTL)); err != nil {
+		return "", err
+	}
+	callback, _ := url.Parse(request.RedirectURI)
+	query := callback.Query()
+	query.Set("code", code)
+	query.Set("state", request.State)
+	callback.RawQuery = query.Encode()
+	return callback.String(), nil
+}
+
+func (s *Service) ExchangeCode(ctx context.Context, clientID, redirectURI, code, verifier string) (Token, error) {
+	client, ok := Clients[clientID]
+	if !ok || redirectURI != client.RedirectURI {
+		return Token{}, oauthError("invalid_client", "客户端信息无效")
+	}
+	if !verifierPattern.MatchString(verifier) {
+		return Token{}, oauthError("invalid_grant", "code_verifier 无效")
+	}
+	stored, err := s.authorizationCode(ctx, tokenHash(code))
+	if err != nil || stored.ClientID != clientID || stored.RedirectURI != redirectURI || stored.RedeemedAt != nil || !s.now().Before(stored.ExpiresAt) {
+		return Token{}, oauthError("invalid_grant", "授权码无效或已过期")
+	}
+	digest := sha256.Sum256([]byte(verifier))
+	actual := base64.RawURLEncoding.EncodeToString(digest[:])
+	if subtle.ConstantTimeCompare([]byte(actual), []byte(stored.CodeChallenge)) != 1 {
+		return Token{}, oauthError("invalid_grant", "PKCE 校验失败")
+	}
+
+	access, err := randomToken(32)
+	if err != nil {
+		return Token{}, err
+	}
+	refresh, err := randomToken(48)
+	if err != nil {
+		return Token{}, err
+	}
+	token := Token{
+		AccessToken: access, RefreshToken: refresh, TokenType: "Bearer",
+		ExpiresIn: int64(s.accessTTL.Seconds()), ExpiresAt: s.now().Add(s.accessTTL),
+	}
+	if err := s.redeemCodeAndStoreToken(ctx, stored.ID, stored.UserID, clientID, tokenHash(access), tokenHash(refresh), token.ExpiresAt, s.now().Add(s.refreshTTL)); err != nil {
+		return Token{}, oauthError("invalid_grant", "授权码已被使用")
+	}
+	return token, nil
+}
+
+func (s *Service) Refresh(ctx context.Context, clientID, refreshToken string) (Token, error) {
+	if _, ok := Clients[clientID]; !ok {
+		return Token{}, oauthError("invalid_client", "客户端信息无效")
+	}
+	access, err := randomToken(32)
+	if err != nil {
+		return Token{}, err
+	}
+	refresh, err := randomToken(48)
+	if err != nil {
+		return Token{}, err
+	}
+	token := Token{AccessToken: access, RefreshToken: refresh, TokenType: "Bearer", ExpiresIn: int64(s.accessTTL.Seconds()), ExpiresAt: s.now().Add(s.accessTTL)}
+	if err := s.rotateToken(ctx, tokenHash(refreshToken), clientID, tokenHash(access), tokenHash(refresh), token.ExpiresAt, s.now().Add(s.refreshTTL)); err != nil {
+		return Token{}, oauthError("invalid_grant", "refresh_token 无效或已过期")
+	}
+	return token, nil
+}
+
+func validChallenge(value string) bool {
+	if len(value) != 43 {
+		return false
+	}
+	_, err := base64.RawURLEncoding.DecodeString(value)
+	return err == nil
+}
+
+func randomToken(size int) (string, error) {
+	value := make([]byte, size)
+	if _, err := rand.Read(value); err != nil {
+		return "", fmt.Errorf("生成安全随机数: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(value), nil
+}
+
+func tokenHash(value string) string {
+	digest := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(digest[:])
+}
+
+type protocolError struct {
+	Code        string `json:"error"`
+	Description string `json:"error_description"`
+}
+
+func (e protocolError) Error() string { return e.Description }
+
+func oauthError(code, description string) error {
+	return protocolError{Code: code, Description: description}
+}

--- a/monkeyai/backend/internal/identity/service_test.go
+++ b/monkeyai/backend/internal/identity/service_test.go
@@ -1,0 +1,65 @@
+package identity
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestClientRegistry(t *testing.T) {
+	tests := map[string]string{
+		"monkeyai-desktop": "monkeyai-desktop://oauth/callback",
+		"monkeyai-mobile":  "monkeyai-mobile://oauth/callback",
+	}
+	for clientID, redirectURI := range tests {
+		client, ok := Clients[clientID]
+		if !ok || client.RedirectURI != redirectURI {
+			t.Fatalf("client %s = %#v", clientID, client)
+		}
+	}
+}
+
+func TestValidChallenge(t *testing.T) {
+	verifier := "0123456789012345678901234567890123456789012"
+	digest := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(digest[:])
+	if !validChallenge(challenge) {
+		t.Fatalf("challenge 应有效: %s", challenge)
+	}
+	if validChallenge("invalid") {
+		t.Fatal("短 challenge 不应有效")
+	}
+}
+
+func TestBeginAuthorizationRejectsUnknownClientBeforeDatabase(t *testing.T) {
+	service := &Service{}
+	_, err := service.BeginAuthorization(t.Context(), url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"unknown"},
+		"redirect_uri":          {"unknown://callback"},
+		"state":                 {"state"},
+		"code_challenge":        {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		"code_challenge_method": {"S256"},
+	})
+	if err == nil {
+		t.Fatal("未知客户端应被拒绝")
+	}
+}
+
+func TestUpstreamLoginRequiresClientAuthorizationRequest(t *testing.T) {
+	service := &Service{}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/auth/v1/oauth/github/start", nil)
+
+	service.startUpstream(recorder, request)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d", recorder.Code)
+	}
+	if got := recorder.Body.String(); got != "{\"error\":{\"code\":\"request_required\",\"message\":\"缺少客户端授权请求\"}}\n" {
+		t.Fatalf("body = %q", got)
+	}
+}

--- a/monkeyai/backend/internal/identity/upstream.go
+++ b/monkeyai/backend/internal/identity/upstream.go
@@ -1,0 +1,253 @@
+package identity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type OAuthConnection struct {
+	ID               string   `json:"id"`
+	Provider         string   `json:"provider"`
+	Name             string   `json:"name"`
+	ClientID         string   `json:"client_id"`
+	ClientSecret     string   `json:"client_secret"`
+	IssuerURL        string   `json:"issuer_url,omitempty"`
+	AuthorizationURL string   `json:"authorization_url,omitempty"`
+	TokenURL         string   `json:"token_url,omitempty"`
+	UserInfoURL      string   `json:"userinfo_url,omitempty"`
+	Scopes           []string `json:"scopes,omitempty"`
+	Enabled          bool     `json:"enabled"`
+}
+
+type authenticationSettings struct {
+	RegistrationEnabled bool              `json:"registration_enabled"`
+	OAuthConnections    []OAuthConnection `json:"oauth_connections"`
+}
+
+type providerMetadata struct {
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	UserInfoEndpoint      string `json:"userinfo_endpoint"`
+}
+
+type upstreamProfile struct {
+	Provider  string
+	Issuer    string
+	Subject   string
+	Username  string
+	Name      string
+	Email     string
+	AvatarURL string
+}
+
+func (s *Service) connections(ctx context.Context) ([]OAuthConnection, error) {
+	value, err := s.settings.GetValue(ctx, "authentication")
+	if err != nil {
+		return nil, err
+	}
+	var settings authenticationSettings
+	if err := json.Unmarshal(value, &settings); err != nil {
+		return nil, fmt.Errorf("解析认证设置: %w", err)
+	}
+	connections := make([]OAuthConnection, 0, len(settings.OAuthConnections))
+	for _, connection := range settings.OAuthConnections {
+		if connection.Enabled {
+			connections = append(connections, connection)
+		}
+	}
+	return connections, nil
+}
+
+func (s *Service) registrationEnabled(ctx context.Context) bool {
+	value, err := s.settings.GetValue(ctx, "authentication")
+	if err != nil {
+		return false
+	}
+	var settings authenticationSettings
+	return json.Unmarshal(value, &settings) == nil && settings.RegistrationEnabled
+}
+
+func (s *Service) connection(ctx context.Context, id string) (OAuthConnection, error) {
+	connections, err := s.connections(ctx)
+	if err != nil {
+		return OAuthConnection{}, err
+	}
+	for _, connection := range connections {
+		if connection.ID == id {
+			return connection, nil
+		}
+	}
+	return OAuthConnection{}, ErrNotFound
+}
+
+func (s *Service) providerURLs(ctx context.Context, connection OAuthConnection) (providerMetadata, error) {
+	metadata := providerMetadata{
+		AuthorizationEndpoint: connection.AuthorizationURL,
+		TokenEndpoint:         connection.TokenURL,
+		UserInfoEndpoint:      connection.UserInfoURL,
+	}
+	if metadata.AuthorizationEndpoint != "" && metadata.TokenEndpoint != "" && metadata.UserInfoEndpoint != "" {
+		return metadata, nil
+	}
+
+	switch connection.Provider {
+	case "github":
+		metadata = providerMetadata{"https://github.com/login/oauth/authorize", "https://github.com/login/oauth/access_token", "https://api.github.com/user"}
+	case "google":
+		metadata = providerMetadata{"https://accounts.google.com/o/oauth2/v2/auth", "https://oauth2.googleapis.com/token", "https://openidconnect.googleapis.com/v1/userinfo"}
+	case "microsoft":
+		metadata = providerMetadata{"https://login.microsoftonline.com/common/oauth2/v2.0/authorize", "https://login.microsoftonline.com/common/oauth2/v2.0/token", "https://graph.microsoft.com/oidc/userinfo"}
+	case "gitlab":
+		metadata = providerMetadata{"https://gitlab.com/oauth/authorize", "https://gitlab.com/oauth/token", "https://gitlab.com/api/v4/user"}
+	case "oidc":
+		if connection.IssuerURL == "" {
+			return providerMetadata{}, errors.New("OIDC issuer_url 不能为空")
+		}
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(connection.IssuerURL, "/")+"/.well-known/openid-configuration", nil)
+		if err != nil {
+			return providerMetadata{}, err
+		}
+		response, err := s.client.Do(request)
+		if err != nil {
+			return providerMetadata{}, fmt.Errorf("读取 OIDC 元数据: %w", err)
+		}
+		defer response.Body.Close()
+		if response.StatusCode != http.StatusOK {
+			return providerMetadata{}, fmt.Errorf("读取 OIDC 元数据: HTTP %d", response.StatusCode)
+		}
+		if err := json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(&metadata); err != nil {
+			return providerMetadata{}, fmt.Errorf("解析 OIDC 元数据: %w", err)
+		}
+	default:
+		return providerMetadata{}, errors.New("不支持的 OAuth 提供方")
+	}
+	return metadata, nil
+}
+
+func (s *Service) upstreamAuthorizeURL(ctx context.Context, connection OAuthConnection, state string) (string, error) {
+	metadata, err := s.providerURLs(ctx, connection)
+	if err != nil {
+		return "", err
+	}
+	endpoint, err := url.Parse(metadata.AuthorizationEndpoint)
+	if err != nil {
+		return "", err
+	}
+	scopes := connection.Scopes
+	if len(scopes) == 0 {
+		scopes = []string{"openid", "profile", "email"}
+		if connection.Provider == "github" {
+			scopes = []string{"read:user", "user:email"}
+		}
+	}
+	query := endpoint.Query()
+	query.Set("response_type", "code")
+	query.Set("client_id", connection.ClientID)
+	query.Set("redirect_uri", s.publicURL+"/api/auth/v1/oauth/callback")
+	query.Set("scope", strings.Join(scopes, " "))
+	query.Set("state", state)
+	endpoint.RawQuery = query.Encode()
+	return endpoint.String(), nil
+}
+
+func (s *Service) exchangeUpstream(ctx context.Context, connection OAuthConnection, code string) (upstreamProfile, error) {
+	metadata, err := s.providerURLs(ctx, connection)
+	if err != nil {
+		return upstreamProfile{}, err
+	}
+	values := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {connection.ClientID},
+		"client_secret": {connection.ClientSecret},
+		"code":          {code},
+		"redirect_uri":  {s.publicURL + "/api/auth/v1/oauth/callback"},
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, metadata.TokenEndpoint, strings.NewReader(values.Encode()))
+	if err != nil {
+		return upstreamProfile{}, err
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	response, err := s.client.Do(request)
+	if err != nil {
+		return upstreamProfile{}, fmt.Errorf("交换上游令牌: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(response.Body, 4096))
+		return upstreamProfile{}, fmt.Errorf("交换上游令牌: HTTP %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var tokenResponse struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(&tokenResponse); err != nil || tokenResponse.AccessToken == "" {
+		return upstreamProfile{}, errors.New("上游未返回 access_token")
+	}
+
+	request, err = http.NewRequestWithContext(ctx, http.MethodGet, metadata.UserInfoEndpoint, nil)
+	if err != nil {
+		return upstreamProfile{}, err
+	}
+	request.Header.Set("Authorization", "Bearer "+tokenResponse.AccessToken)
+	request.Header.Set("Accept", "application/json")
+	response, err = s.client.Do(request)
+	if err != nil {
+		return upstreamProfile{}, fmt.Errorf("读取上游用户: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return upstreamProfile{}, fmt.Errorf("读取上游用户: HTTP %d", response.StatusCode)
+	}
+	var raw map[string]any
+	if err := json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(&raw); err != nil {
+		return upstreamProfile{}, err
+	}
+	profile := normalizeProfile(connection, raw)
+	if profile.Subject == "" {
+		return upstreamProfile{}, errors.New("上游用户缺少 subject")
+	}
+	return profile, nil
+}
+
+func normalizeProfile(connection OAuthConnection, raw map[string]any) upstreamProfile {
+	issuer := connection.IssuerURL
+	if issuer == "" {
+		issuer = connection.Provider
+	}
+	profile := upstreamProfile{
+		Provider:  connection.Provider,
+		Issuer:    issuer,
+		Subject:   stringValue(raw, "sub", "id"),
+		Username:  stringValue(raw, "preferred_username", "login", "username", "userPrincipalName"),
+		Name:      stringValue(raw, "name", "displayName", "login", "username"),
+		Email:     stringValue(raw, "email", "mail", "userPrincipalName"),
+		AvatarURL: stringValue(raw, "picture", "avatar_url"),
+	}
+	if profile.Name == "" {
+		profile.Name = profile.Username
+	}
+	return profile
+}
+
+func stringValue(values map[string]any, keys ...string) string {
+	for _, key := range keys {
+		switch value := values[key].(type) {
+		case string:
+			if value != "" {
+				return value
+			}
+		case float64:
+			return strconv.FormatInt(int64(value), 10)
+		case json.Number:
+			return value.String()
+		}
+	}
+	return ""
+}

--- a/monkeyai/backend/internal/setting/admin.go
+++ b/monkeyai/backend/internal/setting/admin.go
@@ -1,0 +1,67 @@
+package setting
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/chaitin/MonkeyCode/monkeyai/backend/internal/identity"
+	"github.com/go-chi/chi/v5"
+)
+
+func (s *Service) RegisterAdmin(router chi.Router) {
+	router.Get("/settings", func(w http.ResponseWriter, r *http.Request) {
+		records, err := s.AdminList(r.Context())
+		if err != nil {
+			settingError(w, http.StatusInternalServerError, "读取设置失败")
+			return
+		}
+		settingJSON(w, http.StatusOK, map[string]any{"settings": records})
+	})
+	router.Get("/settings/{key}", func(w http.ResponseWriter, r *http.Request) {
+		record, err := s.AdminGet(r.Context(), chi.URLParam(r, "key"))
+		if err != nil {
+			status := http.StatusInternalServerError
+			if errors.Is(err, ErrUnknownKey) || errors.Is(err, ErrNotFound) {
+				status = http.StatusNotFound
+			}
+			settingError(w, status, "设置不存在")
+			return
+		}
+		settingJSON(w, http.StatusOK, record)
+	})
+	router.Put("/settings/{key}", s.putSetting)
+}
+
+func (s *Service) putSetting(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Value         json.RawMessage `json:"value"`
+		SchemaVersion int             `json:"schema_version"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 2<<20)).Decode(&input); err != nil {
+		settingError(w, http.StatusBadRequest, "请求格式无效")
+		return
+	}
+	user, _ := identity.UserFromContext(r.Context())
+	record, err := s.Put(r.Context(), chi.URLParam(r, "key"), input.Value, input.SchemaVersion, user.ID)
+	if err != nil {
+		settingError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	record.Value, err = redact(record.Key, record.Value)
+	if err != nil {
+		settingError(w, http.StatusInternalServerError, "设置已保存，但响应脱敏失败")
+		return
+	}
+	settingJSON(w, http.StatusOK, record)
+}
+
+func settingJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func settingError(w http.ResponseWriter, status int, message string) {
+	settingJSON(w, status, map[string]any{"error": map[string]string{"code": "setting_error", "message": message}})
+}

--- a/monkeyai/backend/internal/setting/agent.go
+++ b/monkeyai/backend/internal/setting/agent.go
@@ -1,0 +1,62 @@
+package setting
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func (s *Service) RegisterAgent(router chi.Router) {
+	router.Get("/config", func(w http.ResponseWriter, r *http.Request) {
+		config, err := s.AgentConfig(r.Context())
+		if err != nil {
+			settingError(w, http.StatusInternalServerError, "读取 Agent 配置失败")
+			return
+		}
+		settingJSON(w, http.StatusOK, config)
+	})
+	router.Get("/config/events", s.events)
+}
+
+func (s *Service) events(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		settingError(w, http.StatusInternalServerError, "当前连接不支持 SSE")
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	events, unsubscribe := s.broker.Subscribe()
+	defer unsubscribe()
+	_, _ = fmt.Fprint(w, "event: ready\ndata: {}\n\n")
+	flusher.Flush()
+
+	heartbeat := time.NewTicker(20 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case event := <-events:
+			config, err := s.AgentConfig(r.Context())
+			if err != nil {
+				return
+			}
+			payload, err := json.Marshal(map[string]any{"change": event, "config": config})
+			if err != nil {
+				return
+			}
+			_, _ = fmt.Fprintf(w, "event: config\nid: %d\ndata: %s\n\n", event.Version, payload)
+			flusher.Flush()
+		case <-heartbeat.C:
+			_, _ = fmt.Fprint(w, ": heartbeat\n\n")
+			flusher.Flush()
+		}
+	}
+}

--- a/monkeyai/backend/internal/setting/broker.go
+++ b/monkeyai/backend/internal/setting/broker.go
@@ -1,0 +1,41 @@
+package setting
+
+import "sync"
+
+type Event struct {
+	Key     string `json:"key"`
+	Version int64  `json:"version"`
+}
+
+type Broker struct {
+	mu          sync.Mutex
+	subscribers map[chan Event]struct{}
+}
+
+func NewBroker() *Broker {
+	return &Broker{subscribers: make(map[chan Event]struct{})}
+}
+
+func (b *Broker) Subscribe() (<-chan Event, func()) {
+	channel := make(chan Event, 1)
+	b.mu.Lock()
+	b.subscribers[channel] = struct{}{}
+	b.mu.Unlock()
+
+	return channel, func() {
+		b.mu.Lock()
+		delete(b.subscribers, channel)
+		b.mu.Unlock()
+	}
+}
+
+func (b *Broker) Publish(event Event) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for channel := range b.subscribers {
+		select {
+		case channel <- event:
+		default:
+		}
+	}
+}

--- a/monkeyai/backend/internal/setting/doc.go
+++ b/monkeyai/backend/internal/setting/doc.go
@@ -1,2 +1,2 @@
-// Package setting 管理当前系统唯一的全局设置。
+// Package setting 管理全局设置以及面向 Agent 的实时配置。
 package setting

--- a/monkeyai/backend/internal/setting/postgres.go
+++ b/monkeyai/backend/internal/setting/postgres.go
@@ -1,0 +1,127 @@
+package setting
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Postgres struct {
+	pool *pgxpool.Pool
+}
+
+func NewPostgres(pool *pgxpool.Pool) *Postgres {
+	return &Postgres{pool: pool}
+}
+
+func (p *Postgres) Get(ctx context.Context, key string) (Record, error) {
+	record, err := scanRecord(p.pool.QueryRow(ctx, `
+		SELECT key, value, schema_version, updated_by_user_id, updated_at
+		FROM settings
+		WHERE key = $1
+	`, key))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Record{}, ErrNotFound
+	}
+	return record, err
+}
+
+func (p *Postgres) List(ctx context.Context) ([]Record, error) {
+	rows, err := p.pool.Query(ctx, `
+		SELECT key, value, schema_version, updated_by_user_id, updated_at
+		FROM settings
+		ORDER BY key
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("查询设置: %w", err)
+	}
+	defer rows.Close()
+
+	records := make([]Record, 0, len(Keys))
+	for rows.Next() {
+		record, err := scanRecord(rows)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	return records, rows.Err()
+}
+
+func (p *Postgres) Put(ctx context.Context, record Record) (Record, error) {
+	tx, err := p.pool.Begin(ctx)
+	if err != nil {
+		return Record{}, fmt.Errorf("开始保存设置: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	stored, err := scanRecord(tx.QueryRow(ctx, `
+		INSERT INTO settings (key, value, schema_version, updated_by_user_id)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (key) DO UPDATE SET
+			value = EXCLUDED.value,
+			schema_version = EXCLUDED.schema_version,
+			updated_by_user_id = EXCLUDED.updated_by_user_id,
+			updated_at = now()
+		RETURNING key, value, schema_version, updated_by_user_id, updated_at
+	`, record.Key, record.Value, record.SchemaVersion, record.UpdatedByUserID))
+	if err != nil {
+		return Record{}, fmt.Errorf("保存设置: %w", err)
+	}
+	payload, err := json.Marshal(Event{Key: stored.Key, Version: stored.UpdatedAt.UnixMilli()})
+	if err != nil {
+		return Record{}, err
+	}
+	if _, err := tx.Exec(ctx, `SELECT pg_notify('monkeyai_settings', $1)`, string(payload)); err != nil {
+		return Record{}, fmt.Errorf("发布设置变更: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Record{}, fmt.Errorf("提交设置: %w", err)
+	}
+	return stored, nil
+}
+
+func (p *Postgres) Listen(ctx context.Context, publish func(Event)) error {
+	connection, err := p.pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("获取设置监听连接: %w", err)
+	}
+	defer connection.Release()
+	if _, err := connection.Exec(ctx, `LISTEN monkeyai_settings`); err != nil {
+		return fmt.Errorf("监听设置变更: %w", err)
+	}
+	for {
+		notification, err := connection.Conn().WaitForNotification(ctx)
+		if err != nil {
+			return err
+		}
+		var event Event
+		if json.Unmarshal([]byte(notification.Payload), &event) == nil && event.Key != "" {
+			publish(event)
+		}
+	}
+}
+
+type scanner interface {
+	Scan(...any) error
+}
+
+func scanRecord(row scanner) (Record, error) {
+	var record Record
+	if err := row.Scan(
+		&record.Key,
+		&record.Value,
+		&record.SchemaVersion,
+		&record.UpdatedByUserID,
+		&record.UpdatedAt,
+	); err != nil {
+		return Record{}, err
+	}
+	return record, nil
+}
+
+var ErrNotFound = errors.New("设置不存在")

--- a/monkeyai/backend/internal/setting/service.go
+++ b/monkeyai/backend/internal/setting/service.go
@@ -1,0 +1,278 @@
+package setting
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+)
+
+var Keys = []string{"branding", "authentication", "email", "billing"}
+
+type Record struct {
+	Key             string          `json:"key"`
+	Value           json.RawMessage `json:"value"`
+	SchemaVersion   int             `json:"schema_version"`
+	UpdatedByUserID string          `json:"updated_by_user_id"`
+	UpdatedAt       time.Time       `json:"updated_at"`
+}
+
+type Config struct {
+	Version   int64                      `json:"version"`
+	UpdatedAt time.Time                  `json:"updated_at"`
+	Settings  map[string]json.RawMessage `json:"settings"`
+}
+
+type Store interface {
+	Get(context.Context, string) (Record, error)
+	List(context.Context) ([]Record, error)
+	Put(context.Context, Record) (Record, error)
+}
+
+type Service struct {
+	store             Store
+	broker            *Broker
+	distributedEvents bool
+}
+
+func NewService(store Store, broker *Broker) *Service {
+	_, distributed := store.(eventListener)
+	return &Service{store: store, broker: broker, distributedEvents: distributed}
+}
+
+type eventListener interface {
+	Listen(context.Context, func(Event)) error
+}
+
+func (s *Service) Listen(ctx context.Context) error {
+	listener, ok := s.store.(eventListener)
+	if !ok {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return listener.Listen(ctx, s.broker.Publish)
+}
+
+func (s *Service) Get(ctx context.Context, key string) (Record, error) {
+	if !slices.Contains(Keys, key) {
+		return Record{}, ErrUnknownKey
+	}
+	return s.store.Get(ctx, key)
+}
+
+func (s *Service) GetValue(ctx context.Context, key string) (json.RawMessage, error) {
+	record, err := s.Get(ctx, key)
+	return record.Value, err
+}
+
+func (s *Service) List(ctx context.Context) ([]Record, error) {
+	return s.store.List(ctx)
+}
+
+func (s *Service) Put(ctx context.Context, key string, value json.RawMessage, schemaVersion int, userID string) (Record, error) {
+	if !slices.Contains(Keys, key) {
+		return Record{}, ErrUnknownKey
+	}
+	if schemaVersion < 1 {
+		return Record{}, errors.New("schema_version 必须大于 0")
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(value, &object); err != nil || object == nil {
+		return Record{}, errors.New("value 必须是 JSON 对象")
+	}
+	value, err := s.mergeSecrets(ctx, key, value)
+	if err != nil {
+		return Record{}, err
+	}
+	if err := json.Unmarshal(value, &object); err != nil {
+		return Record{}, errors.New("value 必须是 JSON 对象")
+	}
+	if err := validate(key, object); err != nil {
+		return Record{}, err
+	}
+
+	record, err := s.store.Put(ctx, Record{
+		Key:             key,
+		Value:           value,
+		SchemaVersion:   schemaVersion,
+		UpdatedByUserID: userID,
+	})
+	if err != nil {
+		return Record{}, err
+	}
+	if !s.distributedEvents {
+		s.broker.Publish(Event{Key: record.Key, Version: record.UpdatedAt.UnixMilli()})
+	}
+	return record, nil
+}
+
+func (s *Service) AdminGet(ctx context.Context, key string) (Record, error) {
+	record, err := s.Get(ctx, key)
+	if err != nil {
+		return Record{}, err
+	}
+	record.Value, err = redact(record.Key, record.Value)
+	return record, err
+}
+
+func (s *Service) AdminList(ctx context.Context) ([]Record, error) {
+	records, err := s.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for index := range records {
+		records[index].Value, err = redact(records[index].Key, records[index].Value)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return records, nil
+}
+
+func (s *Service) AgentConfig(ctx context.Context) (Config, error) {
+	records, err := s.store.List(ctx)
+	if err != nil {
+		return Config{}, err
+	}
+
+	config := Config{Settings: make(map[string]json.RawMessage)}
+	for _, record := range records {
+		value, err := redact(record.Key, record.Value)
+		if err != nil {
+			return Config{}, fmt.Errorf("过滤 %s 配置: %w", record.Key, err)
+		}
+		config.Settings[record.Key] = value
+		if record.UpdatedAt.After(config.UpdatedAt) {
+			config.UpdatedAt = record.UpdatedAt
+		}
+	}
+	config.Version = config.UpdatedAt.UnixMilli()
+	return config, nil
+}
+
+func redact(key string, value json.RawMessage) (json.RawMessage, error) {
+	var object map[string]any
+	if err := json.Unmarshal(value, &object); err != nil {
+		return nil, err
+	}
+	switch key {
+	case "authentication":
+		connections, _ := object["oauth_connections"].([]any)
+		for _, item := range connections {
+			if connection, ok := item.(map[string]any); ok {
+				delete(connection, "client_secret")
+			}
+		}
+	case "email":
+		delete(object, "smtp_password")
+	case "billing":
+		delete(object, "remote_billing_api_key")
+	}
+	return json.Marshal(object)
+}
+
+func (s *Service) mergeSecrets(ctx context.Context, key string, value json.RawMessage) (json.RawMessage, error) {
+	existing, err := s.store.Get(ctx, key)
+	if errors.Is(err, ErrNotFound) {
+		return value, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var next, previous map[string]any
+	if json.Unmarshal(value, &next) != nil || json.Unmarshal(existing.Value, &previous) != nil {
+		return value, nil
+	}
+	switch key {
+	case "authentication":
+		previousByID := make(map[string]map[string]any)
+		for _, item := range anySlice(previous["oauth_connections"]) {
+			connection, _ := item.(map[string]any)
+			previousByID[stringAny(connection["id"])] = connection
+		}
+		for _, item := range anySlice(next["oauth_connections"]) {
+			connection, _ := item.(map[string]any)
+			if stringAny(connection["client_secret"]) == "" {
+				connection["client_secret"] = previousByID[stringAny(connection["id"])]["client_secret"]
+			}
+		}
+	case "email":
+		if stringAny(next["smtp_password"]) == "" {
+			next["smtp_password"] = previous["smtp_password"]
+		}
+	case "billing":
+		if stringAny(next["remote_billing_api_key"]) == "" {
+			next["remote_billing_api_key"] = previous["remote_billing_api_key"]
+		}
+	}
+	return json.Marshal(next)
+}
+
+func validate(key string, value map[string]json.RawMessage) error {
+	switch key {
+	case "branding":
+		if rawString(value["workspace_name"]) == "" || rawString(value["product_name"]) == "" {
+			return errors.New("workspace_name 和 product_name 不能为空")
+		}
+	case "authentication":
+		var connections []struct {
+			ID           string `json:"id"`
+			Provider     string `json:"provider"`
+			Name         string `json:"name"`
+			ClientID     string `json:"client_id"`
+			ClientSecret string `json:"client_secret"`
+			IssuerURL    string `json:"issuer_url"`
+		}
+		if raw, ok := value["oauth_connections"]; ok && json.Unmarshal(raw, &connections) != nil {
+			return errors.New("oauth_connections 格式无效")
+		}
+		seen := make(map[string]bool)
+		for _, connection := range connections {
+			if connection.ID == "" || seen[connection.ID] || connection.Name == "" || connection.ClientID == "" || connection.ClientSecret == "" {
+				return errors.New("OAuth 配置缺少必填字段或 ID 重复")
+			}
+			seen[connection.ID] = true
+			if !slices.Contains([]string{"github", "google", "microsoft", "gitlab", "oidc"}, connection.Provider) {
+				return errors.New("OAuth provider 无效")
+			}
+			if connection.Provider == "oidc" && connection.IssuerURL == "" {
+				return errors.New("OIDC issuer_url 不能为空")
+			}
+		}
+	case "email":
+		var port int
+		if raw, ok := value["smtp_port"]; ok && json.Unmarshal(raw, &port) == nil && (port < 1 || port > 65535) {
+			return errors.New("smtp_port 必须在 1 到 65535 之间")
+		}
+	case "billing":
+		cycle := rawString(value["quota_refresh_cycle"])
+		mode := rawString(value["charging_mode"])
+		if cycle != "" && !slices.Contains([]string{"daily", "weekly", "monthly"}, cycle) {
+			return errors.New("quota_refresh_cycle 无效")
+		}
+		if mode != "" && !slices.Contains([]string{"local", "remote"}, mode) {
+			return errors.New("charging_mode 无效")
+		}
+	}
+	return nil
+}
+
+func rawString(value json.RawMessage) string {
+	var result string
+	_ = json.Unmarshal(value, &result)
+	return result
+}
+
+func anySlice(value any) []any {
+	result, _ := value.([]any)
+	return result
+}
+
+func stringAny(value any) string {
+	result, _ := value.(string)
+	return result
+}
+
+var ErrUnknownKey = errors.New("未知设置域")

--- a/monkeyai/backend/internal/setting/service_test.go
+++ b/monkeyai/backend/internal/setting/service_test.go
@@ -1,0 +1,71 @@
+package setting
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+type memoryStore struct {
+	records map[string]Record
+}
+
+func (m *memoryStore) Get(_ context.Context, key string) (Record, error) {
+	record, ok := m.records[key]
+	if !ok {
+		return Record{}, ErrNotFound
+	}
+	return record, nil
+}
+
+func (m *memoryStore) List(context.Context) ([]Record, error) {
+	records := make([]Record, 0, len(m.records))
+	for _, record := range m.records {
+		records = append(records, record)
+	}
+	return records, nil
+}
+
+func (m *memoryStore) Put(_ context.Context, record Record) (Record, error) {
+	record.UpdatedAt = time.Now()
+	m.records[record.Key] = record
+	return record, nil
+}
+
+func TestAgentConfigRedactsSecrets(t *testing.T) {
+	store := &memoryStore{records: map[string]Record{
+		"authentication": {
+			Key:       "authentication",
+			Value:     json.RawMessage(`{"oauth_connections":[{"id":"github","client_id":"client","client_secret":"secret"}]}`),
+			UpdatedAt: time.Now(),
+		},
+		"email": {
+			Key: "email", Value: json.RawMessage(`{"smtp_host":"smtp.example.com","smtp_password":"secret"}`), UpdatedAt: time.Now(),
+		},
+	}}
+	service := NewService(store, NewBroker())
+	config, err := service.AgentConfig(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, _ := json.Marshal(config)
+	if string(encoded) == "" || strings.Contains(string(encoded), "secret") {
+		t.Fatalf("Agent 配置泄漏密钥: %s", encoded)
+	}
+}
+
+func TestPutPreservesRedactedSecret(t *testing.T) {
+	store := &memoryStore{records: map[string]Record{
+		"authentication": {Key: "authentication", Value: json.RawMessage(`{"oauth_connections":[{"id":"github","provider":"github","name":"GitHub","client_id":"client","client_secret":"secret","enabled":true}]}`)},
+	}}
+	service := NewService(store, NewBroker())
+	_, err := service.Put(t.Context(), "authentication", json.RawMessage(`{"oauth_connections":[{"id":"github","provider":"github","name":"GitHub","client_id":"client","enabled":true}]}`), 1, "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(store.records["authentication"].Value), "secret") {
+		t.Fatalf("密钥未被保留: %s", store.records["authentication"].Value)
+	}
+}

--- a/monkeyai/backend/migrations/000002_identity_add_oauth.down.sql
+++ b/monkeyai/backend/migrations/000002_identity_add_oauth.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+DROP TABLE oauth_tokens;
+DROP TABLE oauth_authorization_codes;
+DROP TABLE oauth_login_states;
+DROP TABLE oauth_authorization_requests;
+DROP TABLE browser_sessions;
+
+COMMIT;

--- a/monkeyai/backend/migrations/000002_identity_add_oauth.up.sql
+++ b/monkeyai/backend/migrations/000002_identity_add_oauth.up.sql
@@ -1,0 +1,82 @@
+BEGIN;
+
+CREATE TABLE browser_sessions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    token_hash text NOT NULL UNIQUE,
+    user_id uuid NOT NULL REFERENCES users (id),
+    authentication_method text NOT NULL,
+    expires_at timestamptz NOT NULL,
+    last_seen_at timestamptz NOT NULL DEFAULT now(),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    revoked_at timestamptz,
+    CONSTRAINT browser_sessions_authentication_method_check CHECK (
+        authentication_method IN ('password', 'oauth')
+    ),
+    CONSTRAINT browser_sessions_expiry_check CHECK (expires_at > created_at)
+);
+
+CREATE INDEX browser_sessions_user_idx
+    ON browser_sessions (user_id)
+    WHERE revoked_at IS NULL;
+
+CREATE TABLE oauth_authorization_requests (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    client_id text NOT NULL,
+    redirect_uri text NOT NULL,
+    state text NOT NULL,
+    code_challenge text NOT NULL,
+    code_challenge_method text NOT NULL,
+    expires_at timestamptz NOT NULL,
+    completed_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT oauth_authorization_requests_method_check CHECK (
+        code_challenge_method = 'S256'
+    ),
+    CONSTRAINT oauth_authorization_requests_expiry_check CHECK (expires_at > created_at)
+);
+
+CREATE TABLE oauth_login_states (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    state_hash text NOT NULL UNIQUE,
+    connection_id text NOT NULL,
+    authorization_request_id uuid NOT NULL REFERENCES oauth_authorization_requests (id),
+    expires_at timestamptz NOT NULL,
+    consumed_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT oauth_login_states_expiry_check CHECK (expires_at > created_at)
+);
+
+CREATE TABLE oauth_authorization_codes (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    code_hash text NOT NULL UNIQUE,
+    authorization_request_id uuid NOT NULL UNIQUE REFERENCES oauth_authorization_requests (id),
+    user_id uuid NOT NULL REFERENCES users (id),
+    client_id text NOT NULL,
+    redirect_uri text NOT NULL,
+    code_challenge text NOT NULL,
+    expires_at timestamptz NOT NULL,
+    redeemed_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT oauth_authorization_codes_expiry_check CHECK (expires_at > created_at)
+);
+
+CREATE TABLE oauth_tokens (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES users (id),
+    client_id text NOT NULL,
+    access_token_hash text NOT NULL UNIQUE,
+    refresh_token_hash text NOT NULL UNIQUE,
+    access_expires_at timestamptz NOT NULL,
+    refresh_expires_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    revoked_at timestamptz,
+    CONSTRAINT oauth_tokens_expiry_check CHECK (
+        access_expires_at > created_at AND refresh_expires_at > access_expires_at
+    )
+);
+
+CREATE INDEX oauth_tokens_user_idx
+    ON oauth_tokens (user_id, client_id)
+    WHERE revoked_at IS NULL;
+
+COMMIT;

--- a/monkeyai/design/admin-data-model.md
+++ b/monkeyai/design/admin-data-model.md
@@ -220,10 +220,8 @@ flowchart LR
 
 | JSON 路径 | JSON 类型 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
-| `value.password_enabled` | `boolean` | 是 | `true` | 是否允许密码登录。 |
-| `value.email_code_enabled` | `boolean` | 是 | `false` | 是否允许邮箱验证码登录。 |
-| `value.registration_enabled` | `boolean` | 是 | `false` | 是否允许通过邮箱自助注册新用户。 |
-| `value.oauth_connections` | `array` | 是 | 空数组 | OAuth 连接列表。 |
+| `value.registration_enabled` | `boolean` | 是 | `false` | 是否允许客户端用户通过 OAuth 自助注册。 |
+| `value.oauth_connections` | `array` | 是 | 空数组 | 客户端用户可用的 OAuth/OIDC 连接列表；不用于管理员登录。 |
 | `value.oauth_connections[].id` | `string` | 是 | 自动生成 | OAuth 连接 UUID，用于管理列表中的连接项。 |
 | `value.oauth_connections[].provider` | `string` | 是 | 无 | 提供方：`github`、`google`、`microsoft`、`gitlab`、`oidc`。 |
 | `value.oauth_connections[].name` | `string` | 是 | 无 | OAuth 连接显示名称。 |

--- a/monkeyai/design/agent-auth-settings.md
+++ b/monkeyai/design/agent-auth-settings.md
@@ -1,0 +1,86 @@
+# MonkeyAI Agent 登录、用户与 Settings 方案
+
+## 1. 客户端注册
+
+首期只注册两个公开客户端。公开客户端无法安全保存 `client_secret`，所以只暴露 `client_id`，并强制使用 PKCE S256。
+
+| 客户端 | `client_id` | 应用回调地址 |
+| --- | --- | --- |
+| 桌面端 | `monkeyai-desktop` | `monkeyai-desktop://oauth/callback` |
+| 移动端 | `monkeyai-mobile` | `monkeyai-mobile://oauth/callback` |
+
+客户端注册信息是代码中的小型静态白名单，不建立 `oauth_clients` 表。`monkeyai-desktop` 是公开的客户端标识，`monkeyai-desktop://oauth/callback` 才是操作系统注册的应用地址。
+
+## 2. Agent 登录流程
+
+1. 客户端生成随机 `state` 和 PKCE `code_verifier`，计算 `code_challenge = BASE64URL(SHA256(code_verifier))`。
+2. 客户端用系统浏览器打开 `GET /oauth/authorize`，传入 `response_type=code`、`client_id`、固定 `redirect_uri`、`state`、`code_challenge` 和 `code_challenge_method=S256`。
+3. 服务端校验客户端白名单后创建 10 分钟有效的授权请求，并跳转到管理端 `/client-login` 页面。
+4. 页面调用服务端检查客户端用户的浏览器会话。已有会话时直接继续；未登录时展示管理员在后台启用的 OAuth/OIDC 登录方式。
+5. 上游 OAuth 回调只回到 MonkeyAI 服务端。服务端绑定或创建用户，建立 HttpOnly 浏览器会话，再返回 `/client-login`。
+6. 页面申请 2 分钟有效、仅能使用一次的授权码，并打开对应的桌面或移动应用地址；页面保留手动“打开应用”按钮。
+7. 客户端向 `POST /oauth/token` 提交授权码和原始 `code_verifier`。服务端校验 PKCE 后返回 1 小时有效的 access token 和 30 天有效的 refresh token。
+8. refresh token 每次刷新都会轮换，旧 token 立即撤销。`POST /oauth/revoke` 可撤销当前令牌组。
+
+OAuth 元数据位于 `GET /.well-known/oauth-authorization-server`，客户端清单位于 `GET /api/auth/v1/clients`。
+
+首期浏览器会话使用主机 Cookie，因此 `MONKEYAI_PUBLIC_URL` 与 `MONKEYAI_ADMIN_URL` 必须使用相同协议和主机名；开发环境可以使用不同端口。
+
+## 3. 管理员登录与首次启动
+
+管理后台不使用 OAuth。管理员通过 `users.email + password_hash` 登录，密码使用带随机 Salt 的 PBKDF2-HMAC-SHA256 保存，成功后建立 HttpOnly 浏览器会话。浏览器会话记录认证方式，管理接口只接受密码认证产生的管理员会话；OAuth 不会绑定管理员账号。
+
+空数据库首次启动时必须使用以下环境变量创建第一个管理员：
+
+```bash
+export MONKEYAI_INITIAL_ADMIN_NAME='MonkeyAI Admin'
+export MONKEYAI_INITIAL_ADMIN_EMAIL='admin@example.com'
+export MONKEYAI_INITIAL_ADMIN_PASSWORD='至少十二个字符的初始密码'
+```
+
+用户表为空且未配置首次管理员凭据时，服务拒绝启动，避免产生无法管理的实例。服务只在用户表为空时创建管理员，后续启动不会重置已有密码。初始化成功后应移除密码环境变量。
+
+## 4. 客户端用户 OAuth 配置
+
+管理员登录后，在 Settings 页面配置客户端用户可用的 OAuth 连接。配置保存在 `settings.authentication.value.oauth_connections`，支持 GitHub、Google、Microsoft、GitLab 和自定义 OIDC。自定义 OIDC 默认通过 `issuer_url/.well-known/openid-configuration` 发现端点，也允许数据中显式提供 `authorization_url`、`token_url`、`userinfo_url` 和 `scopes`。
+
+关闭自助注册时，只有邮箱已由管理员预置的用户能够绑定 OAuth 身份；开启注册后才会自动创建新用户。OAuth 用户不会被自动提升为管理员。
+
+## 5. 用户与管理会话
+
+- 管理端会话使用随机 HttpOnly Cookie；HTTPS 环境自动添加 `Secure`，默认有效期 7 天。
+- 管理接口统一要求 `admin` 角色和密码认证会话；Agent 接口统一要求有效 Bearer access token。
+- 管理员可查看用户、调整角色、启用或停用用户。服务端禁止管理员停用自己或移除自己的管理员角色。
+- 用户停用后，已有浏览器会话和 Agent token 即使尚未过期也无法继续使用。
+- OAuth access token、refresh token、授权码和浏览器会话只在数据库保存 SHA-256 摘要，不保存原文。
+
+## 6. Settings 与 Agent Config
+
+管理接口：
+
+- `GET /api/admin/v1/settings`
+- `GET /api/admin/v1/settings/{key}`
+- `PUT /api/admin/v1/settings/{key}`
+
+配置域为 `branding`、`authentication`、`email`、`billing`。管理端读取时不返回 `client_secret`、SMTP 密码和远程计费密钥；提交空密钥会保留数据库中的旧值。
+
+Agent 接口：
+
+- `GET /api/agent/v1/config`：获取当前完整配置快照。
+- `GET /api/agent/v1/config/events`：订阅 SSE 实时更新。
+
+SSE 建连后发送 `ready`，后续设置变更发送 `config` 事件，事件包含变更域和最新完整快照，每 20 秒发送心跳。在线多实例之间使用 PostgreSQL `LISTEN/NOTIFY` 广播，不持久化事件。系统不建立 `config_changes` 表，不支持 `Last-Event-ID` 补偿；Agent 断线重连后应先重新调用 Config 接口获取基线，再继续订阅。
+
+下发给 Agent 的配置会移除所有管理密钥。
+
+## 7. 数据表
+
+新增表：
+
+- `browser_sessions`
+- `oauth_authorization_requests`
+- `oauth_login_states`
+- `oauth_authorization_codes`
+- `oauth_tokens`
+
+不新增 `oauth_clients` 和 `config_changes`。


### PR DESCRIPTION
## 变更内容

- 实现桌面端与移动端公开 OAuth 客户端，支持 Authorization Code + PKCE S256、令牌刷新轮换与撤销
- 实现独立的管理员账号密码登录，严格区分密码会话与客户端 OAuth 会话
- 实现首次管理员初始化、用户创建、角色调整与启停管理
- 实现 Settings 管理接口、敏感字段脱敏与管理端配置页面
- 实现 Agent Config 快照接口和基于 PostgreSQL LISTEN/NOTIFY 的 SSE 实时推送
- 增加浏览器客户端登录与应用回跳页面
- 增加数据库迁移、设计文档和相关测试

## 关键约束

- 首期客户端为 monkeyai-desktop 和 monkeyai-mobile，不建立 oauth_clients 表
- 不建立 config_changes 表；断线后由 Agent 重新获取完整配置
- 管理员只能使用账号密码登录，OAuth 不绑定管理员账号
- 空数据库必须配置首次管理员凭据

## 验证

- go test ./...
- go vet ./...
- npm run lint
- npm run build
- npm test（30 项通过）

## 待部署联调

- 在真实 PostgreSQL 环境执行迁移
- 使用真实 OAuth 提供方凭据验证完整浏览器回调链路