### PR TITLE
feat: 增加 MonkeyAI 容器化构建与部署配置

### DIFF
--- a/monkeyai/.env.example
+++ b/monkeyai/.env.example
@@ -1,0 +1,8 @@
+POSTGRES_PASSWORD=change-this-database-password
+MONKEYAI_INITIAL_ADMIN_EMAIL=admin@example.com
+MONKEYAI_INITIAL_ADMIN_PASSWORD=change-this-admin-password
+
+# 修改对外端口时，同时修改下面两个地址。
+# MONKEYAI_ADMIN_PORT=8080
+# MONKEYAI_PUBLIC_URL=http://localhost:8080
+# MONKEYAI_ADMIN_URL=http://localhost:8080

--- a/monkeyai/.gitignore
+++ b/monkeyai/.gitignore
@@ -1,0 +1,3 @@
+.env
+.env.*
+!.env.example

--- a/monkeyai/.gitignore
+++ b/monkeyai/.gitignore
@@ -1,3 +1,4 @@
 .env
 .env.*
 !.env.example
+data/

--- a/monkeyai/Makefile
+++ b/monkeyai/Makefile
@@ -1,0 +1,48 @@
+PLATFORM ?= linux/amd64
+TAG ?= $(shell git rev-parse --short HEAD)
+REGISTRY ?= chaitin-registry.cn-hangzhou.cr.aliyuncs.com/monkeycode
+
+ADMIN_IMAGE ?= $(REGISTRY)/monkeyai-admin:$(TAG)
+BACKEND_IMAGE ?= $(REGISTRY)/monkeyai-backend:$(TAG)
+
+.PHONY: image image-admin image-backend push push-admin push-backend images
+
+image: image-admin image-backend
+
+image-admin:
+	docker buildx build \
+	  --platform $(PLATFORM) \
+	  --tag $(ADMIN_IMAGE) \
+	  --load \
+	  ./admin
+	@echo "Admin image: $(ADMIN_IMAGE)"
+
+image-backend:
+	docker buildx build \
+	  --platform $(PLATFORM) \
+	  --tag $(BACKEND_IMAGE) \
+	  --load \
+	  ./backend
+	@echo "Backend image: $(BACKEND_IMAGE)"
+
+push: push-admin push-backend
+
+push-admin:
+	docker buildx build \
+	  --platform $(PLATFORM) \
+	  --tag $(ADMIN_IMAGE) \
+	  --push \
+	  ./admin
+	@echo "Pushed: $(ADMIN_IMAGE)"
+
+push-backend:
+	docker buildx build \
+	  --platform $(PLATFORM) \
+	  --tag $(BACKEND_IMAGE) \
+	  --push \
+	  ./backend
+	@echo "Pushed: $(BACKEND_IMAGE)"
+
+images:
+	@echo "Admin: $(ADMIN_IMAGE)"
+	@echo "Backend: $(BACKEND_IMAGE)"

--- a/monkeyai/README.md
+++ b/monkeyai/README.md
@@ -57,4 +57,4 @@ docker compose up --no-build
 docker compose down
 ```
 
-PostgreSQL 数据保存在 `./data`，执行 `docker compose down` 不会删除该目录。如需清空数据库，请先停止服务，再手动删除 `./data`；该操作不可恢复。
+PostgreSQL 数据保存在 `./data/postgres`，执行 `docker compose down` 不会删除该目录。如需清空数据库，请先停止服务，再手动删除 `./data/postgres`；该操作不可恢复。

--- a/monkeyai/README.md
+++ b/monkeyai/README.md
@@ -57,8 +57,4 @@ docker compose up --no-build
 docker compose down
 ```
 
-如需同时删除 PostgreSQL 数据卷（数据不可恢复）：
-
-```bash
-docker compose down --volumes
-```
+PostgreSQL 数据保存在 `./data`，执行 `docker compose down` 不会删除该目录。如需清空数据库，请先停止服务，再手动删除 `./data`；该操作不可恢复。

