### PR TITLE
调整注册开关至登录方式并明确 OAuth 注册规则

### DIFF
--- a/monkeyai/admin/src/i18n/locales/ar.ts
+++ b/monkeyai/admin/src/i18n/locales/ar.ts
@@ -775,6 +775,17 @@ export const ar = {
         emailCode: "السماح بتسجيل الدخول برمز البريد الإلكتروني",
         emailCodeDescription:
           "السماح بتسجيل الدخول باستخدام رمز تحقق يُرسل عبر البريد الإلكتروني.",
+        allowRegistration: "السماح بإنشاء حسابات جديدة",
+        allowRegistrationDescription:
+          "السماح للمستخدمين الجدد بإنشاء حساب عادي تلقائيًا عبر موفري تسجيل الدخول OAuth / OIDC المفعّلين.",
+        enableRegistrationDialogTitle: "السماح بإنشاء حسابات جديدة؟",
+        enableRegistrationDialogDescription:
+          "سيُنشأ حساب عادي تلقائيًا للمستخدمين الجدد بعد نجاح المصادقة عبر OAuth / OIDC.",
+        disableRegistrationDialogTitle: "إيقاف إنشاء حسابات جديدة؟",
+        disableRegistrationDialogDescription:
+          "سيتمكن الأعضاء الحاليون فقط من تسجيل الدخول عبر OAuth / OIDC. لن تتأثر الحسابات الحالية.",
+        confirmEnableRegistration: "السماح بالتسجيل",
+        confirmDisableRegistration: "إيقاف التسجيل",
       },
       oauth: {
         title: "تسجيل الدخول عبر جهة خارجية",
@@ -805,22 +816,11 @@ export const ar = {
       },
       email: {
         title: "إعدادات البريد الإلكتروني",
-        description: "اضبط إنشاء الحسابات وخدمة البريد الصادر.",
+        description: "إعداد خدمة إرسال رسائل البريد الإلكتروني للنظام.",
         configure: "تهيئة",
         dialogTitle: "تهيئة البريد الإلكتروني",
         dialogDescription: "اضبط هوية المرسل وخدمة إرسال SMTP.",
         sendingConfiguration: "إعدادات الإرسال",
-        allowRegistration: "السماح بإنشاء حسابات جديدة",
-        allowRegistrationDescription:
-          "السماح للمستخدمين غير المدعوين بإنشاء حساب عبر البريد.",
-        enableRegistrationDialogTitle: "السماح بإنشاء حسابات جديدة؟",
-        enableRegistrationDialogDescription:
-          "سيتمكن المستخدمون غير المدعوين فورًا من إنشاء حساب عبر البريد الإلكتروني.",
-        disableRegistrationDialogTitle: "إيقاف إنشاء حسابات جديدة؟",
-        disableRegistrationDialogDescription:
-          "لن يتمكن المستخدمون غير المدعوين من إنشاء حسابات جديدة. لن تتأثر الحسابات الحالية.",
-        confirmEnableRegistration: "السماح بالتسجيل",
-        confirmDisableRegistration: "إيقاف التسجيل",
         senderName: "اسم المرسل",
         senderEmail: "بريد المرسل",
         smtpHost: "مضيف SMTP",

--- a/monkeyai/admin/src/i18n/locales/de-DE.ts
+++ b/monkeyai/admin/src/i18n/locales/de-DE.ts
@@ -817,6 +817,18 @@ export const deDE = {
         emailCode: "Anmeldung mit E-Mail-Code erlauben",
         emailCodeDescription:
           "Die Anmeldung mit einem per E-Mail gesendeten Bestätigungscode erlauben.",
+        allowRegistration: "Registrierung neuer Konten erlauben",
+        allowRegistrationDescription:
+          "Neue Benutzer können über aktivierte OAuth-/OIDC-Anbieter automatisch ein Standardkonto erstellen.",
+        enableRegistrationDialogTitle: "Registrierung neuer Konten aktivieren?",
+        enableRegistrationDialogDescription:
+          "Nach erfolgreicher OAuth-/OIDC-Authentifizierung wird für neue Benutzer automatisch ein Standardkonto erstellt.",
+        disableRegistrationDialogTitle:
+          "Registrierung neuer Konten deaktivieren?",
+        disableRegistrationDialogDescription:
+          "Nur bestehende Mitglieder können sich über OAuth / OIDC anmelden. Bestehende Konten bleiben unverändert.",
+        confirmEnableRegistration: "Registrierung aktivieren",
+        confirmDisableRegistration: "Registrierung deaktivieren",
       },
       oauth: {
         title: "Drittanbieter-Anmeldung",
@@ -849,24 +861,12 @@ export const deDE = {
       },
       email: {
         title: "E-Mail-Einstellungen",
-        description: "Konfigurieren Sie Registrierung und E-Mail-Versand.",
+        description: "Konfigurieren Sie den Versand von System-E-Mails.",
         configure: "Konfigurieren",
         dialogTitle: "E-Mail-Einstellungen konfigurieren",
         dialogDescription:
           "Konfigurieren Sie Absenderidentität und SMTP-Versand.",
         sendingConfiguration: "Versandkonfiguration",
-        allowRegistration: "Registrierung neuer Konten erlauben",
-        allowRegistrationDescription:
-          "Nicht eingeladene Benutzer dürfen ein Konto erstellen.",
-        enableRegistrationDialogTitle: "Registrierung neuer Konten aktivieren?",
-        enableRegistrationDialogDescription:
-          "Benutzer ohne Einladung können sofort ein Konto per E-Mail erstellen.",
-        disableRegistrationDialogTitle:
-          "Registrierung neuer Konten deaktivieren?",
-        disableRegistrationDialogDescription:
-          "Benutzer ohne Einladung können keine neuen Konten mehr erstellen. Bestehende Konten sind nicht betroffen.",
-        confirmEnableRegistration: "Registrierung aktivieren",
-        confirmDisableRegistration: "Registrierung deaktivieren",
         senderName: "Absendername",
         senderEmail: "Absenderadresse",
         smtpHost: "SMTP-Host",

--- a/monkeyai/admin/src/i18n/locales/en-US.ts
+++ b/monkeyai/admin/src/i18n/locales/en-US.ts
@@ -931,6 +931,17 @@ export const enUS = {
         emailCode: "Allow email verification code sign-in",
         emailCodeDescription:
           "Allow members to sign in with a verification code sent by email.",
+        allowRegistration: "Allow new account registration",
+        allowRegistrationDescription:
+          "Allow new users to create a regular account through enabled OAuth / OIDC sign-in providers.",
+        enableRegistrationDialogTitle: "Enable new account registration?",
+        enableRegistrationDialogDescription:
+          "New users will automatically receive a regular account after successful OAuth / OIDC authentication.",
+        disableRegistrationDialogTitle: "Disable new account registration?",
+        disableRegistrationDialogDescription:
+          "Only existing members will be able to sign in through OAuth / OIDC. Existing accounts are not affected.",
+        confirmEnableRegistration: "Enable registration",
+        confirmDisableRegistration: "Disable registration",
       },
       oauth: {
         title: "Third-party sign-in",
@@ -963,23 +974,12 @@ export const enUS = {
       },
       email: {
         title: "Email settings",
-        description: "Configure account registration and outgoing mail.",
+        description: "Configure outgoing system mail.",
         configure: "Configure",
         dialogTitle: "Configure email settings",
         dialogDescription:
           "Configure the sender identity and outgoing SMTP service.",
         sendingConfiguration: "Sending configuration",
-        allowRegistration: "Allow new account registration",
-        allowRegistrationDescription:
-          "Allow users without an invitation to create an account by email.",
-        enableRegistrationDialogTitle: "Enable new account registration?",
-        enableRegistrationDialogDescription:
-          "Users without an invitation will immediately be able to create an account by email.",
-        disableRegistrationDialogTitle: "Disable new account registration?",
-        disableRegistrationDialogDescription:
-          "Users without an invitation will no longer be able to create an account. Existing accounts are not affected.",
-        confirmEnableRegistration: "Enable registration",
-        confirmDisableRegistration: "Disable registration",
         senderName: "Sender name",
         senderEmail: "Sender email",
         smtpHost: "SMTP host",

--- a/monkeyai/admin/src/i18n/locales/es-419.ts
+++ b/monkeyai/admin/src/i18n/locales/es-419.ts
@@ -806,6 +806,17 @@ export const es419 = {
         emailCode: "Permitir inicio de sesión con código por correo",
         emailCodeDescription:
           "Permite iniciar sesión con un código de verificación enviado por correo.",
+        allowRegistration: "Permitir registro de cuentas nuevas",
+        allowRegistrationDescription:
+          "Permite que los usuarios nuevos creen una cuenta estándar mediante proveedores OAuth / OIDC habilitados.",
+        enableRegistrationDialogTitle: "¿Permitir el registro de cuentas?",
+        enableRegistrationDialogDescription:
+          "Se creará automáticamente una cuenta estándar para los usuarios nuevos después de autenticarse con OAuth / OIDC.",
+        disableRegistrationDialogTitle: "¿Desactivar el registro de cuentas?",
+        disableRegistrationDialogDescription:
+          "Solo los miembros existentes podrán iniciar sesión mediante OAuth / OIDC. Las cuentas existentes no se ven afectadas.",
+        confirmEnableRegistration: "Permitir registro",
+        confirmDisableRegistration: "Desactivar registro",
       },
       oauth: {
         title: "Inicio de sesión de terceros",
@@ -837,23 +848,12 @@ export const es419 = {
       },
       email: {
         title: "Configuración de correo",
-        description: "Configura el registro de cuentas y el correo saliente.",
+        description: "Configura el envío de correos del sistema.",
         configure: "Configurar",
         dialogTitle: "Configurar correo",
         dialogDescription:
           "Configura la identidad del remitente y el servicio SMTP.",
         sendingConfiguration: "Configuración de envío",
-        allowRegistration: "Permitir registro de cuentas nuevas",
-        allowRegistrationDescription:
-          "Permite que usuarios sin invitación creen una cuenta.",
-        enableRegistrationDialogTitle: "¿Permitir el registro de cuentas?",
-        enableRegistrationDialogDescription:
-          "Los usuarios sin invitación podrán crear de inmediato una cuenta por correo.",
-        disableRegistrationDialogTitle: "¿Desactivar el registro de cuentas?",
-        disableRegistrationDialogDescription:
-          "Los usuarios sin invitación ya no podrán crear cuentas. Las cuentas existentes no se verán afectadas.",
-        confirmEnableRegistration: "Permitir registro",
-        confirmDisableRegistration: "Desactivar registro",
         senderName: "Nombre del remitente",
         senderEmail: "Correo del remitente",
         smtpHost: "Servidor SMTP",

--- a/monkeyai/admin/src/i18n/locales/fr-FR.ts
+++ b/monkeyai/admin/src/i18n/locales/fr-FR.ts
@@ -808,6 +808,18 @@ export const frFR = {
         emailCode: "Autoriser la connexion par code reçu par e-mail",
         emailCodeDescription:
           "Autorisez la connexion avec un code de vérification envoyé par e-mail.",
+        allowRegistration: "Autoriser les nouvelles inscriptions",
+        allowRegistrationDescription:
+          "Autoriser les nouveaux utilisateurs à créer un compte standard via les fournisseurs OAuth / OIDC activés.",
+        enableRegistrationDialogTitle: "Autoriser les nouvelles inscriptions ?",
+        enableRegistrationDialogDescription:
+          "Un compte standard sera automatiquement créé pour les nouveaux utilisateurs après une authentification OAuth / OIDC réussie.",
+        disableRegistrationDialogTitle:
+          "Désactiver les nouvelles inscriptions ?",
+        disableRegistrationDialogDescription:
+          "Seuls les membres existants pourront se connecter via OAuth / OIDC. Les comptes existants ne sont pas affectés.",
+        confirmEnableRegistration: "Autoriser les inscriptions",
+        confirmDisableRegistration: "Désactiver les inscriptions",
       },
       oauth: {
         title: "Connexion tierce",
@@ -840,24 +852,12 @@ export const frFR = {
       },
       email: {
         title: "Paramètres des e-mails",
-        description: "Configurez l’inscription et l’envoi d’e-mails.",
+        description: "Configurer l’envoi des e-mails système.",
         configure: "Configurer",
         dialogTitle: "Configurer les e-mails",
         dialogDescription:
           "Configurez l’identité de l’expéditeur et le service SMTP.",
         sendingConfiguration: "Configuration de l’envoi",
-        allowRegistration: "Autoriser les nouvelles inscriptions",
-        allowRegistrationDescription:
-          "Autorisez les utilisateurs non invités à créer un compte.",
-        enableRegistrationDialogTitle: "Autoriser les nouvelles inscriptions ?",
-        enableRegistrationDialogDescription:
-          "Les utilisateurs sans invitation pourront immédiatement créer un compte par e-mail.",
-        disableRegistrationDialogTitle:
-          "Désactiver les nouvelles inscriptions ?",
-        disableRegistrationDialogDescription:
-          "Les utilisateurs sans invitation ne pourront plus créer de compte. Les comptes existants ne sont pas affectés.",
-        confirmEnableRegistration: "Autoriser les inscriptions",
-        confirmDisableRegistration: "Désactiver les inscriptions",
         senderName: "Nom de l’expéditeur",
         senderEmail: "E-mail de l’expéditeur",
         smtpHost: "Hôte SMTP",

--- a/monkeyai/admin/src/i18n/locales/ja-JP.ts
+++ b/monkeyai/admin/src/i18n/locales/ja-JP.ts
@@ -785,6 +785,17 @@ export const jaJP = {
         emailCode: "メール認証コードでのログインを許可",
         emailCodeDescription:
           "メールで送信された認証コードでのログインを許可します。",
+        allowRegistration: "新規アカウント登録を許可",
+        allowRegistrationDescription:
+          "有効な OAuth / OIDC ログイン方法を通じて、新規ユーザーの一般アカウントを自動作成します。",
+        enableRegistrationDialogTitle: "新規アカウント登録を有効にしますか？",
+        enableRegistrationDialogDescription:
+          "新規ユーザーが OAuth / OIDC 認証に成功すると、一般アカウントが自動作成されます。",
+        disableRegistrationDialogTitle: "新規アカウント登録を無効にしますか？",
+        disableRegistrationDialogDescription:
+          "OAuth / OIDC でログインできるのは追加済みのメンバーのみになります。既存のアカウントには影響しません。",
+        confirmEnableRegistration: "有効にする",
+        confirmDisableRegistration: "無効にする",
       },
       oauth: {
         title: "外部サービスログイン",
@@ -816,22 +827,11 @@ export const jaJP = {
       },
       email: {
         title: "メール設定",
-        description: "アカウント登録と送信メールを設定します。",
+        description: "システムメールの送信サービスを設定します。",
         configure: "設定",
         dialogTitle: "メール設定",
         dialogDescription: "送信者情報と SMTP 送信サービスを設定します。",
         sendingConfiguration: "送信設定",
-        allowRegistration: "新規アカウント登録を許可",
-        allowRegistrationDescription:
-          "招待されていないユーザーのメール登録を許可します。",
-        enableRegistrationDialogTitle: "新規アカウント登録を有効にしますか？",
-        enableRegistrationDialogDescription:
-          "招待されていないユーザーも、すぐにメールでアカウントを作成できるようになります。",
-        disableRegistrationDialogTitle: "新規アカウント登録を無効にしますか？",
-        disableRegistrationDialogDescription:
-          "招待されていないユーザーは新規アカウントを作成できなくなります。既存のアカウントには影響しません。",
-        confirmEnableRegistration: "有効にする",
-        confirmDisableRegistration: "無効にする",
         senderName: "送信者名",
         senderEmail: "送信元メールアドレス",
         smtpHost: "SMTP ホスト",

--- a/monkeyai/admin/src/i18n/locales/ko-KR.ts
+++ b/monkeyai/admin/src/i18n/locales/ko-KR.ts
@@ -776,6 +776,17 @@ export const koKR = {
         emailCode: "이메일 인증 코드 로그인 허용",
         emailCodeDescription:
           "이메일로 전송된 인증 코드를 사용한 로그인을 허용합니다.",
+        allowRegistration: "새 계정 등록 허용",
+        allowRegistrationDescription:
+          "활성화된 OAuth / OIDC 로그인 제공자를 통해 신규 사용자의 일반 계정을 자동으로 생성합니다.",
+        enableRegistrationDialogTitle: "새 계정 등록을 허용할까요?",
+        enableRegistrationDialogDescription:
+          "신규 사용자가 OAuth / OIDC 인증에 성공하면 일반 계정이 자동으로 생성됩니다.",
+        disableRegistrationDialogTitle: "새 계정 등록을 중지할까요?",
+        disableRegistrationDialogDescription:
+          "기존 멤버만 OAuth / OIDC로 로그인할 수 있습니다. 기존 계정에는 영향을 주지 않습니다.",
+        confirmEnableRegistration: "등록 허용",
+        confirmDisableRegistration: "등록 중지",
       },
       oauth: {
         title: "타사 로그인",
@@ -807,22 +818,11 @@ export const koKR = {
       },
       email: {
         title: "이메일 설정",
-        description: "계정 등록 및 발신 메일 서비스를 설정합니다.",
+        description: "시스템 메일 발송 서비스를 설정합니다.",
         configure: "설정",
         dialogTitle: "이메일 설정",
         dialogDescription: "보낸 사람 정보 및 SMTP 발신 서비스를 설정합니다.",
         sendingConfiguration: "발신 설정",
-        allowRegistration: "새 계정 등록 허용",
-        allowRegistrationDescription:
-          "초대받지 않은 사용자가 이메일로 계정을 만들 수 있습니다.",
-        enableRegistrationDialogTitle: "새 계정 등록을 허용할까요?",
-        enableRegistrationDialogDescription:
-          "초대받지 않은 사용자도 즉시 이메일로 계정을 만들 수 있습니다.",
-        disableRegistrationDialogTitle: "새 계정 등록을 중지할까요?",
-        disableRegistrationDialogDescription:
-          "초대받지 않은 사용자는 더 이상 새 계정을 만들 수 없습니다. 기존 계정은 영향을 받지 않습니다.",
-        confirmEnableRegistration: "등록 허용",
-        confirmDisableRegistration: "등록 중지",
         senderName: "보낸 사람 이름",
         senderEmail: "보낸 사람 이메일",
         smtpHost: "SMTP 호스트",

--- a/monkeyai/admin/src/i18n/locales/ru-RU.ts
+++ b/monkeyai/admin/src/i18n/locales/ru-RU.ts
@@ -806,6 +806,18 @@ export const ruRU = {
         emailCode: "Разрешить вход по коду из письма",
         emailCodeDescription:
           "Разрешить вход по коду подтверждения, отправленному на электронную почту.",
+        allowRegistration: "Разрешить регистрацию новых аккаунтов",
+        allowRegistrationDescription:
+          "Разрешить новым пользователям автоматически создавать обычную учётную запись через включённых провайдеров OAuth / OIDC.",
+        enableRegistrationDialogTitle: "Разрешить регистрацию новых аккаунтов?",
+        enableRegistrationDialogDescription:
+          "После успешной аутентификации OAuth / OIDC для нового пользователя будет автоматически создана обычная учётная запись.",
+        disableRegistrationDialogTitle:
+          "Запретить регистрацию новых аккаунтов?",
+        disableRegistrationDialogDescription:
+          "Вход через OAuth / OIDC будет доступен только существующим участникам. Существующие учётные записи не изменятся.",
+        confirmEnableRegistration: "Разрешить регистрацию",
+        confirmDisableRegistration: "Запретить регистрацию",
       },
       oauth: {
         title: "Вход через сторонние сервисы",
@@ -838,23 +850,11 @@ export const ruRU = {
       },
       email: {
         title: "Настройки электронной почты",
-        description: "Настройте регистрацию и отправку системных писем.",
+        description: "Настройте отправку системных писем.",
         configure: "Настроить",
         dialogTitle: "Настроить электронную почту",
         dialogDescription: "Настройте данные отправителя и SMTP-сервис.",
         sendingConfiguration: "Настройки отправки",
-        allowRegistration: "Разрешить регистрацию новых аккаунтов",
-        allowRegistrationDescription:
-          "Разрешить пользователям без приглашения создавать аккаунты.",
-        enableRegistrationDialogTitle: "Разрешить регистрацию новых аккаунтов?",
-        enableRegistrationDialogDescription:
-          "Пользователи без приглашения сразу смогут создавать аккаунты по электронной почте.",
-        disableRegistrationDialogTitle:
-          "Запретить регистрацию новых аккаунтов?",
-        disableRegistrationDialogDescription:
-          "Пользователи без приглашения больше не смогут создавать аккаунты. Существующие аккаунты не изменятся.",
-        confirmEnableRegistration: "Разрешить регистрацию",
-        confirmDisableRegistration: "Запретить регистрацию",
         senderName: "Имя отправителя",
         senderEmail: "Адрес отправителя",
         smtpHost: "SMTP-сервер",

--- a/monkeyai/admin/src/i18n/locales/zh-CN.ts
+++ b/monkeyai/admin/src/i18n/locales/zh-CN.ts
@@ -879,6 +879,17 @@ export const zhCN = {
         passwordDescription: "允许成员使用邮箱和密码登录。",
         emailCode: "允许使用邮箱验证码登录",
         emailCodeDescription: "允许成员通过邮箱接收验证码登录。",
+        allowRegistration: "允许新账号注册",
+        allowRegistrationDescription:
+          "允许新用户通过已启用的 OAuth / OIDC 登录方式自动创建普通账号。",
+        enableRegistrationDialogTitle: "开启新账号注册？",
+        enableRegistrationDialogDescription:
+          "开启后，新用户通过 OAuth / OIDC 认证成功时将自动创建普通账号。",
+        disableRegistrationDialogTitle: "关闭新账号注册？",
+        disableRegistrationDialogDescription:
+          "关闭后，仅已添加的成员可以通过 OAuth / OIDC 登录，已有账号不受影响。",
+        confirmEnableRegistration: "确认开启",
+        confirmDisableRegistration: "确认关闭",
       },
       oauth: {
         title: "第三方登录",
@@ -908,21 +919,11 @@ export const zhCN = {
       },
       email: {
         title: "邮件设置",
-        description: "配置账号注册和系统邮件的发件服务。",
+        description: "配置系统邮件的发件服务。",
         configure: "配置",
         dialogTitle: "配置邮件设置",
         dialogDescription: "配置发件人身份和 SMTP 发件服务。",
         sendingConfiguration: "发信配置",
-        allowRegistration: "允许新账号注册",
-        allowRegistrationDescription: "允许未受邀请的用户通过邮箱创建新账号。",
-        enableRegistrationDialogTitle: "开启新账号注册？",
-        enableRegistrationDialogDescription:
-          "开启后，未受邀请的用户将可以立即通过邮箱创建新账号。",
-        disableRegistrationDialogTitle: "关闭新账号注册？",
-        disableRegistrationDialogDescription:
-          "关闭后，未受邀请的用户将无法创建新账号，已有账号不受影响。",
-        confirmEnableRegistration: "确认开启",
-        confirmDisableRegistration: "确认关闭",
         senderName: "发件人名称",
         senderEmail: "发件邮箱",
         smtpHost: "SMTP 主机",

--- a/monkeyai/admin/src/i18n/locales/zh-TW.ts
+++ b/monkeyai/admin/src/i18n/locales/zh-TW.ts
@@ -747,6 +747,17 @@ export const zhTW = {
         passwordDescription: "允許成員使用電子郵件和密碼登入。",
         emailCode: "允許使用電子郵件驗證碼登入",
         emailCodeDescription: "允許成員透過電子郵件接收驗證碼登入。",
+        allowRegistration: "允許新帳號註冊",
+        allowRegistrationDescription:
+          "允許新使用者透過已啟用的 OAuth / OIDC 登入方式自動建立一般帳號。",
+        enableRegistrationDialogTitle: "開啟新帳號註冊？",
+        enableRegistrationDialogDescription:
+          "開啟後，新使用者通過 OAuth / OIDC 驗證時將自動建立一般帳號。",
+        disableRegistrationDialogTitle: "關閉新帳號註冊？",
+        disableRegistrationDialogDescription:
+          "關閉後，僅已新增的成員可以透過 OAuth / OIDC 登入，既有帳號不受影響。",
+        confirmEnableRegistration: "確認開啟",
+        confirmDisableRegistration: "確認關閉",
       },
       oauth: {
         title: "第三方登入",
@@ -776,22 +787,11 @@ export const zhTW = {
       },
       email: {
         title: "郵件設定",
-        description: "設定帳號註冊與系統郵件寄送服務。",
+        description: "設定系統郵件的寄件服務。",
         configure: "設定",
         dialogTitle: "設定郵件",
         dialogDescription: "設定寄件者身分和 SMTP 寄件服務。",
         sendingConfiguration: "寄信設定",
-        allowRegistration: "允許新帳號註冊",
-        allowRegistrationDescription:
-          "允許未受邀請的使用者透過電子郵件建立帳號。",
-        enableRegistrationDialogTitle: "開啟新帳號註冊？",
-        enableRegistrationDialogDescription:
-          "開啟後，未受邀請的使用者將可立即透過電子郵件建立新帳號。",
-        disableRegistrationDialogTitle: "關閉新帳號註冊？",
-        disableRegistrationDialogDescription:
-          "關閉後，未受邀請的使用者將無法建立新帳號，現有帳號不受影響。",
-        confirmEnableRegistration: "確認開啟",
-        confirmDisableRegistration: "確認關閉",
         senderName: "寄件者名稱",
         senderEmail: "寄件信箱",
         smtpHost: "SMTP 主機",

--- a/monkeyai/admin/src/pages/other-settings-page.tsx
+++ b/monkeyai/admin/src/pages/other-settings-page.tsx
@@ -140,7 +140,6 @@ type LoginMethodSettings = {
 }
 
 type EmailSettings = {
-  registrationEnabled: boolean
   senderName: string
   senderEmail: string
   smtpHost: string
@@ -188,7 +187,6 @@ const INITIAL_LOGIN_METHOD_SETTINGS: LoginMethodSettings = {
 }
 
 const INITIAL_EMAIL_SETTINGS: EmailSettings = {
-  registrationEnabled: false,
   senderName: "Monkey AI",
   senderEmail: "no-reply@example.com",
   smtpHost: "smtp.example.com",
@@ -226,6 +224,7 @@ export function OtherSettingsPage() {
   const [loginMethodSaving, setLoginMethodSaving] = useState<
     keyof LoginMethodSettings | null
   >(null)
+  const [registrationEnabled, setRegistrationEnabled] = useState(false)
   const [emailSettings, setEmailSettings] = useState(INITIAL_EMAIL_SETTINGS)
   const [savedEmailSettings, setSavedEmailSettings] = useState(
     INITIAL_EMAIL_SETTINGS
@@ -305,21 +304,10 @@ export function OtherSettingsPage() {
                   ? setting.value.email_code_enabled
                   : INITIAL_LOGIN_METHOD_SETTINGS.emailCodeEnabled,
             })
-            const registrationEnabled = Boolean(
-              setting.value.registration_enabled
-            )
-            setEmailSettings((current) => ({
-              ...current,
-              registrationEnabled,
-            }))
-            setSavedEmailSettings((current) => ({
-              ...current,
-              registrationEnabled,
-            }))
+            setRegistrationEnabled(Boolean(setting.value.registration_enabled))
           }
           if (setting.key === "email") {
-            const applyEmail = (current: EmailSettings): EmailSettings => ({
-              registrationEnabled: current.registrationEnabled,
+            const applyEmail = (): EmailSettings => ({
               senderName: String(setting.value.sender_name ?? ""),
               senderEmail: String(setting.value.sender_email ?? ""),
               smtpHost: String(setting.value.smtp_host ?? ""),
@@ -354,11 +342,11 @@ export function OtherSettingsPage() {
 
   const saveAuthentication = async (
     connections: OAuthConnection[],
-    registrationEnabled = savedEmailSettings.registrationEnabled,
+    allowRegistration = registrationEnabled,
     loginMethods = loginMethodSettings
   ) =>
     saveSetting("authentication", {
-      registration_enabled: registrationEnabled,
+      registration_enabled: allowRegistration,
       password_enabled: loginMethods.passwordEnabled,
       email_code_enabled: loginMethods.emailCodeEnabled,
       oauth_connections: connections.map((connection) => ({
@@ -467,7 +455,7 @@ export function OtherSettingsPage() {
       if (
         await saveAuthentication(
           oauthConnections,
-          savedEmailSettings.registrationEnabled,
+          registrationEnabled,
           nextSettings
         )
       ) {
@@ -499,7 +487,6 @@ export function OtherSettingsPage() {
   ) => {
     event.preventDefault()
     const saved = await saveSetting("email", {
-      registration_enabled: emailSettings.registrationEnabled,
       sender_name: emailSettings.senderName,
       sender_email: emailSettings.senderEmail,
       smtp_host: emailSettings.smtpHost,
@@ -1572,6 +1559,25 @@ export function OtherSettingsPage() {
             <Field orientation="horizontal">
               <FieldContent>
                 <FieldTitle>
+                  {t("pages.otherSettings.loginMethods.allowRegistration")}
+                </FieldTitle>
+                <FieldDescription>
+                  {t(
+                    "pages.otherSettings.loginMethods.allowRegistrationDescription"
+                  )}
+                </FieldDescription>
+              </FieldContent>
+              <Switch
+                checked={registrationEnabled}
+                onCheckedChange={setRegistrationPendingValue}
+                aria-label={t(
+                  "pages.otherSettings.loginMethods.allowRegistration"
+                )}
+              />
+            </Field>
+            <Field orientation="horizontal">
+              <FieldContent>
+                <FieldTitle>
                   {t("pages.otherSettings.loginMethods.password")}
                 </FieldTitle>
                 <FieldDescription>
@@ -1825,23 +1831,6 @@ export function OtherSettingsPage() {
             <Item variant="outline">
               <ItemContent>
                 <ItemTitle>
-                  {t("pages.otherSettings.email.allowRegistration")}
-                </ItemTitle>
-                <ItemDescription>
-                  {t("pages.otherSettings.email.allowRegistrationDescription")}
-                </ItemDescription>
-              </ItemContent>
-              <ItemActions>
-                <Switch
-                  checked={savedEmailSettings.registrationEnabled}
-                  onCheckedChange={setRegistrationPendingValue}
-                  aria-label={t("pages.otherSettings.email.allowRegistration")}
-                />
-              </ItemActions>
-            </Item>
-            <Item variant="outline">
-              <ItemContent>
-                <ItemTitle>
                   {t("pages.otherSettings.email.sendingConfiguration")}
                 </ItemTitle>
                 <ItemDescription>
@@ -1926,15 +1915,15 @@ export function OtherSettingsPage() {
             <AlertDialogTitle>
               {t(
                 registrationPendingValue
-                  ? "pages.otherSettings.email.enableRegistrationDialogTitle"
-                  : "pages.otherSettings.email.disableRegistrationDialogTitle"
+                  ? "pages.otherSettings.loginMethods.enableRegistrationDialogTitle"
+                  : "pages.otherSettings.loginMethods.disableRegistrationDialogTitle"
               )}
             </AlertDialogTitle>
             <AlertDialogDescription>
               {t(
                 registrationPendingValue
-                  ? "pages.otherSettings.email.enableRegistrationDialogDescription"
-                  : "pages.otherSettings.email.disableRegistrationDialogDescription"
+                  ? "pages.otherSettings.loginMethods.enableRegistrationDialogDescription"
+                  : "pages.otherSettings.loginMethods.disableRegistrationDialogDescription"
               )}
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -1955,22 +1944,15 @@ export function OtherSettingsPage() {
                     registrationEnabled
                   )
                 ) {
-                  setSavedEmailSettings((settings) => ({
-                    ...settings,
-                    registrationEnabled,
-                  }))
-                  setEmailSettings((settings) => ({
-                    ...settings,
-                    registrationEnabled,
-                  }))
+                  setRegistrationEnabled(registrationEnabled)
                   setRegistrationPendingValue(null)
                 }
               }}
             >
               {t(
                 registrationPendingValue
-                  ? "pages.otherSettings.email.confirmEnableRegistration"
-                  : "pages.otherSettings.email.confirmDisableRegistration"
+                  ? "pages.otherSettings.loginMethods.confirmEnableRegistration"
+                  : "pages.otherSettings.loginMethods.confirmDisableRegistration"
               )}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/monkeyai/backend/internal/identity/postgres_test.go
+++ b/monkeyai/backend/internal/identity/postgres_test.go
@@ -1,0 +1,104 @@
+package identity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type authenticationStub struct {
+	value json.RawMessage
+}
+
+func (s authenticationStub) GetValue(context.Context, string) (json.RawMessage, error) {
+	return s.value, nil
+}
+
+func TestOAuthUserRegistration(t *testing.T) {
+	dsn := os.Getenv("MONKEYAI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("设置 MONKEYAI_TEST_DATABASE_URL 运行 OAuth 用户注册集成测试")
+	}
+	ctx := t.Context()
+	root, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(root.Close)
+	suffix, err := randomToken(12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := pgx.Identifier{"test_identity_" + suffix}.Sanitize()
+	if _, err := root.Exec(ctx, "CREATE SCHEMA "+schema); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if _, err := root.Exec(context.Background(), "DROP SCHEMA "+schema+" CASCADE"); err != nil {
+			t.Error(err)
+		}
+	})
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.ConnConfig.RuntimeParams["search_path"] = schema
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	migration, err := os.ReadFile(filepath.Join("..", "..", "migrations", "000001_initial_create_schema.up.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, string(migration)); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name     string
+		settings string
+		want     error
+	}{
+		{name: "enabled", settings: `{"registration_enabled":true}`},
+		{name: "disabled", settings: `{"registration_enabled":false}`, want: ErrRegistrationDisabled},
+		{name: "unset", settings: `{}`, want: ErrRegistrationDisabled},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			service := NewService(pool, authenticationStub{value: json.RawMessage(test.settings)}, "http://localhost", "http://localhost")
+			profile := upstreamProfile{Provider: "oidc", Issuer: "https://issuer.example.com", Subject: test.name, Email: test.name + "@example.com", Name: test.name}
+			user, err := service.upsertIdentity(ctx, profile, false)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("注册结果 = %v, want %v", err, test.want)
+			}
+			var users, identities int
+			if err := pool.QueryRow(ctx, `SELECT count(*) FROM users WHERE email = $1`, profile.Email).Scan(&users); err != nil {
+				t.Fatal(err)
+			}
+			if err := pool.QueryRow(ctx, `SELECT count(*) FROM user_identities WHERE provider_subject = $1`, profile.Subject).Scan(&identities); err != nil {
+				t.Fatal(err)
+			}
+			if test.want != nil {
+				if users != 0 || identities != 0 {
+					t.Fatalf("拒绝注册后留下用户或身份: users=%d identities=%d", users, identities)
+				}
+				return
+			}
+			if users != 1 || identities != 1 || user.Role != "user" || user.Status != "active" {
+				t.Fatalf("自动创建用户或绑定身份失败: users=%d identities=%d role=%s status=%s", users, identities, user.Role, user.Status)
+			}
+			service.settings = authenticationStub{value: json.RawMessage(`{"registration_enabled":false}`)}
+			again, err := service.upsertIdentity(ctx, profile, false)
+			if err != nil || again.ID != user.ID {
+				t.Fatalf("关闭注册后已有用户重复登录失败: err=%v id=%s", err, again.ID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
“允许新账号注册”原先位于邮件设置，说明仅提到邮箱注册，但实际也控制 OAuth / OIDC 登录后是否自动创建用户，容易误判为 OAuth 登录故障。

将开关移到“登录方式”首项，保留确认弹窗，并同步 10 种语言的说明：开启后，OAuth / OIDC 新用户认证成功会自动创建普通账号。注册状态独立保存在认证设置，邮件配置只提交发信字段；后端注册规则保持默认关闭、已有用户可继续登录。

补充 PostgreSQL 集成测试，覆盖开启、关闭、未配置注册开关，以及关闭后已有用户再次登录。

验证：
- 前端构建、改动文件 ESLint、38 项前端测试通过。
- 独立 PostgreSQL 注册集成测试通过；更新到最新 main 后，identity / setting 单元测试和 go vet 通过。
- 本地浏览器使用模拟接口验证了开关位置、开启/关闭、取消确认和刷新后的状态回显。
