### PR TITLE
修复后台 OAuth 登录与配置保存

### DIFF
--- a/monkeyai/admin/src/components/login-form.tsx
+++ b/monkeyai/admin/src/components/login-form.tsx
@@ -1,7 +1,8 @@
+import { LockKeyIcon } from "@hugeicons/core-free-icons"
+import { HugeiconsIcon } from "@hugeicons/react"
 import { Trans, useTranslation } from "react-i18next"
 
 import { EcosystemRadar } from "@/components/ecosystem-radar"
-import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import {
@@ -12,12 +13,41 @@ import {
   FieldSeparator,
 } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
+
+export type LoginProvider = {
+  id: string
+  provider: string
+  name: string
+}
+
+type LoginFormProps = React.ComponentProps<"div"> & {
+  email: string
+  password: string
+  error: string
+  submitting: boolean
+  oauthSubmitting: string
+  providers: LoginProvider[]
+  onEmailChange: (value: string) => void
+  onPasswordChange: (value: string) => void
+  onLogin: () => void
+  onOAuthLogin: (provider: LoginProvider) => void
+}
 
 export function LoginForm({
+  email,
+  password,
+  error,
+  submitting,
+  oauthSubmitting,
+  providers,
+  onEmailChange,
+  onPasswordChange,
   onLogin,
+  onOAuthLogin,
   className,
   ...props
-}: React.ComponentProps<"div"> & { onLogin: () => void }) {
+}: LoginFormProps) {
   const { t } = useTranslation()
 
   return (
@@ -40,17 +70,23 @@ export function LoginForm({
                 </p>
               </div>
               <Field>
-                <FieldLabel htmlFor="email">{t("login.email")}</FieldLabel>
+                <FieldLabel htmlFor="admin-email">
+                  {t("login.email")}
+                </FieldLabel>
                 <Input
-                  id="email"
+                  id="admin-email"
                   type="email"
                   placeholder="admin@example.com"
+                  autoComplete="username"
+                  value={email}
+                  onChange={(event) => onEmailChange(event.target.value)}
                   required
+                  autoFocus
                 />
               </Field>
               <Field>
                 <div className="flex items-center">
-                  <FieldLabel htmlFor="password">
+                  <FieldLabel htmlFor="admin-password">
                     {t("login.password")}
                   </FieldLabel>
                   <a
@@ -60,49 +96,74 @@ export function LoginForm({
                     {t("login.forgotPassword")}
                   </a>
                 </div>
-                <Input id="password" type="password" required />
+                <Input
+                  id="admin-password"
+                  type="password"
+                  autoComplete="current-password"
+                  value={password}
+                  onChange={(event) => onPasswordChange(event.target.value)}
+                  required
+                />
               </Field>
+              {error && (
+                <p
+                  className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+                  role="alert"
+                >
+                  {error}
+                </p>
+              )}
               <Field>
-                <Button type="submit">{t("login.submit")}</Button>
-              </Field>
-              <FieldSeparator className="*:data-[slot=field-separator-content]:bg-card">
-                {t("login.continueWith")}
-              </FieldSeparator>
-              <Field className="grid grid-cols-3 gap-4">
-                <Button variant="outline" type="button">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                    <path
-                      d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"
-                      fill="currentColor"
-                    />
-                  </svg>
-                  <span className="sr-only">
-                    {t("login.loginWith", { provider: "Apple" })}
-                  </span>
-                </Button>
-                <Button variant="outline" type="button">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                    <path
-                      d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                  <span className="sr-only">
-                    {t("login.loginWith", { provider: "Google" })}
-                  </span>
-                </Button>
-                <Button variant="outline" type="button">
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                    <path
-                      d="M6.915 4.03c-1.968 0-3.683 1.28-4.871 3.113C.704 9.208 0 11.883 0 14.449c0 .706.07 1.369.21 1.973a6.624 6.624 0 0 0 .265.86 5.297 5.297 0 0 0 .371.761c.696 1.159 1.818 1.927 3.593 1.927 1.497 0 2.633-.671 3.965-2.444.76-1.012 1.144-1.626 2.663-4.32l.756-1.339.186-.325c.061.1.121.196.183.3l2.152 3.595c.724 1.21 1.665 2.556 2.47 3.314 1.046.987 1.992 1.22 3.06 1.22 1.075 0 1.876-.355 2.455-.843a3.743 3.743 0 0 0 .81-.973c.542-.939.861-2.127.861-3.745 0-2.72-.681-5.357-2.084-7.45-1.282-1.912-2.957-2.93-4.716-2.93-1.047 0-2.088.467-3.053 1.308-.652.57-1.257 1.29-1.82 2.05-.69-.875-1.335-1.547-1.958-2.056-1.182-.966-2.315-1.303-3.454-1.303zm10.16 2.053c1.147 0 2.188.758 2.992 1.999 1.132 1.748 1.647 4.195 1.647 6.4 0 1.548-.368 2.9-1.839 2.9-.58 0-1.027-.23-1.664-1.004-.496-.601-1.343-1.878-2.832-4.358l-.617-1.028a44.908 44.908 0 0 0-1.255-1.98c.07-.109.141-.224.211-.327 1.12-1.667 2.118-2.602 3.358-2.602zm-10.201.553c1.265 0 2.058.791 2.675 1.446.307.327.737.871 1.234 1.579l-1.02 1.566c-.757 1.163-1.882 3.017-2.837 4.338-1.191 1.649-1.81 1.817-2.486 1.817-.524 0-1.038-.237-1.383-.794-.263-.426-.464-1.13-.464-2.046 0-2.221.63-4.535 1.66-6.088.454-.687.964-1.226 1.533-1.533a2.264 2.264 0 0 1 1.088-.285z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                  <span className="sr-only">
-                    {t("login.loginWith", { provider: "Meta" })}
-                  </span>
+                <Button
+                  type="submit"
+                  size="lg"
+                  className="w-full"
+                  disabled={
+                    submitting ||
+                    Boolean(oauthSubmitting) ||
+                    !email.trim() ||
+                    !password
+                  }
+                  aria-busy={submitting}
+                >
+                  {submitting ? `${t("login.submit")}…` : t("login.submit")}
                 </Button>
               </Field>
+              {providers.length > 0 && (
+                <>
+                  <FieldSeparator className="*:data-[slot=field-separator-content]:bg-card">
+                    {t("login.continueWith")}
+                  </FieldSeparator>
+                  <Field className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    {providers.map((provider) => (
+                      <Button
+                        key={provider.id}
+                        variant="outline"
+                        type="button"
+                        className="min-h-11 min-w-0 justify-start"
+                        disabled={submitting || Boolean(oauthSubmitting)}
+                        aria-busy={oauthSubmitting === provider.id}
+                        aria-label={t("login.loginWith", {
+                          provider: provider.name,
+                        })}
+                        title={provider.name}
+                        onClick={() => onOAuthLogin(provider)}
+                      >
+                        <HugeiconsIcon
+                          aria-hidden="true"
+                          icon={LockKeyIcon}
+                          strokeWidth={2}
+                        />
+                        <span className="truncate">
+                          {oauthSubmitting === provider.id
+                            ? `${provider.name}…`
+                            : provider.name}
+                        </span>
+                      </Button>
+                    ))}
+                  </Field>
+                </>
+              )}
               <FieldDescription className="mt-4 px-2 text-center">
                 <Trans
                   i18nKey="login.legal"

--- a/monkeyai/admin/src/i18n/locales/ar.ts
+++ b/monkeyai/admin/src/i18n/locales/ar.ts
@@ -31,6 +31,8 @@ export const ar = {
     submit: "تسجيل الدخول",
     continueWith: "أو تابع باستخدام",
     loginWith: "تسجيل الدخول باستخدام {{provider}}",
+    oauthAdminRequired: "حساب OAuth هذا غير مرتبط بمسؤول نشط",
+    oauthFailed: "فشل تسجيل الدخول عبر OAuth. حاول مرة أخرى",
     workspacePreview: "معاينة مساحة عمل MonkeyAI",
     legal: "<terms>شروط الخدمة</terms> و <privacy>سياسة الخصوصية</privacy>",
   },

--- a/monkeyai/admin/src/i18n/locales/de-DE.ts
+++ b/monkeyai/admin/src/i18n/locales/de-DE.ts
@@ -31,6 +31,10 @@ export const deDE = {
     submit: "Anmelden",
     continueWith: "Oder fortfahren mit",
     loginWith: "Mit {{provider}} anmelden",
+    oauthAdminRequired:
+      "Dieses OAuth-Konto ist keinem aktiven Administrator zugeordnet",
+    oauthFailed:
+      "OAuth-Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut",
     workspacePreview: "Vorschau des MonkeyAI-Arbeitsbereichs",
     legal:
       "<terms>Nutzungsbedingungen</terms> und <privacy>Datenschutzerklärung</privacy>",

--- a/monkeyai/admin/src/i18n/locales/en-US.ts
+++ b/monkeyai/admin/src/i18n/locales/en-US.ts
@@ -29,6 +29,9 @@ export const enUS = {
     submit: "Sign in",
     continueWith: "Or continue with",
     loginWith: "Sign in with {{provider}}",
+    oauthAdminRequired:
+      "This OAuth account is not linked to an active administrator",
+    oauthFailed: "OAuth sign-in failed. Please try again",
     workspacePreview: "MonkeyAI workspace preview",
     legal:
       "<terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy>",

--- a/monkeyai/admin/src/i18n/locales/es-419.ts
+++ b/monkeyai/admin/src/i18n/locales/es-419.ts
@@ -31,6 +31,9 @@ export const es419 = {
     submit: "Iniciar sesión",
     continueWith: "O continúa con",
     loginWith: "Iniciar sesión con {{provider}}",
+    oauthAdminRequired:
+      "Esta cuenta de OAuth no está vinculada a un administrador activo",
+    oauthFailed: "Error al iniciar sesión con OAuth. Inténtalo de nuevo",
     workspacePreview: "Vista previa del espacio de trabajo de MonkeyAI",
     legal:
       "<terms>Términos del servicio</terms> y <privacy>Política de privacidad</privacy>",

--- a/monkeyai/admin/src/i18n/locales/fr-FR.ts
+++ b/monkeyai/admin/src/i18n/locales/fr-FR.ts
@@ -31,6 +31,9 @@ export const frFR = {
     submit: "Se connecter",
     continueWith: "Ou continuer avec",
     loginWith: "Se connecter avec {{provider}}",
+    oauthAdminRequired:
+      "Ce compte OAuth n’est pas associé à un administrateur actif",
+    oauthFailed: "Échec de la connexion OAuth. Veuillez réessayer",
     workspacePreview: "Aperçu de l’espace de travail MonkeyAI",
     legal:
       "<terms>Conditions d’utilisation</terms> et <privacy>Politique de confidentialité</privacy>",

--- a/monkeyai/admin/src/i18n/locales/ja-JP.ts
+++ b/monkeyai/admin/src/i18n/locales/ja-JP.ts
@@ -31,6 +31,9 @@ export const jaJP = {
     submit: "ログイン",
     continueWith: "または次の方法で続行",
     loginWith: "{{provider}} でログイン",
+    oauthAdminRequired:
+      "この OAuth アカウントは有効な管理者に関連付けられていません",
+    oauthFailed: "OAuth ログインに失敗しました。もう一度お試しください",
     workspacePreview: "MonkeyAI ワークスペースのプレビュー",
     legal:
       "<terms>利用規約</terms> および <privacy>プライバシーポリシー</privacy>",

--- a/monkeyai/admin/src/i18n/locales/ko-KR.ts
+++ b/monkeyai/admin/src/i18n/locales/ko-KR.ts
@@ -31,6 +31,9 @@ export const koKR = {
     submit: "로그인",
     continueWith: "또는 다음으로 계속",
     loginWith: "{{provider}}로 로그인",
+    oauthAdminRequired:
+      "이 OAuth 계정은 활성 관리자 계정에 연결되어 있지 않습니다",
+    oauthFailed: "OAuth 로그인에 실패했습니다. 다시 시도해 주세요",
     workspacePreview: "MonkeyAI 작업 공간 미리보기",
     legal: "<terms>서비스 약관</terms> 및 <privacy>개인정보 처리방침</privacy>",
   },

--- a/monkeyai/admin/src/i18n/locales/ru-RU.ts
+++ b/monkeyai/admin/src/i18n/locales/ru-RU.ts
@@ -31,6 +31,9 @@ export const ruRU = {
     submit: "Войти",
     continueWith: "Или продолжить с помощью",
     loginWith: "Войти через {{provider}}",
+    oauthAdminRequired:
+      "Эта учётная запись OAuth не связана с активным администратором",
+    oauthFailed: "Не удалось войти через OAuth. Повторите попытку",
     workspacePreview: "Предварительный просмотр рабочего пространства MonkeyAI",
     legal:
       "<terms>Условия использования</terms> и <privacy>Политика конфиденциальности</privacy>",

--- a/monkeyai/admin/src/i18n/locales/zh-CN.ts
+++ b/monkeyai/admin/src/i18n/locales/zh-CN.ts
@@ -29,6 +29,8 @@ export const zhCN = {
     submit: "登录",
     continueWith: "或通过以下方式继续",
     loginWith: "使用 {{provider}} 登录",
+    oauthAdminRequired: "该 OAuth 账号未关联到启用状态的管理员账户",
+    oauthFailed: "OAuth 登录失败，请重试",
     workspacePreview: "MonkeyAI 工作区预览",
     legal: "<terms>服务条款</terms> 和 <privacy>隐私政策</privacy>",
   },

--- a/monkeyai/admin/src/i18n/locales/zh-TW.ts
+++ b/monkeyai/admin/src/i18n/locales/zh-TW.ts
@@ -31,6 +31,8 @@ export const zhTW = {
     submit: "登入",
     continueWith: "或透過以下方式繼續",
     loginWith: "使用 {{provider}} 登入",
+    oauthAdminRequired: "此 OAuth 帳號未連結至已啟用的管理員帳戶",
+    oauthFailed: "OAuth 登入失敗，請重試",
     workspacePreview: "MonkeyAI 工作區預覽",
     legal: "<terms>服務條款</terms> 和 <privacy>隱私權政策</privacy>",
   },

--- a/monkeyai/admin/src/lib/oauth.ts
+++ b/monkeyai/admin/src/lib/oauth.ts
@@ -1,0 +1,14 @@
+export function createOAuthConnectionID() {
+  const bytes = new Uint8Array(16)
+  if (globalThis.crypto?.getRandomValues) {
+    globalThis.crypto.getRandomValues(bytes)
+  } else {
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = Math.floor(Math.random() * 256)
+    }
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, (value) => value.toString(16).padStart(2, "0"))
+  return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10).join("")}`
+}

--- a/monkeyai/admin/src/pages/login-page.tsx
+++ b/monkeyai/admin/src/pages/login-page.tsx
@@ -1,25 +1,19 @@
-import { useState, type FormEvent } from "react"
-import { LockKeyIcon } from "@hugeicons/core-free-icons"
-import { HugeiconsIcon } from "@hugeicons/react"
+import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Navigate, useLocation, useNavigate } from "react-router-dom"
 
 import { LanguageToggle } from "@/components/language-toggle"
+import { LoginForm, type LoginProvider } from "@/components/login-form"
 import { ThemeToggle } from "@/components/theme-toggle"
-import { Button } from "@/components/ui/button"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
-import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
 import { useAuth } from "@/hooks/use-auth"
 import { api } from "@/lib/api"
 import type { AuthUser } from "@/lib/auth-context"
 import { DEFAULT_CONSOLE_PATH } from "@/lib/routes"
+
+const oauthErrorKeys: Record<string, string> = {
+  admin_role_required: "login.oauthAdminRequired",
+  user_disabled: "login.oauthAdminRequired",
+}
 
 export function LoginPage() {
   const { t } = useTranslation()
@@ -29,16 +23,37 @@ export function LoginPage() {
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [submitting, setSubmitting] = useState(false)
+  const [oauthSubmitting, setOauthSubmitting] = useState("")
+  const [providers, setProviders] = useState<LoginProvider[]>([])
   const [error, setError] = useState("")
   const destination =
     (location.state as { from?: string } | null)?.from ?? DEFAULT_CONSOLE_PATH
+  const oauthError = new URLSearchParams(location.search).get("oauth_error")
+  const visibleError =
+    error ||
+    (oauthError ? t(oauthErrorKeys[oauthError] ?? "login.oauthFailed") : "")
+
+  useEffect(() => {
+    const controller = new AbortController()
+    api<{ providers: LoginProvider[] }>("/api/auth/v1/providers", {
+      signal: controller.signal,
+    })
+      .then(({ providers: configuredProviders }) => {
+        setProviders(configuredProviders)
+      })
+      .catch((reason: Error) => {
+        if (reason.name !== "AbortError") {
+          setProviders([])
+        }
+      })
+    return () => controller.abort()
+  }, [])
 
   if (!isLoading && user?.role === "admin") {
     return <Navigate to={destination} replace />
   }
 
-  const submit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
+  const submit = async () => {
     setSubmitting(true)
     setError("")
     try {
@@ -55,72 +70,34 @@ export function LoginPage() {
     }
   }
 
+  const startOAuthLogin = (provider: LoginProvider) => {
+    setOauthSubmitting(provider.id)
+    setError("")
+    window.location.assign(
+      `/api/auth/v1/oauth/${encodeURIComponent(provider.id)}/admin-start`
+    )
+  }
+
   return (
-    <main className="relative flex min-h-svh items-center justify-center overflow-hidden bg-background px-4 py-12">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,hsl(var(--primary)/0.12),transparent_46%)]" />
+    <main className="flex min-h-svh flex-col items-center justify-center bg-muted p-4">
       <div className="absolute end-4 top-4 flex items-center gap-2">
         <LanguageToggle />
         <ThemeToggle />
       </div>
-      <Card className="relative w-full max-w-md border-border/80 bg-card/95 shadow-2xl shadow-black/5 backdrop-blur">
-        <CardHeader className="items-center pb-2 text-center">
-          <div className="mb-3 flex size-12 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-sm">
-            <HugeiconsIcon icon={LockKeyIcon} strokeWidth={2} />
-          </div>
-          <CardTitle className="text-2xl">{t("login.title")}</CardTitle>
-          <CardDescription>{t("login.subtitle")}</CardDescription>
-        </CardHeader>
-        <CardContent className="pt-5">
-          <form onSubmit={submit} noValidate>
-            <FieldGroup>
-              <Field>
-                <FieldLabel htmlFor="admin-email">
-                  {t("login.email")}
-                </FieldLabel>
-                <Input
-                  id="admin-email"
-                  type="email"
-                  autoComplete="username"
-                  value={email}
-                  onChange={(event) => setEmail(event.target.value)}
-                  required
-                  autoFocus
-                />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="admin-password">
-                  {t("login.password")}
-                </FieldLabel>
-                <Input
-                  id="admin-password"
-                  type="password"
-                  autoComplete="current-password"
-                  value={password}
-                  onChange={(event) => setPassword(event.target.value)}
-                  required
-                />
-              </Field>
-              {error && (
-                <p
-                  className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
-                  role="alert"
-                >
-                  {error}
-                </p>
-              )}
-              <Button
-                type="submit"
-                size="lg"
-                className="w-full cursor-pointer"
-                disabled={submitting || !email.trim() || !password}
-                aria-busy={submitting}
-              >
-                {submitting ? `${t("login.submit")}…` : t("login.submit")}
-              </Button>
-            </FieldGroup>
-          </form>
-        </CardContent>
-      </Card>
+      <div className="w-full max-w-sm md:max-w-4xl">
+        <LoginForm
+          email={email}
+          password={password}
+          error={visibleError}
+          submitting={submitting}
+          oauthSubmitting={oauthSubmitting}
+          providers={providers}
+          onEmailChange={setEmail}
+          onPasswordChange={setPassword}
+          onLogin={() => void submit()}
+          onOAuthLogin={startOAuthLogin}
+        />
+      </div>
     </main>
   )
 }

--- a/monkeyai/admin/src/pages/other-settings-page.tsx
+++ b/monkeyai/admin/src/pages/other-settings-page.tsx
@@ -77,6 +77,7 @@ import {
 import { Switch } from "@/components/ui/switch"
 import { useSkillTags } from "@/hooks/use-skill-tags"
 import { api } from "@/lib/api"
+import { createOAuthConnectionID } from "@/lib/oauth"
 
 const OAUTH_PROVIDERS = [
   { value: "github", labelKey: "pages.otherSettings.oauth.providers.github" },
@@ -205,6 +206,7 @@ export function OtherSettingsPage() {
   )
   const [oauthDialogOpen, setOauthDialogOpen] = useState(false)
   const [oauthProvider, setOauthProvider] = useState<OAuthProvider>("github")
+  const [oauthSaving, setOauthSaving] = useState(false)
   const [emailSettings, setEmailSettings] = useState(INITIAL_EMAIL_SETTINGS)
   const [savedEmailSettings, setSavedEmailSettings] = useState(
     INITIAL_EMAIL_SETTINGS
@@ -363,6 +365,8 @@ export function OtherSettingsPage() {
 
   const handleAddOauth = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    if (oauthSaving) return
+
     const form = event.currentTarget
     const formData = new FormData(form)
     const name = String(formData.get("name") ?? "").trim()
@@ -379,22 +383,27 @@ export function OtherSettingsPage() {
       return
     }
 
-    const connections = [
-      ...oauthConnections,
-      {
-        id: crypto.randomUUID(),
-        provider: oauthProvider,
-        name,
-        clientId,
-        clientSecret,
-        issuerUrl: issuerUrl || undefined,
-        enabled: true,
-      },
-    ]
-    if (await saveAuthentication(connections)) {
-      setOauthConnections(connections)
-      form.reset()
-      handleOauthDialogOpenChange(false)
+    setOauthSaving(true)
+    try {
+      const connections = [
+        ...oauthConnections,
+        {
+          id: createOAuthConnectionID(),
+          provider: oauthProvider,
+          name,
+          clientId,
+          clientSecret,
+          issuerUrl: issuerUrl || undefined,
+          enabled: true,
+        },
+      ]
+      if (await saveAuthentication(connections)) {
+        setOauthConnections(connections)
+        form.reset()
+        handleOauthDialogOpenChange(false)
+      }
+    } finally {
+      setOauthSaving(false)
     }
   }
 
@@ -1480,12 +1489,24 @@ export function OtherSettingsPage() {
                   </FieldGroup>
                   <DialogFooter>
                     <DialogClose
-                      render={<Button type="button" variant="outline" />}
+                      render={
+                        <Button
+                          type="button"
+                          variant="outline"
+                          disabled={oauthSaving}
+                        />
+                      }
                     >
                       {t("pages.otherSettings.oauth.cancel")}
                     </DialogClose>
-                    <Button type="submit">
-                      {t("pages.otherSettings.oauth.addConnection")}
+                    <Button
+                      type="submit"
+                      disabled={oauthSaving}
+                      aria-busy={oauthSaving}
+                    >
+                      {oauthSaving
+                        ? `${t("pages.otherSettings.oauth.addConnection")}…`
+                        : t("pages.otherSettings.oauth.addConnection")}
                     </Button>
                   </DialogFooter>
                 </form>

--- a/monkeyai/admin/test/oauth.test.mjs
+++ b/monkeyai/admin/test/oauth.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+import { createOAuthConnectionID } from "../src/lib/oauth.ts"
+
+test("creates unique OAuth connection IDs without randomUUID", () => {
+  const first = createOAuthConnectionID()
+  const second = createOAuthConnectionID()
+
+  assert.match(
+    first,
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+  )
+  assert.notEqual(first, second)
+})
+
+test("OAuth settings do not depend on crypto.randomUUID", async () => {
+  const source = await readFile(
+    new URL("../src/pages/other-settings-page.tsx", import.meta.url),
+    "utf8"
+  )
+
+  assert.doesNotMatch(source, /crypto\.randomUUID/)
+  assert.match(source, /createOAuthConnectionID\(\)/)
+})
+
+test("admin login lists configured OAuth providers and uses the admin flow", async () => {
+  const [page, form] = await Promise.all([
+    readFile(new URL("../src/pages/login-page.tsx", import.meta.url), "utf8"),
+    readFile(
+      new URL("../src/components/login-form.tsx", import.meta.url),
+      "utf8"
+    ),
+  ])
+
+  assert.match(page, /\/api\/auth\/v1\/providers/)
+  assert.match(page, /\/admin-start/)
+  assert.match(form, /providers\.map/)
+})

--- a/monkeyai/backend/internal/identity/middleware.go
+++ b/monkeyai/backend/internal/identity/middleware.go
@@ -30,12 +30,12 @@ func (s *Service) RequireAdmin(next http.Handler) http.Handler {
 			writeError(w, http.StatusUnauthorized, "unauthorized", "请先登录")
 			return
 		}
-		user, authenticationMethod, err := s.userByBrowserToken(r.Context(), tokenHash(cookie.Value))
+		user, _, err := s.userByBrowserToken(r.Context(), tokenHash(cookie.Value))
 		if err != nil {
 			writeError(w, http.StatusUnauthorized, "unauthorized", "请先登录")
 			return
 		}
-		if user.Role != "admin" || authenticationMethod != "password" {
+		if user.Role != "admin" {
 			writeError(w, http.StatusForbidden, "forbidden", "需要管理员权限")
 			return
 		}

--- a/monkeyai/backend/internal/identity/oauth.go
+++ b/monkeyai/backend/internal/identity/oauth.go
@@ -26,6 +26,7 @@ func (s *Service) AuthRouter() http.Handler {
 	router.Get("/client-requests/{requestID}", s.clientRequest)
 	router.With(s.RequireBrowser).Post("/client-requests/{requestID}/complete", s.completeClientRequest)
 	router.Get("/oauth/{connectionID}/start", s.startUpstream)
+	router.Get("/oauth/{connectionID}/admin-start", s.startAdminUpstream)
 	router.Get("/oauth/callback", s.upstreamCallback)
 	return router
 }
@@ -179,15 +180,23 @@ func (s *Service) startUpstream(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "request_required", "缺少客户端授权请求")
 		return
 	}
+	request, err := s.authorizationRequest(r.Context(), requestID)
+	if err != nil || request.CompletedAt != nil || !s.now().Before(request.ExpiresAt) {
+		writeError(w, http.StatusBadRequest, "request_unavailable", "授权请求无效")
+		return
+	}
+	s.beginUpstream(w, r, requestID, loginPurposeClient)
+}
+
+func (s *Service) startAdminUpstream(w http.ResponseWriter, r *http.Request) {
+	s.beginUpstream(w, r, "", loginPurposeAdmin)
+}
+
+func (s *Service) beginUpstream(w http.ResponseWriter, r *http.Request, requestID, purpose string) {
 	connectionID := chi.URLParam(r, "connectionID")
 	connection, err := s.connection(r.Context(), connectionID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "provider_not_found", "登录方式不存在")
-		return
-	}
-	request, err := s.authorizationRequest(r.Context(), requestID)
-	if err != nil || request.CompletedAt != nil || !s.now().Before(request.ExpiresAt) {
-		writeError(w, http.StatusBadRequest, "request_unavailable", "授权请求无效")
 		return
 	}
 	state, err := randomToken(32)
@@ -195,7 +204,7 @@ func (s *Service) startUpstream(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "server_error", "无法发起登录")
 		return
 	}
-	if err := s.createLoginState(r.Context(), tokenHash(state), connectionID, requestID, s.now().Add(s.requestTTL)); err != nil {
+	if err := s.createLoginState(r.Context(), tokenHash(state), connectionID, requestID, purpose, s.now().Add(s.requestTTL)); err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error", "无法发起登录")
 		return
 	}
@@ -209,36 +218,61 @@ func (s *Service) startUpstream(w http.ResponseWriter, r *http.Request) {
 
 func (s *Service) upstreamCallback(w http.ResponseWriter, r *http.Request) {
 	state, err := s.consumeLoginState(r.Context(), tokenHash(r.URL.Query().Get("state")))
-	if err != nil || r.URL.Query().Get("code") == "" {
+	if err != nil {
 		http.Redirect(w, r, s.clientLoginURL("", "oauth_callback"), http.StatusFound)
+		return
+	}
+	if r.URL.Query().Get("code") == "" {
+		http.Redirect(w, r, s.upstreamResultURL(state, "oauth_callback"), http.StatusFound)
 		return
 	}
 	connection, err := s.connection(r.Context(), state.ConnectionID)
 	if err != nil {
-		http.Redirect(w, r, s.clientLoginURL(state.AuthorizationRequestID, "provider_unavailable"), http.StatusFound)
+		http.Redirect(w, r, s.upstreamResultURL(state, "provider_unavailable"), http.StatusFound)
 		return
 	}
 	profile, err := s.exchangeUpstream(r.Context(), connection, r.URL.Query().Get("code"))
 	if err != nil {
-		http.Redirect(w, r, s.clientLoginURL(state.AuthorizationRequestID, "oauth_exchange"), http.StatusFound)
+		http.Redirect(w, r, s.upstreamResultURL(state, "oauth_exchange"), http.StatusFound)
 		return
 	}
-	user, err := s.upsertIdentity(r.Context(), profile)
+	adminLogin := state.Purpose == loginPurposeAdmin
+	user, err := s.upsertIdentity(r.Context(), profile, adminLogin)
 	if err != nil {
 		code := "user_unavailable"
-		if errors.Is(err, ErrAdminPasswordRequired) {
+		switch {
+		case errors.Is(err, ErrAdminRoleRequired):
+			code = "admin_role_required"
+		case adminLogin && errors.Is(err, ErrUserDisabled):
+			code = "admin_role_required"
+		case errors.Is(err, ErrAdminPasswordRequired):
 			code = "admin_password_required"
 		}
-		http.Redirect(w, r, s.clientLoginURL(state.AuthorizationRequestID, code), http.StatusFound)
+		http.Redirect(w, r, s.upstreamResultURL(state, code), http.StatusFound)
 		return
 	}
 	token, err := randomToken(32)
 	if err != nil || s.createBrowserSession(r.Context(), user.ID, tokenHash(token), "oauth", s.now().Add(s.sessionTTL)) != nil {
-		http.Redirect(w, r, s.clientLoginURL(state.AuthorizationRequestID, "session_failed"), http.StatusFound)
+		http.Redirect(w, r, s.upstreamResultURL(state, "session_failed"), http.StatusFound)
 		return
 	}
 	http.SetCookie(w, &http.Cookie{Name: sessionCookie, Value: token, Path: "/", HttpOnly: true, Secure: s.secureCookie, SameSite: http.SameSiteLaxMode, MaxAge: int(s.sessionTTL.Seconds())})
-	http.Redirect(w, r, s.clientLoginURL(state.AuthorizationRequestID, ""), http.StatusFound)
+	http.Redirect(w, r, s.upstreamResultURL(state, ""), http.StatusFound)
+}
+
+func (s *Service) upstreamResultURL(state LoginState, errorCode string) string {
+	if state.Purpose == loginPurposeAdmin {
+		query := url.Values{}
+		if errorCode != "" {
+			query.Set("oauth_error", errorCode)
+		}
+		result := s.adminURL + "/login"
+		if encoded := query.Encode(); encoded != "" {
+			result += "?" + encoded
+		}
+		return result
+	}
+	return s.clientLoginURL(state.AuthorizationRequestID, errorCode)
 }
 
 func (s *Service) clientLoginURL(requestID, errorCode string) string {

--- a/monkeyai/backend/internal/identity/postgres.go
+++ b/monkeyai/backend/internal/identity/postgres.go
@@ -130,12 +130,12 @@ func (s *Service) rotateToken(ctx context.Context, oldRefreshHash, clientID, acc
 	return tx.Commit(ctx)
 }
 
-func (s *Service) createLoginState(ctx context.Context, stateHash, connectionID, requestID string, expiresAt time.Time) error {
+func (s *Service) createLoginState(ctx context.Context, stateHash, connectionID, requestID, purpose string, expiresAt time.Time) error {
 	_, err := s.db.Exec(ctx, `
 		INSERT INTO oauth_login_states (
-			state_hash, connection_id, authorization_request_id, expires_at
-		) VALUES ($1, $2, $3, $4)
-	`, stateHash, connectionID, requestID, expiresAt)
+			state_hash, connection_id, authorization_request_id, purpose, expires_at
+		) VALUES ($1, $2, nullif($3, '')::uuid, $4, $5)
+	`, stateHash, connectionID, requestID, purpose, expiresAt)
 	return err
 }
 
@@ -145,8 +145,8 @@ func (s *Service) consumeLoginState(ctx context.Context, stateHash string) (Logi
 		UPDATE oauth_login_states
 		SET consumed_at = now()
 		WHERE state_hash = $1 AND consumed_at IS NULL AND expires_at > now()
-		RETURNING connection_id, authorization_request_id
-	`, stateHash).Scan(&state.ConnectionID, &state.AuthorizationRequestID)
+		RETURNING connection_id, coalesce(authorization_request_id::text, ''), purpose
+	`, stateHash).Scan(&state.ConnectionID, &state.AuthorizationRequestID, &state.Purpose)
 	return state, err
 }
 
@@ -269,7 +269,7 @@ func scanUser(row rowScanner) (User, error) {
 	return user, nil
 }
 
-func (s *Service) upsertIdentity(ctx context.Context, profile upstreamProfile) (User, error) {
+func (s *Service) upsertIdentity(ctx context.Context, profile upstreamProfile, adminOnly bool) (User, error) {
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
 		return User{}, err
@@ -283,11 +283,8 @@ func (s *Service) upsertIdentity(ctx context.Context, profile upstreamProfile) (
 			AND i.deleted_at IS NULL AND u.deleted_at IS NULL
 	`, profile.Provider, profile.Issuer, profile.Subject))
 	if err == nil {
-		if user.Role == "admin" {
-			return User{}, ErrAdminPasswordRequired
-		}
-		if user.Status != "active" {
-			return User{}, ErrUserDisabled
+		if err := validateUpstreamUser(user, adminOnly); err != nil {
+			return User{}, err
 		}
 		err = tx.QueryRow(ctx, `
 			UPDATE users SET name = $2, avatar_url = nullif($3, ''), last_login_at = now(), updated_at = now()
@@ -307,6 +304,9 @@ func (s *Service) upsertIdentity(ctx context.Context, profile upstreamProfile) (
 	}
 
 	if profile.Email == "" {
+		if adminOnly {
+			return User{}, ErrAdminRoleRequired
+		}
 		profile.Email = fmt.Sprintf("%s@%s.oauth.local", profile.Subject, profile.Provider)
 	}
 	if profile.Name == "" {
@@ -315,36 +315,47 @@ func (s *Service) upsertIdentity(ctx context.Context, profile upstreamProfile) (
 	if profile.Name == "" {
 		profile.Name = profile.Email
 	}
-	var existingRole, existingStatus string
-	err = tx.QueryRow(ctx, `
-		SELECT role, status FROM users
+	user, err = scanUser(tx.QueryRow(ctx, `
+		SELECT id, name, email, coalesce(avatar_url, ''), role, status, joined_at, last_login_at
+		FROM users
 		WHERE lower(email) = lower($1) AND deleted_at IS NULL
-	`, profile.Email).Scan(&existingRole, &existingStatus)
+	`, profile.Email))
 	switch {
-	case err == nil && existingRole == "admin":
-		return User{}, ErrAdminPasswordRequired
-	case err == nil && existingStatus != "active":
-		return User{}, ErrUserDisabled
+	case err == nil:
+		if err := validateUpstreamUser(user, adminOnly); err != nil {
+			return User{}, err
+		}
+		err = tx.QueryRow(ctx, `
+			UPDATE users SET name = $2, avatar_url = nullif($3, ''), last_login_at = now(), updated_at = now()
+			WHERE id = $1
+			RETURNING id, name, email, coalesce(avatar_url, ''), role, status, joined_at, last_login_at
+		`, user.ID, profile.Name, profile.AvatarURL).Scan(&user.ID, &user.Name, &user.Email, &user.AvatarURL, &user.Role, &user.Status, &user.JoinedAt, &user.LastLoginAt)
+		if err != nil {
+			return User{}, err
+		}
 	case errors.Is(err, pgx.ErrNoRows):
+		if adminOnly {
+			return User{}, ErrAdminRoleRequired
+		}
 		if !s.registrationEnabled(ctx) {
 			return User{}, ErrRegistrationDisabled
 		}
+		err = tx.QueryRow(ctx, `
+			INSERT INTO users (name, email, avatar_url, role, last_login_at)
+			VALUES ($1, $2, nullif($3, ''), 'user', now())
+			ON CONFLICT (lower(email)) WHERE deleted_at IS NULL DO UPDATE SET
+				name = EXCLUDED.name, avatar_url = EXCLUDED.avatar_url,
+				last_login_at = now(), updated_at = now()
+			WHERE users.role = 'user' AND users.status = 'active'
+			RETURNING id, name, email, coalesce(avatar_url, ''), role, status, joined_at, last_login_at
+		`, profile.Name, profile.Email, profile.AvatarURL).Scan(&user.ID, &user.Name, &user.Email, &user.AvatarURL, &user.Role, &user.Status, &user.JoinedAt, &user.LastLoginAt)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return User{}, ErrAdminPasswordRequired
+		}
+		if err != nil {
+			return User{}, err
+		}
 	case err != nil:
-		return User{}, err
-	}
-	err = tx.QueryRow(ctx, `
-		INSERT INTO users (name, email, avatar_url, role, last_login_at)
-		VALUES ($1, $2, nullif($3, ''), 'user', now())
-		ON CONFLICT (lower(email)) WHERE deleted_at IS NULL DO UPDATE SET
-			name = EXCLUDED.name, avatar_url = EXCLUDED.avatar_url,
-			last_login_at = now(), updated_at = now()
-		WHERE users.role = 'user' AND users.status = 'active'
-		RETURNING id, name, email, coalesce(avatar_url, ''), role, status, joined_at, last_login_at
-	`, profile.Name, profile.Email, profile.AvatarURL).Scan(&user.ID, &user.Name, &user.Email, &user.AvatarURL, &user.Role, &user.Status, &user.JoinedAt, &user.LastLoginAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return User{}, ErrAdminPasswordRequired
-	}
-	if err != nil {
 		return User{}, err
 	}
 	_, err = tx.Exec(ctx, `
@@ -360,9 +371,23 @@ func (s *Service) upsertIdentity(ctx context.Context, profile upstreamProfile) (
 	return user, nil
 }
 
+func validateUpstreamUser(user User, adminOnly bool) error {
+	if user.Status != "active" {
+		return ErrUserDisabled
+	}
+	if adminOnly && user.Role != "admin" {
+		return ErrAdminRoleRequired
+	}
+	if !adminOnly && user.Role == "admin" {
+		return ErrAdminPasswordRequired
+	}
+	return nil
+}
+
 var (
 	ErrNotFound              = errors.New("记录不存在")
 	ErrUserDisabled          = errors.New("用户已停用")
 	ErrRegistrationDisabled  = errors.New("未开放新用户注册")
 	ErrAdminPasswordRequired = errors.New("管理员必须使用密码登录")
+	ErrAdminRoleRequired     = errors.New("管理后台 OAuth 登录必须关联管理员")
 )

--- a/monkeyai/backend/internal/identity/service.go
+++ b/monkeyai/backend/internal/identity/service.go
@@ -77,7 +77,13 @@ type AuthorizationCode struct {
 type LoginState struct {
 	ConnectionID           string
 	AuthorizationRequestID string
+	Purpose                string
 }
+
+const (
+	loginPurposeClient = "client"
+	loginPurposeAdmin  = "admin"
+)
 
 type Token struct {
 	AccessToken  string    `json:"access_token"`
@@ -124,12 +130,27 @@ func NewService(db *pgxpool.Pool, settings SettingReader, publicURL, adminURL st
 }
 
 func (s *Service) BeginAuthorization(ctx context.Context, values url.Values) (AuthorizationRequest, error) {
+	request, err := s.newAuthorizationRequest(values)
+	if err != nil {
+		return AuthorizationRequest{}, err
+	}
+	if err := s.createAuthorizationRequest(ctx, &request); err != nil {
+		return AuthorizationRequest{}, err
+	}
+	return request, nil
+}
+
+func (s *Service) newAuthorizationRequest(values url.Values) (AuthorizationRequest, error) {
 	if values.Get("response_type") != "code" {
 		return AuthorizationRequest{}, oauthError("unsupported_response_type", "仅支持 authorization code")
 	}
 	client, ok := Clients[values.Get("client_id")]
-	if !ok || values.Get("redirect_uri") != client.RedirectURI {
-		return AuthorizationRequest{}, oauthError("invalid_request", "client_id 或 redirect_uri 无效")
+	if !ok {
+		return AuthorizationRequest{}, oauthError("invalid_request", "client_id 无效")
+	}
+	redirectURI := values.Get("redirect_uri")
+	if redirectURI == "" {
+		return AuthorizationRequest{}, oauthError("invalid_request", "redirect_uri 不能为空")
 	}
 	state := values.Get("state")
 	if state == "" {
@@ -140,18 +161,14 @@ func (s *Service) BeginAuthorization(ctx context.Context, values url.Values) (Au
 		return AuthorizationRequest{}, oauthError("invalid_request", "必须使用有效的 PKCE S256")
 	}
 
-	request := AuthorizationRequest{
+	return AuthorizationRequest{
 		ClientID:            client.ID,
-		RedirectURI:         client.RedirectURI,
+		RedirectURI:         redirectURI,
 		State:               state,
 		CodeChallenge:       challenge,
 		CodeChallengeMethod: "S256",
 		ExpiresAt:           s.now().Add(s.requestTTL),
-	}
-	if err := s.createAuthorizationRequest(ctx, &request); err != nil {
-		return AuthorizationRequest{}, err
-	}
-	return request, nil
+	}, nil
 }
 
 func (s *Service) CompleteAuthorization(ctx context.Context, requestID, userID string) (string, error) {
@@ -178,8 +195,7 @@ func (s *Service) CompleteAuthorization(ctx context.Context, requestID, userID s
 }
 
 func (s *Service) ExchangeCode(ctx context.Context, clientID, redirectURI, code, verifier string) (Token, error) {
-	client, ok := Clients[clientID]
-	if !ok || redirectURI != client.RedirectURI {
+	if _, ok := Clients[clientID]; !ok {
 		return Token{}, oauthError("invalid_client", "客户端信息无效")
 	}
 	if !verifierPattern.MatchString(verifier) {

--- a/monkeyai/backend/internal/identity/service_test.go
+++ b/monkeyai/backend/internal/identity/service_test.go
@@ -3,10 +3,12 @@ package identity
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 )
 
 func TestClientRegistry(t *testing.T) {
@@ -49,6 +51,28 @@ func TestBeginAuthorizationRejectsUnknownClientBeforeDatabase(t *testing.T) {
 	}
 }
 
+func TestAuthorizationRequestUsesClientRedirectURI(t *testing.T) {
+	service := &Service{
+		now:        func() time.Time { return time.Unix(1_700_000_000, 0) },
+		requestTTL: 10 * time.Minute,
+	}
+	redirectURI := "http://127.0.0.1:54321/oauth/callback"
+	request, err := service.newAuthorizationRequest(url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"monkeyai-desktop"},
+		"redirect_uri":          {redirectURI},
+		"state":                 {"state"},
+		"code_challenge":        {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		"code_challenge_method": {"S256"},
+	})
+	if err != nil {
+		t.Fatalf("动态 redirect_uri 不应被拒绝: %v", err)
+	}
+	if request.RedirectURI != redirectURI {
+		t.Fatalf("redirect_uri = %q, want %q", request.RedirectURI, redirectURI)
+	}
+}
+
 func TestUpstreamLoginRequiresClientAuthorizationRequest(t *testing.T) {
 	service := &Service{}
 	recorder := httptest.NewRecorder()
@@ -61,5 +85,41 @@ func TestUpstreamLoginRequiresClientAuthorizationRequest(t *testing.T) {
 	}
 	if got := recorder.Body.String(); got != "{\"error\":{\"code\":\"request_required\",\"message\":\"缺少客户端授权请求\"}}\n" {
 		t.Fatalf("body = %q", got)
+	}
+}
+
+func TestValidateUpstreamUserForAdminLogin(t *testing.T) {
+	tests := []struct {
+		name      string
+		user      User
+		adminOnly bool
+		want      error
+	}{
+		{name: "active admin can use admin login", user: User{Role: "admin", Status: "active"}, adminOnly: true},
+		{name: "regular user cannot use admin login", user: User{Role: "user", Status: "active"}, adminOnly: true, want: ErrAdminRoleRequired},
+		{name: "disabled admin cannot use admin login", user: User{Role: "admin", Status: "disabled"}, adminOnly: true, want: ErrUserDisabled},
+		{name: "admin cannot enter client flow", user: User{Role: "admin", Status: "active"}, want: ErrAdminPasswordRequired},
+		{name: "regular user can enter client flow", user: User{Role: "user", Status: "active"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateUpstreamUser(test.user, test.adminOnly)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestAdminOAuthResultURL(t *testing.T) {
+	service := &Service{adminURL: "https://admin.example.com"}
+	state := LoginState{Purpose: loginPurposeAdmin}
+
+	if got := service.upstreamResultURL(state, ""); got != "https://admin.example.com/login" {
+		t.Fatalf("success URL = %q", got)
+	}
+	if got := service.upstreamResultURL(state, "admin_role_required"); got != "https://admin.example.com/login?oauth_error=admin_role_required" {
+		t.Fatalf("error URL = %q", got)
 	}
 }

--- a/monkeyai/backend/migrations/000003_identity_allow_admin_oauth_login.down.sql
+++ b/monkeyai/backend/migrations/000003_identity_allow_admin_oauth_login.down.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+DELETE FROM oauth_login_states WHERE purpose = 'admin';
+
+ALTER TABLE oauth_login_states
+    DROP CONSTRAINT oauth_login_states_target_check,
+    DROP CONSTRAINT oauth_login_states_purpose_check,
+    ALTER COLUMN authorization_request_id SET NOT NULL,
+    DROP COLUMN purpose;
+
+COMMIT;

--- a/monkeyai/backend/migrations/000003_identity_allow_admin_oauth_login.up.sql
+++ b/monkeyai/backend/migrations/000003_identity_allow_admin_oauth_login.up.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+ALTER TABLE oauth_login_states
+    ALTER COLUMN authorization_request_id DROP NOT NULL,
+    ADD COLUMN purpose text NOT NULL DEFAULT 'client';
+
+ALTER TABLE oauth_login_states
+    ADD CONSTRAINT oauth_login_states_purpose_check CHECK (
+        purpose IN ('client', 'admin')
+    ),
+    ADD CONSTRAINT oauth_login_states_target_check CHECK (
+        (purpose = 'client' AND authorization_request_id IS NOT NULL)
+        OR (purpose = 'admin' AND authorization_request_id IS NULL)
+    );
+
+COMMIT;

--- a/monkeyai/design/admin-data-model.md
+++ b/monkeyai/design/admin-data-model.md
@@ -221,7 +221,7 @@ flowchart LR
 | JSON 路径 | JSON 类型 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- | --- |
 | `value.registration_enabled` | `boolean` | 是 | `false` | 是否允许客户端用户通过 OAuth 自助注册。 |
-| `value.oauth_connections` | `array` | 是 | 空数组 | 客户端用户可用的 OAuth/OIDC 连接列表；不用于管理员登录。 |
+| `value.oauth_connections` | `array` | 是 | 空数组 | 管理后台和客户端用户共用的 OAuth/OIDC 连接列表；管理后台只接受关联到启用状态管理员的身份。 |
 | `value.oauth_connections[].id` | `string` | 是 | 自动生成 | OAuth 连接 UUID，用于管理列表中的连接项。 |
 | `value.oauth_connections[].provider` | `string` | 是 | 无 | 提供方：`github`、`google`、`microsoft`、`gitlab`、`oidc`。 |
 | `value.oauth_connections[].name` | `string` | 是 | 无 | OAuth 连接显示名称。 |

--- a/monkeyai/design/agent-auth-settings.md
+++ b/monkeyai/design/agent-auth-settings.md
@@ -4,17 +4,17 @@
 
 首期只注册两个公开客户端。公开客户端无法安全保存 `client_secret`，所以只暴露 `client_id`，并强制使用 PKCE S256。
 
-| 客户端 | `client_id` | 应用回调地址 |
+| 客户端 | `client_id` | 默认应用回调地址 |
 | --- | --- | --- |
 | 桌面端 | `monkeyai-desktop` | `monkeyai-desktop://oauth/callback` |
 | 移动端 | `monkeyai-mobile` | `monkeyai-mobile://oauth/callback` |
 
-客户端注册信息是代码中的小型静态白名单，不建立 `oauth_clients` 表。`monkeyai-desktop` 是公开的客户端标识，`monkeyai-desktop://oauth/callback` 才是操作系统注册的应用地址。
+客户端注册信息是代码中的小型静态白名单，不建立 `oauth_clients` 表。服务端校验 `client_id`，但不要求客户端传入的 `redirect_uri` 与默认应用回调地址完全一致；本次授权使用客户端传入的非空回调地址，并在换取 token 时校验它与授权请求中保存的地址一致。
 
 ## 2. Agent 登录流程
 
 1. 客户端生成随机 `state` 和 PKCE `code_verifier`，计算 `code_challenge = BASE64URL(SHA256(code_verifier))`。
-2. 客户端用系统浏览器打开 `GET /oauth/authorize`，传入 `response_type=code`、`client_id`、固定 `redirect_uri`、`state`、`code_challenge` 和 `code_challenge_method=S256`。
+2. 客户端用系统浏览器打开 `GET /oauth/authorize`，传入 `response_type=code`、`client_id`、非空 `redirect_uri`、`state`、`code_challenge` 和 `code_challenge_method=S256`。
 3. 服务端校验客户端白名单后创建 10 分钟有效的授权请求，并跳转到管理端 `/client-login` 页面。
 4. 页面调用服务端检查客户端用户的浏览器会话。已有会话时直接继续；未登录时展示管理员在后台启用的 OAuth/OIDC 登录方式。
 5. 上游 OAuth 回调只回到 MonkeyAI 服务端。服务端绑定或创建用户，建立 HttpOnly 浏览器会话，再返回 `/client-login`。
@@ -28,7 +28,9 @@ OAuth 元数据位于 `GET /.well-known/oauth-authorization-server`，客户端�
 
 ## 3. 管理员登录与首次启动
 
-管理后台不使用 OAuth。管理员通过 `users.email + password_hash` 登录，密码使用带随机 Salt 的 PBKDF2-HMAC-SHA256 保存，成功后建立 HttpOnly 浏览器会话。浏览器会话记录认证方式，管理接口只接受密码认证产生的管理员会话；OAuth 不会绑定管理员账号。
+管理后台同时支持密码和管理员启用的 OAuth/OIDC 登录。密码使用 `users.email + password_hash` 校验，并以带随机 Salt 的 PBKDF2-HMAC-SHA256 保存；OAuth/OIDC 登录页动态列出当前启用的连接。两种方式成功后都会建立 HttpOnly 浏览器会话。
+
+OAuth/OIDC 回调只允许关联到已存在、启用状态且 `role = 'admin'` 的用户。首次使用某个第三方身份时，可以按上游返回的邮箱绑定同邮箱管理员；不会通过 OAuth 自动创建管理员，也不会把普通用户提升为管理员。普通用户或停用用户完成上游认证后仍会被管理后台拒绝。
 
 空数据库首次启动时必须使用以下环境变量创建第一个管理员：
 
@@ -40,16 +42,16 @@ export MONKEYAI_INITIAL_ADMIN_PASSWORD='至少十二个字符的初始密码'
 
 用户表为空且未配置首次管理员凭据时，服务拒绝启动，避免产生无法管理的实例。服务只在用户表为空时创建管理员，后续启动不会重置已有密码。初始化成功后应移除密码环境变量。
 
-## 4. 客户端用户 OAuth 配置
+## 4. OAuth 配置
 
-管理员登录后，在 Settings 页面配置客户端用户可用的 OAuth 连接。配置保存在 `settings.authentication.value.oauth_connections`，支持 GitHub、Google、Microsoft、GitLab 和自定义 OIDC。自定义 OIDC 默认通过 `issuer_url/.well-known/openid-configuration` 发现端点，也允许数据中显式提供 `authorization_url`、`token_url`、`userinfo_url` 和 `scopes`。
+管理员登录后，在 Settings 页面配置管理后台和客户端用户共用的 OAuth 连接。配置保存在 `settings.authentication.value.oauth_connections`，支持 GitHub、Google、Microsoft、GitLab 和自定义 OIDC；只有启用的连接会显示在登录页。自定义 OIDC 默认通过 `issuer_url/.well-known/openid-configuration` 发现端点，也允许数据中显式提供 `authorization_url`、`token_url`、`userinfo_url` 和 `scopes`。
 
 关闭自助注册时，只有邮箱已由管理员预置的用户能够绑定 OAuth 身份；开启注册后才会自动创建新用户。OAuth 用户不会被自动提升为管理员。
 
 ## 5. 用户与管理会话
 
 - 管理端会话使用随机 HttpOnly Cookie；HTTPS 环境自动添加 `Secure`，默认有效期 7 天。
-- 管理接口统一要求 `admin` 角色和密码认证会话；Agent 接口统一要求有效 Bearer access token。
+- 管理接口统一要求当前会话用户为启用状态的 `admin` 角色，密码和 OAuth 会话均可；Agent 接口统一要求有效 Bearer access token。
 - 管理员可查看用户、调整角色、启用或停用用户。服务端禁止管理员停用自己或移除自己的管理员角色。
 - 用户停用后，已有浏览器会话和 Agent token 即使尚未过期也无法继续使用。
 - OAuth access token、refresh token、授权码和浏览器会话只在数据库保存 SHA-256 摘要，不保存原文。


### PR DESCRIPTION
## 变更说明

- 恢复后台最初的登录页样式，并保留邮箱密码登录
- 在后台登录页动态列出已启用的 OAuth/OIDC 配置
- 支持管理员通过 OAuth 登录，且仅允许启用状态、`role = admin` 的用户进入后台
- 修复添加 OAuth 配置时因 `crypto.randomUUID` 不可用而未发起保存请求的问题
- 允许客户端 OAuth 使用本次传入的非空动态 `redirect_uri`，换取 Token 时仍校验与授权请求一致
- 更新认证流程和数据模型设计文档

## 验证

- `cd monkeyai/backend && go test ./...`
- `cd monkeyai/admin && npm test`（33 项通过）
- `cd monkeyai/admin && npm run build`
- `cd monkeyai/admin && npm run lint`