--- a/monkeyai/README.md
+++ b/monkeyai/README.md
@@ -1,0 +1,64 @@
+# MonkeyAI
+
+## Docker Compose 启动
+
+复制环境变量示例并至少修改数据库密码和初始管理员密码：
+
+```bash
+cp .env.example .env
+docker compose up --build
+```
+
+启动后访问 <http://localhost:8080>。Compose 会等待 PostgreSQL 就绪、执行数据库迁移，然后依次启动 Backend 和 Admin。
+
+初始管理员只会在用户表为空时创建。首次启动成功后，可从 `.env` 中移除 `MONKEYAI_INITIAL_ADMIN_EMAIL` 和 `MONKEYAI_INITIAL_ADMIN_PASSWORD`，服务不会重置已有账号或密码。
+
+若修改 `MONKEYAI_ADMIN_PORT`，还需将 `MONKEYAI_PUBLIC_URL` 和 `MONKEYAI_ADMIN_URL` 改为浏览器实际访问的地址。生产环境应使用同一域名下的 HTTPS 地址。
+
+## 构建和推送镜像
+
+Makefile 默认构建 `linux/amd64` 镜像，使用当前 Git 短提交号作为标签，并沿用 MonkeyCode 的镜像仓库：
+
+```bash
+make image
+make push
+```
+
+也可以只处理单个服务：
+
+```bash
+make image-admin
+make image-backend
+make push-admin
+make push-backend
+```
+
+发布指定标签或多架构镜像时覆盖对应变量：
+
+```bash
+make push TAG=v1.0.0
+make push PLATFORM=linux/amd64,linux/arm64
+make push REGISTRY=registry.example.com/team
+```
+
+运行 `make images` 可在构建前查看最终镜像名称。执行 push 前需先通过 `docker login` 登录目标仓库。
+
+需要用 Compose 验证已推送的镜像时，可传入完整镜像名并跳过本地构建：
+
+```bash
+ADMIN_IMAGE=registry.example.com/team/monkeyai-admin:v1.0.0 \
+BACKEND_IMAGE=registry.example.com/team/monkeyai-backend:v1.0.0 \
+docker compose up --no-build
+```
+
+停止服务：
+
+```bash
+docker compose down
+```
+
+如需同时删除 PostgreSQL 数据卷（数据不可恢复）：
+
+```bash
+docker compose down --volumes
+```

--- a/monkeyai/admin/.dockerignore
+++ b/monkeyai/admin/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.pnpm-store
+dist
+.git
+.gitignore
+.env
+.env.*
+!.env.example
+coverage
+*.log
+.DS_Store

--- a/monkeyai/admin/Dockerfile
+++ b/monkeyai/admin/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:24-alpine AS builder
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@10.12.4 --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm build
+
+FROM nginx:alpine
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY --from=builder --chown=nginx:nginx /app/dist /usr/share/nginx/html
+
+USER nginx
+
+EXPOSE 8080
+
+ENTRYPOINT []
+CMD ["nginx", "-g", "daemon off;"]

--- a/monkeyai/admin/nginx.conf
+++ b/monkeyai/admin/nginx.conf
@@ -1,0 +1,69 @@
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    access_log /dev/stdout;
+    error_log /dev/stderr warn;
+
+    client_body_temp_path /tmp/client_body;
+    proxy_temp_path /tmp/proxy;
+    fastcgi_temp_path /tmp/fastcgi;
+    uwsgi_temp_path /tmp/uwsgi;
+    scgi_temp_path /tmp/scgi;
+
+    sendfile on;
+    tcp_nopush on;
+    keepalive_timeout 65;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css application/json application/javascript application/xml image/svg+xml;
+
+    upstream monkeyai_backend {
+        server backend:8080;
+        keepalive 32;
+    }
+
+    server {
+        listen 8080;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        location ~ ^/(?:api|oauth|v1)(?:/|$) {
+            proxy_pass http://monkeyai_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off;
+        }
+
+        location = /.well-known/oauth-authorization-server {
+            proxy_pass http://monkeyai_backend;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location ~* \.(?:css|js|png|jpg|jpeg|gif|svg|ico|webp|woff2?)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            try_files $uri =404;
+        }
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}

--- a/monkeyai/backend/.dockerignore
+++ b/monkeyai/backend/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+bin
+coverage
+*.out
+*.log
+.DS_Store

--- a/monkeyai/backend/Dockerfile
+++ b/monkeyai/backend/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1.7
+
+FROM --platform=$BUILDPLATFORM golang:1.27-alpine AS builder
+
+WORKDIR /src
+ENV CGO_ENABLED=0
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -trimpath -ldflags="-s -w" -o /out/monkeyai-server ./cmd/server
+
+FROM alpine:3.23
+
+RUN apk add --no-cache ca-certificates tzdata \
+    && addgroup -S monkeyai \
+    && adduser -S -G monkeyai monkeyai
+
+WORKDIR /app
+
+COPY --from=builder --chown=monkeyai:monkeyai /out/monkeyai-server ./monkeyai-server
+
+USER monkeyai
+
+EXPOSE 8080
+
+CMD ["./monkeyai-server"]

