### PR TITLE
修复 MonkeyAI 模型代理不兼容下发模型名的问题

### DIFF
--- a/monkeyai/backend/api/agent.yaml
+++ b/monkeyai/backend/api/agent.yaml
@@ -1492,10 +1492,10 @@ components:
         id:
           type: string
           format: uuid
-          description: MonkeyAI 内部模型 ID，调用模型代理时作为请求的 model 值。
+          description: MonkeyAI 内部模型 UUID，模型代理兼容使用该值作为请求的 model。
         model:
           type: string
-          description: 数据库 models.model_id 中配置的真实上游模型名称。
+          description: 数据库 models.model_id 中配置的模型名称，Agent 调用模型代理时作为请求的 model 值。
         display_name:
           type: string
           description: Agent 向用户展示的模型名称。

--- a/monkeyai/backend/internal/app/billing_test.go
+++ b/monkeyai/backend/internal/app/billing_test.go
@@ -159,12 +159,20 @@ func TestBillingIntegration(t *testing.T) {
 		if body.Int("max_completion_tokens") != 2000 {
 			t.Errorf("未限制输出: %v", body)
 		}
+		if body.String("model") != "billing-model" {
+			t.Errorf("上游模型名错误: %v", body)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"id":"upstream-reused-id","usage":{"prompt_tokens":10000,"completion_tokens":2000,"prompt_tokens_details":{"cached_tokens":4000}}}`)
 	}))
 	defer upstream.Close()
 	model := must("POST", "/api/admin/v1/models", resource.Object{"model_id": "billing-model", "display_name": "计费模型", "protocol": "openai_chat_completions", "base_url": upstream.URL, "api_key": "test-key", "advanced_config": resource.Object{"context_window_tokens": 20000, "max_output_tokens": 2000}, "credit_multiplier": 1, "authorization": resource.Object{"user_ids": []string{user}, "group_ids": []string{}}}, "")
-	body := resource.Object{"model": model.String("id"), "messages": []resource.Object{{"role": "user", "content": "测试"}}}
+	catalog := must("GET", "/api/v1/models", nil, "")["models"].([]any)
+	if len(catalog) != 1 {
+		t.Fatalf("模型目录错误: %v", catalog)
+	}
+	agentModel := resource.Object(catalog[0].(map[string]any))
+	body := resource.Object{"model": agentModel.String("model"), "messages": []resource.Object{{"role": "user", "content": "测试"}}}
 	code, out, headers := call("POST", "/v1/chat/completions", body, key, "http-call-1")
 	if code != 200 {
 		t.Fatalf("模型调用: %d %v", code, out)
@@ -179,6 +187,11 @@ func TestBillingIntegration(t *testing.T) {
 	if detail.String("status") != "settled" || detail.String("amount") != "1.480000" {
 		t.Fatalf("结算错误: %v", detail)
 	}
+	var recordedModel string
+	if err := pool.QueryRow(ctx, `SELECT model_id FROM model_calls WHERE id=$1`, transaction).Scan(&recordedModel); err != nil || recordedModel != model.String("id") {
+		t.Fatalf("模型调用记录未使用主键 UUID: %s, %v", recordedModel, err)
+	}
+	body["model"] = model.String("id")
 	if code, _, _ := call("POST", "/v1/chat/completions", body, key, "http-call-1"); code != 409 || requests.Load() != 1 {
 		t.Fatalf("重复执行: %d %d", code, requests.Load())
 	}

--- a/monkeyai/backend/internal/model/postgres.go
+++ b/monkeyai/backend/internal/model/postgres.go
@@ -211,7 +211,7 @@ func (p *Postgres) ListAvailable(ctx context.Context, userID string, isAdmin boo
 	return models, nil
 }
 
-func (p *Postgres) Resolve(ctx context.Context, userID, id string) (Model, error) {
+func (p *Postgres) Resolve(ctx context.Context, userID, requestedModel string) (Model, error) {
 	item, err := scanModel(database.Reader(ctx, p.pool).QueryRow(ctx, `
 		WITH RECURSIVE user_groups(group_id) AS (
 			SELECT id FROM groups WHERE deleted_at IS NULL AND id IN(SELECT group_id FROM group_users WHERE user_id=$1 AND removed_at IS NULL)
@@ -228,7 +228,7 @@ func (p *Postgres) Resolve(ctx context.Context, userID, id string) (Model, error
 			m.created_at, m.updated_at
 		FROM models m
 		JOIN users u ON u.id = $1
-		WHERE m.id = $2 AND m.enabled AND m.deleted_at IS NULL
+		WHERE (m.id::text = $2 OR m.model_id = $2) AND m.enabled AND m.deleted_at IS NULL
 			AND (
 				(u.role = 'admin' AND m.ownership_type = 'system')
 				OR m.owner_user_id = $1
@@ -238,7 +238,9 @@ func (p *Postgres) Resolve(ctx context.Context, userID, id string) (Model, error
 						AND (rag.user_id = $1 OR rag.group_id IN (SELECT group_id FROM user_groups))
 				)
 			)
-	`, userID, id))
+		ORDER BY (m.id::text = $2) DESC, m.created_at, m.id
+		LIMIT 1
+	`, userID, requestedModel))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Model{}, ErrUnauthorized
 	}

