### PR TITLE
修复 MCP 同步请求提前超时

### DIFF
--- a/backend/biz/setting/usecase/mcp.go
+++ b/backend/biz/setting/usecase/mcp.go
@@ -19,6 +19,11 @@ import (
 	"github.com/chaitin/MonkeyCode/backend/pkg/netguard"
 )
 
+const (
+	mcpSyncRequestCount = 3
+	mcpSyncTimeoutGrace = 5 * time.Second
+)
+
 type userMCPUsecase struct {
 	repo       domain.UserMCPRepo
 	syncClient domain.UserMCPSyncClient
@@ -45,9 +50,13 @@ func NewUserMCPSyncClient(i *do.Injector) (domain.UserMCPSyncClient, error) {
 	return &httpUserMCPSyncClient{
 		baseURL: cfg.MCPHub.URL,
 		token:   cfg.MCPHub.Token,
-		client:  &http.Client{Timeout: 15 * time.Second},
+		client:  &http.Client{Timeout: mcpSyncTimeout(cfg.MCPHub.UpstreamTimeoutDuration())},
 		logger:  logger,
 	}, nil
+}
+
+func mcpSyncTimeout(upstreamTimeout time.Duration) time.Duration {
+	return mcpSyncRequestCount*upstreamTimeout + mcpSyncTimeoutGrace
 }
 
 func (u *userMCPUsecase) ListUpstreams(ctx context.Context, uid uuid.UUID, cursor domain.CursorReq) (*domain.ListUserMCPUpstreamsResp, error) {

--- a/backend/biz/setting/usecase/mcp_test.go
+++ b/backend/biz/setting/usecase/mcp_test.go
@@ -2,11 +2,16 @@ package usecase
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/samber/do"
 
+	"github.com/chaitin/MonkeyCode/backend/config"
 	"github.com/chaitin/MonkeyCode/backend/domain"
 )
 
@@ -14,6 +19,28 @@ func TestUnconfiguredUserMCPSyncClientReturnsError(t *testing.T) {
 	err := (&unconfiguredUserMCPSyncClient{}).SyncUpstream(context.Background(), uuid.New())
 	if err == nil || !strings.Contains(err.Error(), "not configured") {
 		t.Fatalf("SyncUpstream() error = %v, want configuration error", err)
+	}
+}
+
+func TestUserMCPSyncClientTimeoutCoversCompleteHandshake(t *testing.T) {
+	i := do.New()
+	do.ProvideValue(i, &config.Config{MCPHub: config.MCPHub{
+		URL:             "http://127.0.0.1:8888",
+		Token:           "test-token",
+		UpstreamTimeout: "20s",
+	}})
+	do.ProvideValue(i, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	client, err := NewUserMCPSyncClient(i)
+	if err != nil {
+		t.Fatalf("NewUserMCPSyncClient() error = %v", err)
+	}
+	httpClient, ok := client.(*httpUserMCPSyncClient)
+	if !ok {
+		t.Fatalf("NewUserMCPSyncClient() type = %T, want *httpUserMCPSyncClient", client)
+	}
+	if httpClient.client.Timeout != 65*time.Second {
+		t.Fatalf("client timeout = %s, want 1m5s", httpClient.client.Timeout)
 	}
 }
 


### PR DESCRIPTION
## 问题

私有化后台同步 MCP 时，后台调用内部 MCP Hub 的 HTTP 客户端固定 15 秒超时，但 MCP Hub 同步过程需要依次完成 initialize、notifications/initialized 和 tools/list，并且单次上游请求默认允许 60 秒，导致外层请求可能提前超时。

## 修改

- 根据 mcp_hub.upstream_timeout 计算完整同步链路的等待时间
- 覆盖三次顺序 MCP 请求，并预留 5 秒内部处理时间
- 新增测试验证自定义上游超时会正确应用到同步客户端

## 测试

- go test ./biz/setting/usecase ./biz/team/usecase ./biz/mcphub/...