### PR TITLE
修复 Agent 模型列表返回真实模型名称

### DIFF
--- a/monkeyai/backend/api/README.md
+++ b/monkeyai/backend/api/README.md
@@ -23,6 +23,8 @@ Agent 使用 OAuth access token 按资源类型读取，整体 `GET /api/v1/conf
 
 模型列表中的 `model_gateway.base_url` 为代理 `/v1` 地址，`authentication` 固定为 `api_key`。专家清单、资源 resolve、技能包下载以及连接器工具和认证接口沿用原路径与权限规则。
 
+模型列表每项的 `id` 为平台内部模型 UUID，`model` 为数据库 `models.model_id` 中配置的真实上游模型名称。调用模型代理时，请求体的 `model` 参数使用列表项的 `id`，由代理定位配置、检查权限并转换为上游模型名称。
+
 ## 用户模型与分享
 
 以下接口均使用 Agent OAuth access token：`Authorization: Bearer <access_token>`，完整契约见 `agent.yaml`。模型代理调用仍使用独立的调用密钥。

--- a/monkeyai/backend/api/agent.yaml
+++ b/monkeyai/backend/api/agent.yaml
@@ -1492,11 +1492,10 @@ components:
         id:
           type: string
           format: uuid
-          description: MonkeyAI 内部模型 ID。
+          description: MonkeyAI 内部模型 ID，调用模型代理时作为请求的 model 值。
         model:
           type: string
-          format: uuid
-          description: 调用模型代理时传入的 model 值，当前与 id 相同。
+          description: 数据库 models.model_id 中配置的真实上游模型名称。
         display_name:
           type: string
           description: Agent 向用户展示的模型名称。

--- a/monkeyai/backend/internal/model/agent_test.go
+++ b/monkeyai/backend/internal/model/agent_test.go
@@ -36,10 +36,10 @@ func TestAgentModelsEndpoint(t *testing.T) {
 	if err := json.Unmarshal(first.Body.Bytes(), &body); err != nil {
 		t.Fatal(err)
 	}
-	if first.Code != http.StatusOK || len(body.Models) != 1 || body.Models[0].Model != "model-1" || body.Gateway.BaseURL != "https://monkeyai.example.com/v1" || body.Gateway.Authentication != "api_key" {
+	if first.Code != http.StatusOK || len(body.Models) != 1 || body.Models[0].ID != "model-1" || body.Models[0].Model != "upstream-name" || body.Gateway.BaseURL != "https://monkeyai.example.com/v1" || body.Gateway.Authentication != "api_key" {
 		t.Fatalf("模型目录无效: %d %s", first.Code, first.Body.String())
 	}
-	for _, key := range []string{"upstream", `"settings"`, `"rules"`, `"skills"`, `"experts"`, `"connectors"`} {
+	for _, key := range []string{"upstream-secret", "https://upstream.example.com/v1", `"settings"`, `"rules"`, `"skills"`, `"experts"`, `"connectors"`} {
 		if strings.Contains(first.Body.String(), key) {
 			t.Fatalf("模型目录包含无关数据: %s", first.Body.String())
 		}

--- a/monkeyai/backend/internal/model/service.go
+++ b/monkeyai/backend/internal/model/service.go
@@ -119,7 +119,7 @@ func (s *Service) AgentModels(ctx context.Context, userID string, isAdmin bool) 
 			OwnershipType:       item.OwnershipType,
 			OwnerUserID:         item.OwnerUserID,
 			ID:                  item.ID,
-			Model:               item.ID,
+			Model:               item.ModelID,
 			DisplayName:         item.DisplayName,
 			Protocol:            item.Protocol,
 			ContextWindowTokens: item.AdvancedConfig.ContextWindowTokens,


### PR DESCRIPTION
Agent 读取 `GET /api/v1/models` 时，列表项的 `model` 原先返回平台内部 UUID。现在改为数据库 `models.model_id` 中配置的真实上游模型名称，例如 `upstream-name`。

同步更新 OpenAPI 和接口说明，移除 `model` 的 UUID 格式约束，并明确模型代理请求仍使用列表项的 `id` 定位配置。现有接口测试验证 `id` 和 `model` 的各自取值，同时保留上游地址及密钥不泄露的检查。

验证：`go test ./internal/model/...`、`go test ./...`、`go vet ./...`、API YAML 与本地引用检查、迁移版本与配对检查、`git diff --check` 均通过。