--- a/monkeyai/backend/internal/model/postgres_test.go
+++ b/monkeyai/backend/internal/model/postgres_test.go
@@ -1,0 +1,135 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chaitin/MonkeyCode/monkeyai/backend/internal/resource"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestResolveModelName(t *testing.T) {
+	dsn := os.Getenv("MONKEYAI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("设置 MONKEYAI_TEST_DATABASE_URL 运行模型解析集成测试")
+	}
+	ctx := t.Context()
+	root, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(root.Close)
+	schema := "test_model_" + strings.ReplaceAll(resource.ID(), "-", "")
+	if _, err := root.Exec(ctx, "CREATE SCHEMA "+schema); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if _, err := root.Exec(context.Background(), "DROP SCHEMA "+schema+" CASCADE"); err != nil {
+			t.Error(err)
+		}
+	})
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.ConnConfig.RuntimeParams["search_path"] = schema
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	exec := func(query string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, query, args...); err != nil {
+			t.Fatal(err)
+		}
+	}
+	paths, err := filepath.Glob("../../migrations/*.up.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		exec(string(data))
+	}
+	owner, user, admin := resource.ID(), resource.ID(), resource.ID()
+	exec(`INSERT INTO users(id,name,email,role) VALUES($1,'所有者','owner@example.com','user'),($2,'调用者','user@example.com','user'),($3,'管理员','admin@example.com','admin')`, owner, user, admin)
+	repo := NewPostgres(pool)
+	create := func(name, ownership string) Model {
+		t.Helper()
+		item, err := repo.Create(ctx, Model{
+			OwnerUserID: owner, OwnershipType: ownership, ModelID: name, DisplayName: name,
+			Protocol: ProtocolOpenAIChat, BaseURL: "https://example.com/v1", APIKey: "test-key",
+			AdvancedConfig: AdvancedConfig{ContextWindowTokens: 32000, MaxOutputTokens: 4096}, CreditMultiplier: 1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return item
+	}
+	shared := create("provider/chat-model", "system")
+	exec(`INSERT INTO resource_access_grants(resource_type,resource_id,user_id,access_level,granted_by_user_id) VALUES('model',$1,$2,'read_only',$3)`, shared.ID, user, owner)
+	private := create("private-model", "user")
+	disabled := create("disabled-model", "system")
+	exec(`UPDATE models SET enabled=false WHERE id=$1`, disabled.ID)
+	deleted := create("deleted-model", "system")
+	exec(`UPDATE models SET deleted_at=now() WHERE id=$1`, deleted.ID)
+	uuidName := create(resource.ID(), "user")
+	create(shared.ID, "user")
+	create(shared.ModelID, "system")
+	groupModel := create("group-model", "system")
+	parent, child := resource.ID(), resource.ID()
+	exec(`INSERT INTO groups(id,name,parent_id) VALUES($1,'父组',NULL),($2,'子组',$1)`, parent, child)
+	exec(`INSERT INTO group_users(group_id,user_id,assigned_by_user_id) VALUES($1,$2,$3)`, child, user, owner)
+	exec(`INSERT INTO resource_access_grants(resource_type,resource_id,group_id,access_level,granted_by_user_id) VALUES('model',$1,$2,'read_only',$3)`, groupModel.ID, parent, owner)
+
+	for _, tc := range []struct {
+		name, user, requested, want string
+	}{
+		{"模型名", user, shared.ModelID, shared.ID},
+		{"主键", user, shared.ID, shared.ID},
+		{"主键优先", owner, shared.ID, shared.ID},
+		{"同名稳定选择", owner, shared.ModelID, shared.ID},
+		{"UUID格式模型名", owner, uuidName.ModelID, uuidName.ID},
+		{"自有模型", owner, private.ModelID, private.ID},
+		{"父组授权", user, groupModel.ModelID, groupModel.ID},
+		{"管理员系统模型", admin, shared.ModelID, shared.ID},
+		{"未授权", user, private.ModelID, ""},
+		{"管理员无权使用他人私有模型", admin, private.ModelID, ""},
+		{"已停用", admin, disabled.ModelID, ""},
+		{"已删除", admin, deleted.ModelID, ""},
+		{"不存在", user, "missing-model", ""},
+		{"空模型名", user, "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			service := NewService(repo).WithKeyAuthenticator(keyAuthenticatorStub{userID: tc.user})
+			target, err := service.Resolve(ctx, "test-key", tc.requested)
+			if tc.want == "" {
+				if !errors.Is(err, ErrUnauthorized) {
+					t.Fatalf("应拒绝调用，实际错误: %v", err)
+				}
+				return
+			}
+			if err != nil || target.ID != tc.want || target.UserID != tc.user || target.UpstreamModelID == "" || target.APIKey != "test-key" {
+				t.Fatalf("模型解析错误: %+v, %v", target, err)
+			}
+		})
+	}
+	models, err := NewService(repo).AgentModels(ctx, user, false)
+	if err != nil || len(models) != 2 {
+		t.Fatalf("下发模型目录错误: %+v, %v", models, err)
+	}
+	for _, entry := range models {
+		item, err := repo.Resolve(ctx, user, entry.Model)
+		if err != nil || item.ID != entry.ID || item.ModelID != entry.Model {
+			t.Fatalf("下发模型无法解析: %+v, %v", entry, err)
+		}
+	}
+}


### PR DESCRIPTION
Agent 模型目录下发的是 `models.model_id`，但 llmproxy 原先只按主键 UUID 查找模型，导致使用下发模型名调用失败。现在同时支持模型名和 UUID，继续按原有授权、启用和删除条件过滤，并用解析出的主键 UUID 计费和记录调用。

- 精确 UUID 匹配优先；多个可用模型同名时按创建时间、UUID 稳定选择。
- 修正 Agent API 字段说明，补充模型名、UUID、分组授权、停用和删除等数据库回归测试。
- 计费集成测试直接使用 Agent 目录下发的模型名，验证上游模型名、记录中的 UUID，以及改用 UUID 重试时的幂等行为。

验证：Go 1.27.1 下，使用隔离的 PostgreSQL 和 RustFS 环境执行 `go test ./... -count=1` 全量通过；`go vet ./...`、API YAML 与内部引用检查、迁移检查及 `git diff --check` 均通过。
