### PR TITLE
修复模型授权列表为空时页面白屏

### DIFF
--- a/monkeyai/admin/src/pages/models-page.tsx
+++ b/monkeyai/admin/src/pages/models-page.tsx
@@ -112,8 +112,8 @@ type ApiModel = {
   }
   credit_multiplier: number
   authorization: {
-    user_ids: string[]
-    group_ids: string[]
+    user_ids: string[] | null
+    group_ids: string[] | null
   }
   enabled: boolean
 }
@@ -138,8 +138,8 @@ function fromApiModel(model: ApiModel): Model {
     apiKeyConfigured: model.api_key_configured,
     multiplier: model.credit_multiplier,
     authorization: {
-      groupIds: model.authorization.group_ids,
-      memberIds: model.authorization.user_ids,
+      groupIds: model.authorization.group_ids ?? [],
+      memberIds: model.authorization.user_ids ?? [],
     },
     enabled: model.enabled,
     type: model.ownership_type,


### PR DESCRIPTION
模型仅授权给用户或用户组时，接口返回的另一项授权列表可能为 `null`，页面渲染授权名称时调用 `.map()` 导致白屏。

在模型接口转换处将 `user_ids`、`group_ids` 的空值统一转为空数组，并让接口类型明确接受 `null`，保证列表展示和编辑表单使用数组。

验证：
- 复现修复前的 `null.map` 异常，修复后仅用户、仅用户组、两项为 null、空数组和混合授权共 5 种场景通过。
- `pnpm test`：36 项测试通过。
- 修改文件的 ESLint 检查及 `pnpm build` 通过。