--- a/monkeyai/docker-compose.yml
+++ b/monkeyai/docker-compose.yml
@@ -1,0 +1,83 @@
+name: monkeyai
+
+services:
+  db:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-monkeyai}
+      POSTGRES_USER: ${POSTGRES_USER:-monkeyai}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?请设置 POSTGRES_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  migrate:
+    image: migrate/migrate:v4.18.3
+    command:
+      - -path=/migrations
+      - -database=${MONKEYAI_DATABASE_URL:-postgres://${POSTGRES_USER:-monkeyai}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-monkeyai}?sslmode=disable}
+      - up
+    volumes:
+      - ./backend/migrations:/migrations:ro
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: "no"
+
+  backend:
+    image: ${BACKEND_IMAGE:-monkeyai-backend:local}
+    build:
+      context: ./backend
+    restart: unless-stopped
+    init: true
+    environment:
+      MONKEYAI_DATABASE_URL: ${MONKEYAI_DATABASE_URL:-postgres://${POSTGRES_USER:-monkeyai}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-monkeyai}?sslmode=disable}
+      MONKEYAI_HTTP_ADDR: :8080
+      MONKEYAI_LOG_LEVEL: ${MONKEYAI_LOG_LEVEL:-info}
+      MONKEYAI_PUBLIC_URL: ${MONKEYAI_PUBLIC_URL:-http://localhost:8080}
+      MONKEYAI_ADMIN_URL: ${MONKEYAI_ADMIN_URL:-http://localhost:8080}
+      MONKEYAI_INITIAL_ADMIN_NAME: ${MONKEYAI_INITIAL_ADMIN_NAME:-MonkeyAI Admin}
+      MONKEYAI_INITIAL_ADMIN_EMAIL: ${MONKEYAI_INITIAL_ADMIN_EMAIL:-}
+      MONKEYAI_INITIAL_ADMIN_PASSWORD: ${MONKEYAI_INITIAL_ADMIN_PASSWORD:-}
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "wget", "-Y", "off", "-q", "--spider", "http://127.0.0.1:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    read_only: true
+    tmpfs:
+      - /tmp
+
+  admin:
+    image: ${ADMIN_IMAGE:-monkeyai-admin:local}
+    build:
+      context: ./admin
+    restart: unless-stopped
+    init: true
+    ports:
+      - "${MONKEYAI_ADMIN_PORT:-8080}:8080"
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-Y", "off", "-q", "--spider", "http://127.0.0.1:8080/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    read_only: true
+    tmpfs:
+      - /tmp
+
+volumes:
+  postgres_data:

--- a/monkeyai/docker-compose.yml
+++ b/monkeyai/docker-compose.yml
@@ -2,14 +2,14 @@ name: monkeyai
 
 services:
   db:
-    image: postgres:17-alpine
+    image: chaitin-registry.cn-hangzhou.cr.aliyuncs.com/basic/postgres:18.6
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-monkeyai}
       POSTGRES_USER: ${POSTGRES_USER:-monkeyai}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?请设置 POSTGRES_PASSWORD}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - ./data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
@@ -78,6 +78,3 @@ services:
     read_only: true
     tmpfs:
       - /tmp
-
-volumes:
-  postgres_data:

--- a/monkeyai/docker-compose.yml
+++ b/monkeyai/docker-compose.yml
@@ -1,5 +1,3 @@
-name: monkeyai
-
 services:
   db:
     image: chaitin-registry.cn-hangzhou.cr.aliyuncs.com/basic/postgres:18.6
@@ -9,7 +7,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-monkeyai}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?请设置 POSTGRES_PASSWORD}
     volumes:
-      - ./data:/var/lib/postgresql
+      - ./data/postgres:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
@@ -18,7 +16,7 @@ services:
       start_period: 10s
 
   migrate:
-    image: migrate/migrate:v4.18.3
+    image: chaitin-registry.cn-hangzhou.cr.aliyuncs.com/basic/migrate:v4.18.3
     command:
       - -path=/migrations
       - -database=${MONKEYAI_DATABASE_URL:-postgres://${POSTGRES_USER:-monkeyai}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-monkeyai}?sslmode=disable}


### PR DESCRIPTION
## 概要

为 MonkeyAI Admin 和 Backend 增加可用于本地开发、镜像发布和完整环境启动的容器化配置。

## 主要改动

- 增加 Admin 多阶段 Dockerfile，使用 pnpm 构建并通过非 root Nginx 托管
- 增加 Admin Nginx 配置，支持 SPA 路由以及 API、OAuth、模型接口反向代理
- 增加 Backend Go 1.27 多阶段 Dockerfile和非 root 运行时镜像
- 增加 Docker Compose，编排 PostgreSQL、数据库迁移、Backend 和 Admin，并配置启动依赖及健康检查
- 使用内部 PostgreSQL 18.6 镜像，数据持久化到本地 `./data`
- 增加 Makefile，支持分别或统一构建、推送 Admin 和 Backend 镜像，并支持覆盖平台、标签和仓库
- 增加环境变量示例、忽略规则和使用文档

## 验证

- `docker compose build`
- `docker compose up -d --wait`，全部服务健康
- 首页、会话接口、OAuth 元数据和初始管理员登录链路验证
- `go test ./...`
- `go vet ./...`
- `pnpm test`，30 项通过
- `pnpm lint`
- `docker compose config --quiet`
- Makefile 本地构建 Admin、Backend 镜像
- 多架构 push 命令展开检查