### PR TITLE
优化 MonkeyAI Go 代码并修复私有依赖镜像构建

### DIFF
--- a/monkeyai/Makefile
+++ b/monkeyai/Makefile
@@ -14,6 +14,7 @@ image-admin:
 	docker buildx build \
 	  --platform $(PLATFORM) \
 	  --tag $(ADMIN_IMAGE) \
+	  --secret id=netrc,src=${HOME}/.netrc \
 	  --load \
 	  ./admin
 	@echo "Admin image: $(ADMIN_IMAGE)"
@@ -22,6 +23,7 @@ image-backend:
 	docker buildx build \
 	  --platform $(PLATFORM) \
 	  --tag $(BACKEND_IMAGE) \
+	  --secret id=netrc,src=${HOME}/.netrc \
 	  --load \
 	  ./backend
 	@echo "Backend image: $(BACKEND_IMAGE)"
@@ -30,6 +32,7 @@ image-migrate:
 	docker buildx build \
 	  --platform $(PLATFORM) \
 	  --tag $(MIGRATE_IMAGE) \
+	  --secret id=netrc,src=${HOME}/.netrc \
 	  --load \
 	  ./backend/migrations
 	@echo "Migrate image: $(MIGRATE_IMAGE)"
@@ -40,6 +43,7 @@ push-admin:
 	docker buildx build \
 	  --platform $(PLATFORM) \
 	  --tag $(ADMIN_IMAGE) \
+	  --secret id=netrc,src=${HOME}/.netrc \
 	  --push \
 	  ./admin
 	@echo "Pushed: $(ADMIN_IMAGE)"
@@ -48,6 +52,7 @@ push-backend:
 	docker buildx build \
 	  --platform $(PLATFORM) \
 	  --tag $(BACKEND_IMAGE) \
+	  --secret id=netrc,src=${HOME}/.netrc \
 	  --push \
 	  ./backend
 	@echo "Pushed: $(BACKEND_IMAGE)"
@@ -55,6 +60,7 @@ push-backend:
 push-migrate:
 	docker buildx build \
 	  --platform $(PLATFORM) \
+	  --secret id=netrc,src=${HOME}/.netrc \
 	  --tag $(MIGRATE_IMAGE) \
 	  --push \
 	  ./backend/migrations

--- a/monkeyai/backend/Dockerfile
+++ b/monkeyai/backend/Dockerfile
@@ -17,7 +17,10 @@ COPY . .
 
 ARG TARGETOS
 ARG TARGETARCH
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=secret,id=netrc,target=/root/.netrc \
+    --mount=type=ssh \
     GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -trimpath -ldflags="-s -w" -o /out/monkeyai-server ./cmd/server
 

--- a/monkeyai/backend/internal/billing/wallet.go
+++ b/monkeyai/backend/internal/billing/wallet.go
@@ -90,9 +90,8 @@ func walletFailure(err error) (string, string) {
 	if errors.Is(err, opensdk.ErrCreditAccountSuspended) {
 		code = "wallet_account_suspended"
 	}
-	var e *opensdk.WalletError
 	trace := ""
-	if errors.As(err, &e) {
+	if e, ok := errors.AsType[*opensdk.WalletError](err); ok {
 		trace = e.TraceID
 	}
 	return code, trace

--- a/monkeyai/backend/internal/httpapi/cache.go
+++ b/monkeyai/backend/internal/httpapi/cache.go
@@ -25,7 +25,7 @@ func CachedJSON(w http.ResponseWriter, r *http.Request, value map[string]any) er
 	etag := `"` + version + `"`
 	w.Header().Set("ETag", etag)
 	w.Header().Set("Cache-Control", "private, no-cache")
-	for _, match := range strings.Split(r.Header.Get("If-None-Match"), ",") {
+	for match := range strings.SplitSeq(r.Header.Get("If-None-Match"), ",") {
 		match = strings.TrimPrefix(strings.TrimSpace(match), "W/")
 		if match == etag || match == "*" {
 			w.WriteHeader(http.StatusNotModified)

--- a/monkeyai/backend/internal/mcp/remote.go
+++ b/monkeyai/backend/internal/mcp/remote.go
@@ -72,8 +72,8 @@ func (c *remoteClient) call(ctx context.Context, id int, method string, params a
 		}
 		for scanner.Scan() {
 			line := scanner.Text()
-			if strings.HasPrefix(line, "data:") {
-				event.WriteString(strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+			if after, ok := strings.CutPrefix(line, "data:"); ok {
+				event.WriteString(strings.TrimPrefix(after, " "))
 				event.WriteByte('\n')
 			}
 			if line == "" && event.Len() > 0 && check() {

--- a/monkeyai/backend/internal/mcp/transport.go
+++ b/monkeyai/backend/internal/mcp/transport.go
@@ -15,7 +15,7 @@ import (
 
 func allowedIP(ip netip.Addr) bool {
 	ip = ip.Unmap()
-	for _, s := range strings.Split(os.Getenv("MONKEYAI_MCP_ALLOWED_CIDRS"), ",") {
+	for s := range strings.SplitSeq(os.Getenv("MONKEYAI_MCP_ALLOWED_CIDRS"), ",") {
 		p, err := netip.ParsePrefix(strings.TrimSpace(s))
 		if err == nil && p.Contains(ip) {
 			return true
@@ -78,7 +78,7 @@ func discover(ctx context.Context, target string, headers map[string]string) ([]
 	cursor := ""
 	cursors := map[string]bool{}
 	names := map[string]bool{}
-	for page := 0; page < 100; page++ {
+	for page := range 100 {
 		params := map[string]string{}
 		if cursor != "" {
 			params["cursor"] = cursor

--- a/monkeyai/backend/internal/proxy/usage.go
+++ b/monkeyai/backend/internal/proxy/usage.go
@@ -73,8 +73,7 @@ func newUsageCapture(logger *slog.Logger, src io.ReadCloser, ctx usageCaptureCon
 		reader: reader,
 		writer: writer,
 	}
-	ctx.proxy.captures.Add(1)
-	go func() { defer ctx.proxy.captures.Done(); capture.handleShadow() }()
+	ctx.proxy.captures.Go(capture.handleShadow)
 	return capture
 }
 

--- a/monkeyai/backend/internal/resource/storage.go
+++ b/monkeyai/backend/internal/resource/storage.go
@@ -62,8 +62,7 @@ func (s *S3) Init(ctx context.Context) error {
 	if err == nil {
 		return nil
 	}
-	var missing *types.NotFound
-	if !errors.As(err, &missing) {
+	if _, ok := errors.AsType[*types.NotFound](err); !ok {
 		return err
 	}
 	_, err = s.client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: &s.bucket})


### PR DESCRIPTION
## 变更说明

- 使用 Go 1.27 标准库能力简化错误转换、字符串遍历与并发任务管理
- 为镜像构建命令传入 `.netrc` BuildKit secret
- 在 Backend 编译阶段复用 Go 模块缓存并挂载私有仓库认证，修复 `opensdk` 下载失败

## 验证

- `go test ./...`
- `go vet ./...`
- `make image`
- Backend 使用 `--no-cache` 完成冷构建