### PR TITLE
feat: 构建独立数据库迁移镜像

### DIFF
--- a/monkeyai/Makefile
+++ b/monkeyai/Makefile
@@ -4,10 +4,11 @@ REGISTRY ?= chaitin-registry.cn-hangzhou.cr.aliyuncs.com/monkeycode
 
 ADMIN_IMAGE ?= $(REGISTRY)/monkeyai-admin:$(TAG)
 BACKEND_IMAGE ?= $(REGISTRY)/monkeyai-backend:$(TAG)
+MIGRATE_IMAGE ?= $(REGISTRY)/monkeyai-migrate:$(TAG)
 
-.PHONY: image image-admin image-backend push push-admin push-backend images
+.PHONY: image image-admin image-backend image-migrate push push-admin push-backend push-migrate images
 
-image: image-admin image-backend
+image: image-admin image-backend image-migrate
 
 image-admin:
 	docker buildx build \
@@ -25,7 +26,15 @@ image-backend:
 	  ./backend
 	@echo "Backend image: $(BACKEND_IMAGE)"
 
-push: push-admin push-backend
+image-migrate:
+	docker buildx build \
+	  --platform $(PLATFORM) \
+	  --tag $(MIGRATE_IMAGE) \
+	  --load \
+	  ./backend/migrations
+	@echo "Migrate image: $(MIGRATE_IMAGE)"
+
+push: push-admin push-backend push-migrate
 
 push-admin:
 	docker buildx build \
@@ -43,6 +52,15 @@ push-backend:
 	  ./backend
 	@echo "Pushed: $(BACKEND_IMAGE)"
 
+push-migrate:
+	docker buildx build \
+	  --platform $(PLATFORM) \
+	  --tag $(MIGRATE_IMAGE) \
+	  --push \
+	  ./backend/migrations
+	@echo "Pushed: $(MIGRATE_IMAGE)"
+
 images:
 	@echo "Admin: $(ADMIN_IMAGE)"
 	@echo "Backend: $(BACKEND_IMAGE)"
+	@echo "Migrate: $(MIGRATE_IMAGE)"

--- a/monkeyai/README.md
+++ b/monkeyai/README.md
@@ -29,8 +29,10 @@ make push
 ```bash
 make image-admin
 make image-backend
+make image-migrate
 make push-admin
 make push-backend
+make push-migrate
 ```
 
 发布指定标签或多架构镜像时覆盖对应变量：
@@ -48,8 +50,11 @@ make push REGISTRY=registry.example.com/team
 ```bash
 ADMIN_IMAGE=registry.example.com/team/monkeyai-admin:v1.0.0 \
 BACKEND_IMAGE=registry.example.com/team/monkeyai-backend:v1.0.0 \
+MIGRATE_IMAGE=registry.example.com/team/monkeyai-migrate:v1.0.0 \
 docker compose up --no-build
 ```
+
+迁移 SQL 已打包在 Migrate 镜像中。远程部署无需同步 `backend/migrations` 目录，但必须为 `MIGRATE_IMAGE` 指定与 Backend 相同发布版本的已推送镜像。
 
 停止服务：
 

--- a/monkeyai/backend/migrations/Dockerfile
+++ b/monkeyai/backend/migrations/Dockerfile
@@ -1,0 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
+FROM chaitin-registry.cn-hangzhou.cr.aliyuncs.com/basic/migrate:v4.18.3
+
+COPY *.sql /migrations/

--- a/monkeyai/docker-compose.yml
+++ b/monkeyai/docker-compose.yml
@@ -16,13 +16,13 @@ services:
       start_period: 10s
 
   migrate:
-    image: chaitin-registry.cn-hangzhou.cr.aliyuncs.com/basic/migrate:v4.18.3
+    image: ${MIGRATE_IMAGE:-monkeyai-migrate:local}
+    build:
+      context: ./backend/migrations
     command:
       - -path=/migrations
       - -database=${MONKEYAI_DATABASE_URL:-postgres://${POSTGRES_USER:-monkeyai}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-monkeyai}?sslmode=disable}
       - up
-    volumes:
-      - ./backend/migrations:/migrations:ro
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## 变更内容

- 新增 MonkeyAI 独立数据库迁移镜像，将迁移 SQL 打包到镜像中
- Compose 改用 MIGRATE_IMAGE，移除对远程宿主机迁移目录的依赖
- Makefile 增加迁移镜像的构建与推送目标
- 补充远程镜像部署说明

## 验证

- 成功构建 monkeyai-migrate 测试镜像，并确认镜像内包含全部迁移 SQL
- docker compose config 通过
- go test ./migrations 通过
- git diff --check 通过