### PR TITLE
完善 MonkeyAI MCP 工具代理

### DIFF
--- a/monkeyai/README.md
+++ b/monkeyai/README.md
@@ -89,7 +89,7 @@ Agent 按资源类型读取 `/api/v1/settings`、`/api/v1/models`、`/api/v1/rul
 
 资源管理列表支持 `q`、`ownership_type`、`cursor` 和 `limit`（1—200），管理页面及关联选择器会读取全部分页。模板图标限 1 MiB 的 PNG/JPEG，由后端验证尺寸并经授权接口读取。
 
-当前工具下发声明 `capabilities: [catalog]`，包含工具目录与积分配置。本次不实现 MCP 生产调用网关、实际计费扣减或 Desktop/OhMyAgent 本地加载器；不下发不存在的执行地址。对象采用不可变 key，旧包与失败上传遗留对象保留，不在写事务中删除，以免破坏备份或正在下载的资源；清理时必须确认无数据库引用且超过备份保留窗口。
+工具下发声明 `capabilities: [catalog, invoke]`，包含工具目录、积分配置和 `mcp_gateway`（代理 URL、`streamable_http` 传输及 `mcp:invoke` 调用密钥要求）。远程工具经服务端代理调用，上游凭证留在后端；Desktop/OhMyAgent 本地加载器独立接入。对象采用不可变 key，旧包与失败上传遗留对象保留，不在写事务中删除，以免破坏备份或正在下载的资源；清理时必须确认无数据库引用且超过备份保留窗口。
 
 备份应同时保留 PostgreSQL 快照与该快照引用的 RustFS 对象。恢复时先恢复对象和数据库，再用资源摘要验证技能下载。完整部署启动前不要清空 RustFS 数据卷。
 
@@ -103,7 +103,7 @@ Agent 按资源类型读取 `/api/v1/settings`、`/api/v1/models`、`/api/v1/rul
 - 首次升级先执行 `000002_billing_create_transactions` 增量迁移；保留历史账户和流水。已有交易后 down 迁移主动拒绝，回滚应关闭新调用扣费并保留交易恢复能力。
 - 默认关闭实际扣费，仅记录调用。检查价格、额度和模型上限后，在费用设置中开启。旧计费设置写接口返回冲突提示，统一通过计费接口写入。
 - 模型需要配置有效的 `context_window_tokens` 和 `max_output_tokens`。代理以管理员确认的模型上下文上界预留、强制输出限制，使用真实 usage 结算；目前仅支持单结果同步调用，不支持 `n > 1`、`best_of > 1` 或后台异步生成。上下文上界错误、缺失用量或实际费用超出预留都会转待核查，不能按估值扣款。
-- 模型调用沿用 `/v1/chat/completions`、`/v1/responses`、`/v1/messages`；MCP 使用 `POST /mcp/connectors/{id}`，密钥作用域为 `mcp:invoke`。集中认证工具成功收费；独立认证、免认证和明确失败不收费。远程 HTTP 返回 JSON/SSE 均可解析。
+- 模型调用沿用 `/v1/chat/completions`、`/v1/responses`、`/v1/messages`；MCP 使用 `POST /mcp/connectors/{id}`，密钥作用域为 `mcp:invoke`。集中认证工具成功收费；独立认证、免认证和明确失败不收费。入口采用无状态 Streamable HTTP，支持握手、通知、工具列表和调用，返回 JSON；上游 JSON/SSE 均可解析。OAuth 调用前自动刷新，每次上游会话结束后清理。详见 [MCP 接入说明](backend/api/README.md#mcp-代理)。
 - 返回的 `X-Billing-Transaction-ID` 关联真实交易；可选 `Idempotency-Key` 重复请求返回原交易 ID 和 409，禁止再次执行；`X-Session-ID` 可选，提供时验证所属用户。
 - 周期采用上海时区；每分钟准备最多 100 个账户，读取或调用时兜底开户。额度变更不重发当期余额；周期切换在当前周期结束时生效。未消费余额不结转，跨周期调用仍结算到原账户。
 - 待结算交易按原交易 ID 自动重试，最多退避一小时；执行中断 30 分钟后转核查，不自动重放上游。管理端可填写证据和用量处理未知结果，已结算本地扣款通过关联冲正全额退款。流水禁止更新或删除。

--- a/monkeyai/admin/nginx.conf
+++ b/monkeyai/admin/nginx.conf
@@ -42,7 +42,7 @@ http {
         root /usr/share/nginx/html;
         index index.html;
 
-        location ~ ^/(?:api|oauth|v1)(?:/|$) {
+        location ~ ^/(?:api|oauth|v1|mcp)(?:/|$) {
             proxy_pass http://monkeyai_backend;
             proxy_http_version 1.1;
             proxy_set_header Host $http_host;

--- a/monkeyai/admin/vite.config.ts
+++ b/monkeyai/admin/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     proxy: {
       "/api": process.env.MONKEYAI_DEV_BACKEND_URL ?? "http://localhost:8080",
       "/oauth": process.env.MONKEYAI_DEV_BACKEND_URL ?? "http://localhost:8080",
+      "/mcp": process.env.MONKEYAI_DEV_BACKEND_URL ?? "http://localhost:8080",
     },
   },
   resolve: {

--- a/monkeyai/backend/api/README.md
+++ b/monkeyai/backend/api/README.md
@@ -84,3 +84,38 @@ Agent 模型列表包含 `ownership_type`（固定为 `system` / `user`）及 `o
 已有事务内业务审计继续与变更原子提交，并通过服务端生成的 `request_id` 关联请求；完成时补齐脱敏参数和 HTTP 结果。没有事务审计或事务已回滚时补录请求事件，批量操作保留每个目标的事件。后置补录失败会记录带请求 ID 的服务日志，不改变已返回的业务结果；此机制不能保证数据库不可用或进程在业务提交后崩溃时仍保存补录事件。
 
 请求参数采用字段白名单，密码、密钥、凭证、Header、OAuth Token、URL、内容正文及未知配置默认脱敏。JSON 捕获最多 64 KiB，超限、无效 JSON 和上传文件仅记录省略标记；失败原因只保存标准 HTTP 状态说明。来源 IP 取实际连接地址，不信任任意转发头；部署在反向代理后时显示代理地址。历史记录中未采集的 IP、请求 ID 等字段展示为空。
+
+
+## MCP 代理
+
+`GET /api/v1/connectors` 以及专家清单、资源 resolve 的连接对象包含 `capabilities: [catalog, invoke]` 和 `mcp_gateway`：
+
+```json
+{
+  "url": "https://monkeyai.example/mcp/connectors/<connector-id>",
+  "transport": "streamable_http",
+  "authentication": "api_key",
+  "required_scope": "mcp:invoke"
+}
+```
+
+客户端将每个连接注册为独立的 HTTP MCP Server，使用 `Authorization: Bearer <调用密钥>`；密钥须有 `mcp:invoke` 权限。目录使用 OAuth access token 读取，代理使用调用密钥。连接若为 `authorization_required`，需先通过现有连接认证接口完成 Header/OAuth 认证。配置中不包含上游地址、Header 或 OAuth Token。访问令牌已过期但仍有刷新令牌的 OAuth 连接继续下发目录，由代理自动刷新；缺少刷新能力时要求重新授权。
+
+握手示例：
+
+```http
+POST /mcp/connectors/<connector-id>
+Authorization: Bearer <调用密钥>
+Content-Type: application/json
+Accept: application/json, text/event-stream
+
+{"jsonrpc":"2.0","id":"init-1","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"agent","version":"1"}}}
+```
+
+随后发送无 ID 的 `notifications/initialized`，再使用 `tools/list` 和 `tools/call`。后续请求携带协商得到的 `MCP-Protocol-Version`。工具名称区分大小写，列表只返回当前用户可调用的启用工具；不接受非空分页游标。调用参数与有效工具结果保留原始数值精度、`_meta` 和 `structuredContent`。
+
+入口为无状态 Streamable HTTP：POST 返回 JSON，通知返回空的 202，GET/DELETE 返回 405；不产生下游 `Mcp-Session-Id`，不提供主动推送、resources、prompts 或 sampling/elicitation。上游支持 HTTP POST 的 JSON/SSE 响应，每次调用独立握手并在结束后发送 DELETE 清理上游会话；不支持旧版 GET SSE 传输、跨调用上游会话状态或本地 stdio 进程。非空 Origin 必须与 `MONKEYAI_PUBLIC_URL` 同源。
+
+工具调用可携带 `X-Session-ID` 关联本人工作会话，或 `Idempotency-Key` 避免重复执行；重复请求返回 409 和原 `X-Billing-Transaction-ID`。集中认证仅成功调用收费，独立认证和免认证只记录调用。JSON-RPC 错误或 `isError=true` 释放预留；超时、断流、无效结果保持未知状态供核查，不自动重放。上游 JSON/SSE 响应限制为 4 MiB，请求体限制为 1 MiB。
+
+协议错误使用 JSON-RPC 数字错误码；权限、额度等业务错误保留 HTTP 状态，并在 `error.data.code` 中提供业务错误码。上游内部错误详情不直接返回，使用 `X-Billing-Transaction-ID` 查询交易。生产 Nginx 和本地 Vite 已将 `/mcp` 转发到后端。

--- a/monkeyai/backend/api/agent.yaml
+++ b/monkeyai/backend/api/agent.yaml
@@ -498,29 +498,40 @@ paths:
         type: string
         format: uuid
       required: true
+    - in: header
+      name: MCP-Protocol-Version
+      description: 后续请求应携带握手协商的版本；未知版本返回 400。
+      schema:
+        type: string
+        enum: ['2024-11-05', '2025-03-26', '2025-06-18', '2025-11-25']
     post:
-      summary: MCP 执行网关：集中认证成功调用计费
-      responses:
-        '200':
-          description: 请求成功
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  jsonrpc:
-                    const: '2.0'
-                  id: {}
-                  result: {}
-                  error: {}
-        '400':
-          description: 参数不合法
-        '401':
-          description: 未登录
-        '403':
-          description: 权限不足
-        '409':
-          description: 修订号、幂等键或交易状态冲突
+      summary: MCP 工具代理：集中认证成功调用计费
+      description: >-
+        无状态 Streamable HTTP 入口，返回 JSON，支持上游 JSON 和 SSE 响应。
+        Bearer 长期调用密钥必须包含 mcp:invoke；OAuth access token 不可代替调用密钥。
+        initialize 协商协议版本，不支持的版本返回服务端支持的 2025-11-25。
+        工具目录仅包含当前用户可用且启用的工具；调用前刷新 OAuth 凭证。
+        通知返回空的 202，无 ID 的消息不会执行工具。请求不支持批量 JSON-RPC。
+        不创建下游 MCP 会话，不提供服务端推送、resources、prompts 或双向交互。
+        每次工具调用独立建立并清理上游会话，原始参数与有效工具结果保真传递。
+        非空 Origin 必须与服务公开地址同源。客户端应接受 application/json 和 text/event-stream。
+        X-Billing-Transaction-ID 用于查询；X-Billing-Status 为 pending 时结算等待恢复。
+        集中认证工具成功收费，独立认证、免认证、JSON-RPC 错误及 isError=true 不收费。
+        超时、断流和无效结果转入核查，不重放上游；重复幂等键返回 409 和原交易 ID。
+        业务错误使用 JSON-RPC error，data.code 保留业务错误码，data.references 保留交易引用。
+      security:
+      - InvocationKey: []
+      parameters:
+      - in: header
+        name: Idempotency-Key
+        schema:
+          type: string
+          maxLength: 128
+      - in: header
+        name: X-Session-ID
+        schema:
+          type: string
+          format: uuid
       requestBody:
         required: true
         content:
@@ -530,32 +541,95 @@ paths:
               properties:
                 jsonrpc:
                   const: '2.0'
-                id: {}
+                id:
+                  type: [string, number]
+                  description: 请求必须携带，通知省略；原值随响应返回。
                 method:
-                  enum:
-                  - initialize
-                  - notifications/initialized
-                  - ping
-                  - tools/list
-                  - tools/call
+                  type: string
+                  examples: [initialize, notifications/initialized, ping, tools/list, tools/call]
                 params:
                   type: object
-              required:
-              - jsonrpc
-              - method
-      parameters:
-      - in: header
-        name: Idempotency-Key
-        schema:
-          type: string
-      - in: header
-        name: X-Session-ID
-        schema:
-          type: string
-          format: uuid
+                  description: tools/call 使用精确工具名称 name 和对象 arguments，保留 _meta 等扩展字段；tools/list 返回完整目录，不接受非空 cursor。
+              required: [jsonrpc, method]
+      responses:
+        '200':
+          description: JSON-RPC 结果或协议错误
+          headers:
+            X-Billing-Transaction-ID:
+              schema:
+                type: string
+                format: uuid
+            X-Billing-Status:
+              schema:
+                type: string
+                enum: [pending]
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jsonrpc:
+                    const: '2.0'
+                  id:
+                    type: [string, number, 'null']
+                  result: {}
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: integer
+                      message:
+                        type: string
+                      data: {}
+                    required: [code, message]
+                required: [jsonrpc, id]
+        '202':
+          description: 已接收通知，响应体为空
+        '400':
+          description: 请求格式、参数或协议版本不合法
+        '401':
+          description: 调用密钥缺失、失效或没有 mcp:invoke 作用域
+        '402':
+          description: 积分不足
+        '403':
+          description: 请求来源、用户、会话或连接认证不允许调用
+        '404':
+          description: 连接不存在、已禁用或未获授权
+        '409':
+          description: 幂等键或交易状态冲突，不重复执行工具
+          headers:
+            X-Billing-Transaction-ID:
+              schema:
+                type: string
+                format: uuid
+        '413':
+          description: 请求体超过 1 MiB
+        '415':
+          description: 请求类型必须为 application/json
+        '502':
+          description: 上游连接或握手失败
+    get:
+      summary: 此无状态入口不提供 SSE 订阅
       security:
       - InvocationKey: []
-      description: Bearer 长期调用密钥必须包含 mcp:invoke。响应 X-Billing-Transaction-ID 用于查询。结果不确定保持冻结，不自动重放上游。
+      responses:
+        '405':
+          description: 不支持此方法，Allow 为 POST
+        '401':
+          description: 调用密钥无效
+        '403':
+          description: 请求来源不允许
+    delete:
+      summary: 此无状态入口不维护下游 MCP 会话
+      security:
+      - InvocationKey: []
+      responses:
+        '405':
+          description: 不支持此方法，Allow 为 POST
+        '401':
+          description: 调用密钥无效
+        '403':
+          description: 请求来源不允许
   /api/v1/users:
     get:
       summary: 按用户名或邮箱查找分享接收用户
@@ -2363,6 +2437,21 @@ components:
             type: string
             enum:
             - catalog
+            - invoke
+        mcp_gateway:
+          type: object
+          description: 当前连接的 MCP 工具代理配置，不含上游地址或凭证；调用前仍需完成 authorization_status 要求的认证。
+          properties:
+            url:
+              type: string
+              format: uri
+            transport:
+              const: streamable_http
+            authentication:
+              const: api_key
+            required_scope:
+              const: mcp:invoke
+          required: [url, transport, authentication, required_scope]
         tools:
           type: array
           items:
@@ -2377,6 +2466,7 @@ components:
       - name
       - authorization_status
       - capabilities
+      - mcp_gateway
       - tools
     AgentExpert:
       type: object

--- a/monkeyai/backend/internal/agentconfig/resources.go
+++ b/monkeyai/backend/internal/agentconfig/resources.go
@@ -156,12 +156,12 @@ func (r *Resources) connectorDTO(ctx context.Context, q resource.Queryer, c cata
 			}
 			valid = record != nil && *record
 
-			if valid {
+			if valid || cred.String("oauth_refresh_token") != "" {
 				status = "authorized"
 			}
 		}
 	}
-	return resource.Object{"id": o["id"], "provider_id": o["provider_id"], "provider_identifier": c.providers[o.String("provider_id")]["identifier"], "icon_path": connectorIcon(c.providers[o.String("provider_id")], o.String("id")), "name": o["name"], "authorization_mode": o["authorization_mode"], "authorization_method": o["authorization_method"], "authorization_status": status, "connection_status": o["connection_status"], "capabilities": []string{"catalog"}, "tools": safe, "tools_version": resource.Hash(safe), "tools_path": "/api/v1/connectors/" + o.String("id") + "/tools"}, nil
+	return resource.Object{"id": o["id"], "provider_id": o["provider_id"], "provider_identifier": c.providers[o.String("provider_id")]["identifier"], "icon_path": connectorIcon(c.providers[o.String("provider_id")], o.String("id")), "name": o["name"], "authorization_mode": o["authorization_mode"], "authorization_method": o["authorization_method"], "authorization_status": status, "connection_status": o["connection_status"], "capabilities": []string{"catalog", "invoke"}, "mcp_gateway": resource.Object{"url": r.mcp.PublicURL + "/mcp/connectors/" + o.String("id"), "transport": "streamable_http", "authentication": "api_key", "required_scope": "mcp:invoke"}, "tools": safe, "tools_version": resource.Hash(safe), "tools_path": "/api/v1/connectors/" + o.String("id") + "/tools"}, nil
 }
 func (r *Resources) manifest(ctx context.Context, q resource.Queryer, c catalog, expert, user string) (resource.Object, error) {
 	e := c.experts[expert]

--- a/monkeyai/backend/internal/app/billing_test.go
+++ b/monkeyai/backend/internal/app/billing_test.go
@@ -212,13 +212,17 @@ func TestBillingIntegration(t *testing.T) {
 	}
 	// MCP 通过真实鉴权、目录和工具执行入口验证成功收费、业务失败不收费。
 	must("POST", "/api/admin/v1/billing/accounts/"+user+"/adjustments", resource.Object{"delta": "100", "reason": "工具测试", "idempotency_key": "adjust-http-2"}, "")
+	var toolCalls atomic.Int64
 	mcpUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var in struct {
 			ID     int    `json:"id"`
 			Method string `json:"method"`
 			Params struct {
+				Meta      json.RawMessage `json:"_meta"`
 				Arguments struct {
-					Fail bool `json:"fail"`
+					Fail   bool        `json:"fail"`
+					Format string      `json:"format"`
+					Value  json.Number `json:"value"`
 				} `json:"arguments"`
 			} `json:"params"`
 		}
@@ -233,6 +237,24 @@ func TestBillingIntegration(t *testing.T) {
 		case "tools/list":
 			result = resource.Object{"tools": []resource.Object{{"name": "search", "inputSchema": resource.Object{"type": "object"}}}}
 		case "tools/call":
+			toolCalls.Add(1)
+			if in.Params.Arguments.Value != "" && (in.Params.Arguments.Value != "9007199254740993" || !bytes.Contains(in.Params.Meta, []byte("request-trace"))) {
+				t.Error("代理改变参数精度或丢失元数据")
+			}
+			switch in.Params.Arguments.Format {
+			case "rpc":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resource.Object{"jsonrpc": "2.0", "id": in.ID, "error": resource.Object{"code": -32602, "message": "private-upstream-error"}})
+				return
+			case "invalid":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resource.Object{"jsonrpc": "2.0", "id": in.ID, "result": resource.Object{}})
+				return
+			case "sse":
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = io.WriteString(w, "data: {\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"content\":[]}}\n\n")
+				return
+			}
 			result = resource.Object{"content": []resource.Object{{"type": "text", "text": "结果"}}, "isError": in.Params.Arguments.Fail}
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -281,10 +303,50 @@ func TestBillingIntegration(t *testing.T) {
 				t.Fatalf("MCP %s %t: %v", mode, failed, detail)
 			}
 		}
+		if mode == "centralized" {
+			gateway := "/mcp/connectors/" + connector.String("id")
+			request := resource.Object{"jsonrpc": "2.0", "id": "client-call", "method": "tools/call", "params": json.RawMessage(`{"name":"search","arguments":{"value":9007199254740993},"_meta":{"trace":"request-trace"}}`)}
+			code, out, first := call("POST", gateway, request, key, "mcp-once")
+			if code != 200 || out.String("id") != "client-call" || out["result"] == nil {
+				t.Fatalf("工具调用结果错误: %d %v", code, out)
+			}
+			count := toolCalls.Load()
+			request["params"] = json.RawMessage(`{"_meta":{"trace":"request-trace"},"arguments":{"value":9007199254740993},"name":"search"}`)
+			code, duplicateResult, duplicate := call("POST", gateway, request, key, "mcp-once")
+			if code != 409 || toolCalls.Load() != count || duplicate.Get("X-Billing-Transaction-ID") != first.Get("X-Billing-Transaction-ID") {
+				t.Fatal("幂等请求重复调用或丢失交易 ID")
+			}
+			if duplicateResult["error"].(map[string]any)["data"].(map[string]any)["code"] != "request_already_accepted" {
+				t.Fatal("JSON 字段顺序不应引起幂等冲突")
+			}
+			for _, test := range []struct{ format, status, amount string }{{"rpc", "released", "0.000000"}, {"sse", "settled", "2.500000"}, {"invalid", "unknown", "0.000000"}} {
+				request["params"] = resource.Object{"name": "search", "arguments": resource.Object{"format": test.format}}
+				code, out, headers := call("POST", gateway, request, key, "")
+				id := headers.Get("X-Billing-Transaction-ID")
+				if code != 200 || id == "" {
+					t.Fatalf("MCP 结果分类失败: %d %v", code, out)
+				}
+				detail := must("GET", "/api/admin/v1/billing/transactions/"+id, nil, "")
+				if detail.String("status") != test.status || detail.String("amount") != test.amount {
+					t.Fatalf("%s 结算错误: %v", test.format, detail)
+				}
+				encoded, _ := json.Marshal(out)
+				if strings.Contains(string(encoded), "private-upstream-error") {
+					t.Fatal("上游协议错误泄露内部详情")
+				}
+				if test.format == "invalid" && out["error"] == nil {
+					t.Fatal("无效结果被当作成功返回")
+				}
+			}
+		}
+
 	}
 	reconciliation = must("GET", "/api/admin/v1/billing/reconciliation", nil, "")
-	if len(reconciliation["differences"].([]any)) != 0 || reconciliation.Int("total") != 0 {
+	if len(reconciliation["differences"].([]any)) != 0 || reconciliation.Int("total") != 1 {
 		t.Fatalf("MCP 账目不平: %v", reconciliation)
+	}
+	if reconciliation["items"].([]any)[0].(map[string]any)["error_code"] != "mcp_invalid_result" {
+		t.Fatalf("无效结果未保留供核查: %v", reconciliation)
 	}
 	modelStats := must("GET", "/api/admin/v1/statistics/models?range=24h", nil, "")
 	if modelStats["summary"].(map[string]any)["calls"].(float64) == 0 {

--- a/monkeyai/backend/internal/app/resources_test.go
+++ b/monkeyai/backend/internal/app/resources_test.go
@@ -131,6 +131,10 @@ func TestResourceIntegration(t *testing.T) {
 		}
 		users = append(users, id)
 	}
+	invokeKeys := map[string]string{}
+	for _, name := range []string{"a", "b"} {
+		invokeKeys[name] = must("POST", "/api/v1/api-keys", resource.Object{"name": "MCP 测试", "scopes": []string{"mcp:invoke"}}, name, "").String("api_key")
+	}
 	t.Run("用户模型与批量分享", func(t *testing.T) { testModelSharing(t, pool, handler, users) })
 	t.Run("独立资源目录", func(t *testing.T) {
 		for _, kind := range []string{"settings", "models", "rules", "skills", "experts", "connectors"} {
@@ -429,6 +433,71 @@ DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION reject_test_tag();`)
 	if code, _, _ := call("GET", "/api/v1/connectors/"+conn.String("id")+"/tools", nil, "b", ""); code != 404 {
 		t.Fatalf("工具目录越权: %d", code)
 	}
+	t.Run("MCP 协议与资源授权", func(t *testing.T) {
+		gateway := "/mcp/connectors/" + conn.String("id")
+		for _, version := range []string{"2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25", "2099-01-01"} {
+			out := must("POST", gateway, resource.Object{"jsonrpc": "2.0", "id": "init", "method": "initialize", "params": resource.Object{"protocolVersion": version}}, invokeKeys["a"], "")
+			want := version
+			if version == "2099-01-01" {
+				want = "2025-11-25"
+			}
+			if out.String("id") != "init" || out["result"].(map[string]any)["protocolVersion"] != want {
+				t.Fatalf("版本协商错误: %v", out)
+			}
+		}
+		for _, method := range []string{"notifications/initialized", "notifications/cancelled", "tools/call"} {
+			code, out, h := call("POST", gateway, resource.Object{"jsonrpc": "2.0", "method": method}, invokeKeys["a"], "")
+			if code != 202 || len(out) != 0 || h.Get("X-Billing-Transaction-ID") != "" {
+				t.Fatalf("通知不应执行或返回响应: %d %v", code, out)
+			}
+		}
+		in := resource.Object{"jsonrpc": "2.0", "id": "list", "method": "tools/list"}
+		for _, test := range []struct {
+			token  string
+			status int
+		}{{"a", 401}, {invokeKeys["b"], 404}, {"", 401}} {
+			if code, _, _ := call("POST", gateway, in, test.token, ""); code != test.status {
+				t.Fatalf("身份或资源授权失效: %d", code)
+			}
+		}
+		modelKey := must("POST", "/api/v1/api-keys", resource.Object{"name": "模型专用", "scopes": []string{"model:invoke"}}, "a", "").String("api_key")
+		if code, _, _ := call("POST", gateway, in, modelKey, ""); code != 401 {
+			t.Fatal("模型密钥越权调用 MCP")
+		}
+		out := must("POST", gateway, in, invokeKeys["a"], "")
+		if len(out["result"].(map[string]any)["tools"].([]any)) != 1 {
+			t.Fatalf("代理目录缺失: %v", out)
+		}
+		must("PATCH", "/api/admin/v1/connectors/"+conn.String("id")+"/tools/"+tool.String("id"), resource.Object{"enabled": false, "credits_per_call": "0"}, "", "")
+		out = must("POST", gateway, in, invokeKeys["a"], "")
+		if len(out["result"].(map[string]any)["tools"].([]any)) != 0 {
+			t.Fatal("禁用工具仍被暴露")
+		}
+		out = must("POST", gateway, resource.Object{"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": resource.Object{"name": "ExactTool"}}, invokeKeys["a"], "")
+		if out["error"].(map[string]any)["code"] != float64(-32602) {
+			t.Fatal("禁用工具仍可执行")
+		}
+		must("PATCH", "/api/admin/v1/connectors/"+conn.String("id")+"/tools/"+tool.String("id"), resource.Object{"enabled": true, "credits_per_call": "0"}, "", "")
+		out = must("POST", gateway, resource.Object{"jsonrpc": "2.0", "id": "unknown", "method": "resources/list"}, invokeKeys["a"], "")
+		if out["error"].(map[string]any)["code"] != float64(-32601) {
+			t.Fatal("未支持的方法应返回协议错误")
+		}
+		catalog := must("GET", "/api/v1/connectors", nil, "a", "")
+		entry := catalog["connectors"].([]any)[0].(map[string]any)
+		proxy := entry["mcp_gateway"].(map[string]any)
+		if proxy["url"] != "http://localhost:8080"+gateway || proxy["transport"] != "streamable_http" || proxy["required_scope"] != "mcp:invoke" || len(entry["capabilities"].([]any)) != 2 {
+			t.Fatalf("未下发可执行代理: %v", entry)
+		}
+		if _, err := pool.Exec(ctx, `UPDATE connector_providers SET enabled=false WHERE id=$1`, provider.String("id")); err != nil {
+			t.Fatal(err)
+		}
+		if code, _, _ := call("POST", gateway, in, invokeKeys["a"], ""); code != 404 {
+			t.Fatal("禁用模板仍可代理")
+		}
+		if _, err := pool.Exec(ctx, `UPDATE connector_providers SET enabled=true WHERE id=$1`, provider.String("id")); err != nil {
+			t.Fatal(err)
+		}
+	})
 	allGroup := must("POST", "/api/admin/v1/groups", resource.Object{"name": "资源测试组", "parent_id": nil}, "", "")
 	must("PUT", "/api/admin/v1/groups/"+allGroup.String("id")+"/members", resource.Object{"member_ids": users}, "", "")
 	must("POST", "/api/admin/v1/rules", resource.Object{"name": "强制规则", "content": "强制", "grants": []resource.Object{{"group_id": allGroup.String("id"), "usage_requirement": "required"}}}, "", "")
@@ -450,11 +519,11 @@ DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION reject_test_tag();`)
 		w.Header().Set("Content-Type", "application/json")
 		switch in.Method {
 		case "initialize":
-			_ = json.NewEncoder(w).Encode(resource.Object{"id": in.ID, "result": resource.Object{"protocolVersion": "2025-03-26"}})
+			_ = json.NewEncoder(w).Encode(resource.Object{"jsonrpc": "2.0", "id": in.ID, "result": resource.Object{"protocolVersion": "2025-03-26"}})
 		case "notifications/initialized":
 			w.WriteHeader(202)
 		case "tools/list":
-			_ = json.NewEncoder(w).Encode(resource.Object{"id": in.ID, "result": resource.Object{"tools": []resource.Object{{"name": r.Header.Get("X-Account"), "description": "Account tool", "inputSchema": resource.Object{"type": "object"}}}}})
+			_ = json.NewEncoder(w).Encode(resource.Object{"jsonrpc": "2.0", "id": in.ID, "result": resource.Object{"tools": []resource.Object{{"name": r.Header.Get("X-Account"), "description": "Account tool", "inputSchema": resource.Object{"type": "object"}}}}})
 		}
 	}))
 	defer independent.Close()
@@ -481,7 +550,18 @@ DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION reject_test_tag();`)
 			t.Fatal("用户工具目录泄露认证元信息或缺失")
 		}
 	}
+	for _, name := range []string{"a", "b"} {
+		out := must("POST", "/mcp/connectors/"+c2.String("id"), resource.Object{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}, invokeKeys[name], "")
+		tools := out["result"].(map[string]any)["tools"].([]any)
+		if len(tools) != 1 || tools[0].(map[string]any)["name"] != "Tool-"+name {
+			t.Fatal("独立凭证代理目录串用")
+		}
+	}
 	must("DELETE", "/api/v1/connectors/"+c2.String("id")+"/credential", nil, "a", "")
+	if code, _, _ := call("POST", "/mcp/connectors/"+c2.String("id"), resource.Object{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}, invokeKeys["a"], ""); code != 403 {
+		t.Fatal("撤销凭证后代理仍可使用")
+	}
+
 	directory := must("GET", "/api/v1/connectors/"+c2.String("id")+"/tools", nil, "a", "")
 	if len(directory["items"].([]any)) != 0 {
 		t.Fatal("撤销凭证后工具仍可用")
@@ -512,6 +592,28 @@ DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION reject_test_tag();`)
 	status := must("GET", "/api/admin/v1/connector-authorizations/"+auth.String("id"), nil, "", "")
 	if status.String("status") != "authorized" {
 		t.Fatal("OAuth 状态未落库")
+	}
+	must("POST", "/api/admin/v1/connectors/"+c3.String("id")+"/test", nil, "", "")
+	oauthTools := must("GET", "/api/admin/v1/connectors/"+c3.String("id")+"/tools", nil, "", "")["items"].([]any)
+	oauthTool := resource.Object(oauthTools[0].(map[string]any))
+	must("PATCH", "/api/admin/v1/connectors/"+c3.String("id")+"/tools/"+oauthTool.String("id"), resource.Object{"enabled": true, "credits_per_call": "0"}, "", "")
+	if _, err := pool.Exec(ctx, `UPDATE connector_credentials SET oauth_access_token='expired-token',oauth_expires_at=now()-interval '1 minute' WHERE connector_id=$1`, c3.String("id")); err != nil {
+		t.Fatal(err)
+	}
+	refreshable := must("GET", "/api/v1/connectors", nil, "a", "")
+	for _, raw := range refreshable["connectors"].([]any) {
+		entry := resource.Object(raw.(map[string]any))
+		if entry.String("id") == c3.String("id") && (entry.String("authorization_status") != "authorized" || len(entry["tools"].([]any)) != 1) {
+			t.Fatal("可自动刷新的 OAuth 凭证不应要求手工重新授权")
+		}
+	}
+	refreshed := must("POST", "/mcp/connectors/"+c3.String("id"), resource.Object{"jsonrpc": "2.0", "id": "oauth", "method": "tools/list"}, invokeKeys["a"], "")
+	if refreshed["result"] == nil {
+		t.Fatalf("OAuth 自动刷新失败: %v", refreshed)
+	}
+	var fresh bool
+	if err := pool.QueryRow(ctx, `SELECT oauth_access_token='private-oauth-token' AND oauth_expires_at>now() FROM connector_credentials WHERE connector_id=$1`, c3.String("id")).Scan(&fresh); err != nil || !fresh {
+		t.Fatalf("刷新凭证未持久化: %v", err)
 	}
 	snap := must("GET", "/api/v1/connectors", nil, "a", "")
 	encoded, _ := json.Marshal(snap)

--- a/monkeyai/backend/internal/mcp/gateway.go
+++ b/monkeyai/backend/internal/mcp/gateway.go
@@ -1,15 +1,19 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"mime"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/chaitin/MonkeyCode/monkeyai/backend/internal/resource"
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 )
 
 type KeyAuthenticator interface {
@@ -27,152 +31,210 @@ type InvocationBilling interface {
 }
 
 func (s *Service) RegisterGateway(router chi.Router, keys KeyAuthenticator, billing InvocationBilling) {
-	router.Post("/mcp/connectors/{id}", func(w http.ResponseWriter, r *http.Request) {
-		token, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
-		if !ok {
-			resource.Fail(w, &resource.Error{Status: 401, Code: "invalid_key", Message: "缺少 MCP 调用密钥"})
+	router.HandleFunc("/mcp/connectors/{id}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		if origin := r.Header.Get("Origin"); origin != "" {
+			provided, err := url.Parse(origin)
+			public, _ := url.Parse(s.PublicURL)
+			if err != nil || public == nil || provided.User != nil || provided.Path != "" || provided.RawQuery != "" || provided.Fragment != "" || !strings.EqualFold(provided.Scheme, public.Scheme) || !strings.EqualFold(provided.Host, public.Host) {
+				rpcFail(w, nil, &resource.Error{Status: 403, Code: "invalid_origin", Message: "请求来源不被允许"})
+				return
+			}
+		}
+		scheme, token, ok := strings.Cut(r.Header.Get("Authorization"), " ")
+		if !ok || !strings.EqualFold(scheme, "Bearer") || strings.TrimSpace(token) == "" {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="mcp"`)
+			rpcFail(w, nil, &resource.Error{Status: 401, Code: "invalid_key", Message: "缺少 MCP 调用密钥"})
 			return
 		}
 		user, err := keys.Authenticate(r.Context(), strings.TrimSpace(token), "mcp:invoke")
 		if err != nil {
-			resource.Fail(w, &resource.Error{Status: 401, Code: "invalid_key", Message: "MCP 调用密钥无效或权限不足"})
+			w.Header().Set("WWW-Authenticate", `Bearer realm="mcp", error="invalid_token"`)
+			rpcFail(w, nil, &resource.Error{Status: 401, Code: "invalid_key", Message: "MCP 调用密钥无效或权限不足"})
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", "POST")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		media, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil || media != "application/json" {
+			rpcFail(w, nil, &resource.Error{Status: 415, Code: "invalid_content_type", Message: "请求须使用 application/json"})
+			return
+		}
+		if version := r.Header.Get("MCP-Protocol-Version"); version != "" && !supportedVersion(version) {
+			rpcFail(w, nil, &resource.Error{Status: 400, Code: "unsupported_protocol", Message: "MCP 协议版本不支持"})
+			return
+		}
+		in, ok := readRequest(w, r)
+		if !ok {
 			return
 		}
 		connector, err := s.Connector(r.Context(), s.Store.Pool, chi.URLParam(r, "id"), user, false)
 		if err != nil {
-			resource.Fail(w, err)
+			rpcFail(w, in.ID, err)
 			return
 		}
-		var in struct {
-			Version string          `json:"jsonrpc"`
-			ID      json.RawMessage `json:"id"`
-			Method  string          `json:"method"`
-			Params  json.RawMessage `json:"params"`
-		}
-		if err = resource.Decode(w, r, &in); err != nil {
-			resource.Fail(w, err)
+		if strings.HasPrefix(in.Method, "notifications/") {
+			if len(in.ID) != 0 {
+				rpcReply(w, 400, in.ID, nil, &rpcError{Code: -32600, Message: "通知不能包含请求 ID"})
+				return
+			}
+			w.WriteHeader(http.StatusAccepted)
 			return
 		}
-		if in.Version != "2.0" {
-			resource.Fail(w, resource.Invalid("JSON-RPC 版本无效"))
+		if len(in.ID) == 0 {
+			// 无 ID 的消息不执行工具，也不产生 JSON-RPC 响应。
+			w.WriteHeader(http.StatusAccepted)
 			return
-		}
-		respond := func(result any) {
-			resource.JSON(w, 200, map[string]any{"jsonrpc": "2.0", "id": in.ID, "result": result})
 		}
 		switch in.Method {
 		case "initialize":
-			respond(map[string]any{"protocolVersion": "2025-03-26", "capabilities": map[string]any{"tools": map[string]any{}}, "serverInfo": map[string]string{"name": "MonkeyAI", "version": "1"}})
-			return
-		case "notifications/initialized":
-			w.WriteHeader(202)
-			return
+			var params struct {
+				Version string `json:"protocolVersion"`
+			}
+			if json.Unmarshal(in.Params, &params) != nil || params.Version == "" {
+				rpcReply(w, 200, in.ID, nil, &rpcError{Code: -32602, Message: "缺少 MCP 协议版本"})
+				return
+			}
+			if !supportedVersion(params.Version) {
+				params.Version = protocolVersion
+			}
+			rpcReply(w, 200, in.ID, resource.Object{"protocolVersion": params.Version, "capabilities": resource.Object{"tools": resource.Object{}}, "serverInfo": resource.Object{"name": "MonkeyAI", "version": "1"}}, nil)
 		case "ping":
-			respond(map[string]any{})
-			return
+			rpcReply(w, 200, in.ID, resource.Object{}, nil)
+		case "tools/list", "tools/call":
+			s.invoke(w, r, in, connector, user, billing)
+		default:
+			rpcReply(w, 200, in.ID, nil, &rpcError{Code: -32601, Message: "不支持此方法"})
 		}
-		tools, err := s.Tools(r.Context(), s.Store.Pool, connector, user, false)
-		if err != nil {
-			resource.Fail(w, err)
-			return
-		}
-		if in.Method == "tools/list" {
-			out := []map[string]any{}
-			for _, tool := range tools {
-				out = append(out, map[string]any{"name": tool["name"], "description": tool["description"], "inputSchema": tool["input_schema"]})
+	})
+}
+
+func (s *Service) invoke(w http.ResponseWriter, r *http.Request, in request, connector resource.Object, user string, billing InvocationBilling) {
+	credential, err := s.Credential(r.Context(), s.Store.Pool, connector, user)
+	if errors.Is(err, pgx.ErrNoRows) {
+		err = &resource.Error{Status: 403, Code: "authorization_required", Message: "请先完成连接认证"}
+	}
+	if err != nil {
+		rpcFail(w, in.ID, err)
+		return
+	}
+	headers := map[string]string{}
+	if credential != nil {
+		if credential.String("method") == "oauth" {
+			credential, err = s.refresh(r.Context(), connector, credential)
+			if err != nil {
+				rpcFail(w, in.ID, &resource.Error{Status: 403, Code: "authorization_required", Message: "OAuth 已失效，请重新授权"})
+				return
 			}
-			respond(map[string]any{"tools": out})
-			return
-		}
-		if in.Method != "tools/call" {
-			resource.JSON(w, 200, map[string]any{"jsonrpc": "2.0", "id": in.ID, "error": map[string]any{"code": -32601, "message": "不支持此方法"}})
-			return
-		}
-		if len(in.ID) == 0 || string(in.ID) == "null" {
-			resource.Fail(w, resource.Invalid("工具调用必须带请求 ID"))
-			return
-		}
-		var params struct {
-			Name      string         `json:"name"`
-			Arguments map[string]any `json:"arguments"`
-		}
-		if json.Unmarshal(in.Params, &params) != nil || params.Name == "" {
-			resource.Fail(w, resource.Invalid("工具参数无效"))
-			return
-		}
-		var tool resource.Object
-		for _, candidate := range tools {
-			if candidate.String("name") == params.Name {
-				tool = candidate
-				break
-			}
-		}
-		if tool == nil {
-			resource.Fail(w, resource.NotFound)
-			return
-		}
-		credential, err := s.Credential(r.Context(), s.Store.Pool, connector, user)
-		if err != nil {
-			resource.Fail(w, err)
-			return
-		}
-		headers := map[string]string{}
-		if credential != nil {
-			if connector.String("authorization_method") == "oauth" {
-				headers["Authorization"] = "Bearer " + credential.String("oauth_access_token")
-			} else {
-				b, _ := json.Marshal(credential["http_headers"])
-				if err = json.Unmarshal(b, &headers); err != nil {
-					resource.Fail(w, err)
-					return
-				}
-			}
-		}
-		remote, err := openRemote(r.Context(), connector.String("url"), headers)
-		if err != nil {
-			resource.Fail(w, &resource.Error{Status: 502, Code: "mcp_connect_failed", Message: "工具上游连接失败"})
-			return
-		}
-		defer remote.http.CloseIdleConnections()
-		id, err := billing.Begin(r.Context(), Invocation{UserID: user, ConnectorID: connector.String("id"), ToolID: tool.String("id"), SessionID: r.Header.Get("X-Session-ID"), IdempotencyKey: r.Header.Get("Idempotency-Key"), RequestHash: resource.Hash(map[string]any{"connector": connector.String("id"), "params": params})})
-		if err != nil {
-			resource.Fail(w, err)
-			return
-		}
-		if err = billing.Start(r.Context(), id); err != nil {
-			resource.Fail(w, err)
-			return
-		}
-		w.Header().Set("X-Billing-Transaction-ID", id)
-		result, callErr := remote.call(r.Context(), 2, "tools/call", params)
-		outcome := InvocationResult{Known: true, Result: "succeeded"}
-		var rpc *rpcError
-		if callErr != nil {
-			outcome.Result = "failed"
-			outcome.ErrorCode = "mcp_call_failed"
-			outcome.Known = errors.As(callErr, &rpc)
+			headers["Authorization"] = "Bearer " + credential.String("oauth_access_token")
 		} else {
-			var body struct {
-				IsError bool `json:"isError"`
-			}
-			if string(result) == "null" || json.Unmarshal(result, &body) != nil {
-				outcome.Known = false
-				outcome.Result = "failed"
-				outcome.ErrorCode = "mcp_invalid_result"
-			} else if body.IsError {
-				outcome.Result = "failed"
-				outcome.ErrorCode = "mcp_tool_error"
+			body, _ := json.Marshal(credential["http_headers"])
+			if err = json.Unmarshal(body, &headers); err != nil {
+				rpcFail(w, in.ID, err)
+				return
 			}
 		}
+	}
+	tools, err := credentialTools(r.Context(), s.Store.Pool, connector, credential, false)
+	if err != nil {
+		rpcFail(w, in.ID, err)
+		return
+	}
+	if in.Method == "tools/list" {
+		var params struct {
+			Cursor string `json:"cursor"`
+		}
+		if len(in.Params) > 0 && (json.Unmarshal(in.Params, &params) != nil || params.Cursor != "") {
+			rpcReply(w, 200, in.ID, nil, &rpcError{Code: -32602, Message: "工具目录游标无效"})
+			return
+		}
+		out := []resource.Object{}
+		for _, tool := range tools {
+			out = append(out, resource.Object{"name": tool["name"], "description": tool["description"], "inputSchema": tool["input_schema"]})
+		}
+		rpcReply(w, 200, in.ID, resource.Object{"tools": out}, nil)
+		return
+	}
+	var params map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(in.Params))
+	decoder.UseNumber()
+	err = decoder.Decode(&params)
+	name, _ := params["name"].(string)
+	arguments, hasArguments := params["arguments"]
+	_, objectArguments := arguments.(map[string]any)
+	if err != nil || name == "" || (hasArguments && !objectArguments) {
+		rpcReply(w, 200, in.ID, nil, &rpcError{Code: -32602, Message: "工具参数无效"})
+		return
+	}
+	var tool resource.Object
+	for _, candidate := range tools {
+		if candidate.String("name") == name {
+			tool = candidate
+			break
+		}
+	}
+	if tool == nil {
+		rpcReply(w, 200, in.ID, nil, &rpcError{Code: -32602, Message: "工具不存在或未启用"})
+		return
+	}
+	remote, err := openRemote(r.Context(), connector.String("url"), headers)
+	if err != nil {
+		rpcFail(w, in.ID, &resource.Error{Status: 502, Code: "mcp_connect_failed", Message: "工具上游连接失败"})
+		return
+	}
+	defer remote.close()
+	id, err := billing.Begin(r.Context(), Invocation{UserID: user, ConnectorID: connector.String("id"), ToolID: tool.String("id"), SessionID: r.Header.Get("X-Session-ID"), IdempotencyKey: r.Header.Get("Idempotency-Key"), RequestHash: resource.Hash(resource.Object{"connector": connector.String("id"), "params": params, "session_id": r.Header.Get("X-Session-ID")})})
+	if err != nil {
+		rpcFail(w, in.ID, err)
+		return
+	}
+	w.Header().Set("X-Billing-Transaction-ID", id)
+	if err = billing.Start(r.Context(), id); err != nil {
 		ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
 		defer cancel()
-		if err = billing.Finish(ctx, id, outcome); err != nil {
+		if billing.Finish(ctx, id, InvocationResult{Known: true, Result: "failed", ErrorCode: "mcp_not_started"}) != nil {
 			w.Header().Set("X-Billing-Status", "pending")
 		}
-		if callErr != nil {
-			resource.JSON(w, 200, map[string]any{"jsonrpc": "2.0", "id": in.ID, "error": map[string]any{"code": -32603, "message": "工具调用失败，可凭交易 ID 查询状态"}})
-			return
+		rpcFail(w, in.ID, err)
+		return
+	}
+	result, callErr := remote.call(r.Context(), 2, "tools/call", in.Params)
+	outcome := InvocationResult{Known: true, Result: "succeeded"}
+	var rpc *rpcError
+	if callErr != nil {
+		outcome.Result = "failed"
+		outcome.ErrorCode = "mcp_call_failed"
+		outcome.Known = errors.As(callErr, &rpc)
+	} else {
+		var body struct {
+			Content []json.RawMessage `json:"content"`
+			IsError bool              `json:"isError"`
 		}
-		respond(result)
-	})
+		if json.Unmarshal(result, &body) != nil || body.Content == nil {
+			outcome.Known = false
+			outcome.Result = "failed"
+			outcome.ErrorCode = "mcp_invalid_result"
+			callErr = errors.New("MCP 工具结果无效")
+		} else if body.IsError {
+			outcome.Result = "failed"
+			outcome.ErrorCode = "mcp_tool_error"
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
+	defer cancel()
+	if err = billing.Finish(ctx, id, outcome); err != nil {
+		w.Header().Set("X-Billing-Status", "pending")
+	}
+	if callErr != nil {
+		code := -32603
+		if rpc != nil {
+			code = rpc.Code
+		}
+		rpcReply(w, 200, in.ID, nil, &rpcError{Code: code, Message: "工具调用失败，可凭交易 ID 查询状态"})
+		return
+	}
+	rpcReply(w, 200, in.ID, result, nil)
 }

--- a/monkeyai/backend/internal/mcp/protocol.go
+++ b/monkeyai/backend/internal/mcp/protocol.go
@@ -1,0 +1,102 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"slices"
+
+	"github.com/chaitin/MonkeyCode/monkeyai/backend/internal/resource"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+const protocolVersion = "2025-11-25"
+
+func supportedVersion(version string) bool {
+	return slices.Contains([]string{"2024-11-05", "2025-03-26", "2025-06-18", protocolVersion}, version)
+}
+
+type request struct {
+	Version string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+func readRequest(w http.ResponseWriter, r *http.Request) (request, bool) {
+	var in request
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<20))
+	if err != nil {
+		status := http.StatusBadRequest
+		var limit *http.MaxBytesError
+		if errors.As(err, &limit) {
+			status = http.StatusRequestEntityTooLarge
+		}
+		rpcReply(w, status, nil, nil, &rpcError{Code: -32700, Message: "请求超限或不完整"})
+		return in, false
+	}
+	if !json.Valid(body) {
+		rpcReply(w, 400, nil, nil, &rpcError{Code: -32700, Message: "JSON 格式无效"})
+		return in, false
+	}
+	if json.Unmarshal(body, &in) != nil || in.Version != "2.0" || in.Method == "" || !validID(in.ID) {
+		rpcReply(w, 400, nil, nil, &rpcError{Code: -32600, Message: "JSON-RPC 请求无效"})
+		return in, false
+	}
+	if len(in.Params) > 0 && !bytes.HasPrefix(bytes.TrimSpace(in.Params), []byte("{")) {
+		rpcReply(w, 400, in.ID, nil, &rpcError{Code: -32602, Message: "参数必须为 JSON 对象"})
+		return in, false
+	}
+	return in, true
+}
+
+func validID(id json.RawMessage) bool {
+	if len(id) == 0 {
+		return true
+	}
+	var value any
+	decoder := json.NewDecoder(bytes.NewReader(id))
+	decoder.UseNumber()
+	if decoder.Decode(&value) != nil {
+		return false
+	}
+	switch value.(type) {
+	case string, json.Number:
+		return true
+	default:
+		return false
+	}
+}
+
+func rpcReply(w http.ResponseWriter, status int, id json.RawMessage, result any, err *rpcError) {
+	out := map[string]any{"jsonrpc": "2.0", "id": id}
+	if err != nil {
+		out["error"] = err
+	} else {
+		out["result"] = result
+	}
+	resource.JSON(w, status, out)
+}
+
+func rpcFail(w http.ResponseWriter, id json.RawMessage, err error) {
+	var failure *resource.Error
+	var postgres *pgconn.PgError
+	if !errors.As(err, &failure) {
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			failure = resource.NotFound
+		case errors.As(err, &postgres) && postgres.Code == "22P02":
+			failure = &resource.Error{Status: 400, Code: "invalid_request", Message: "资源标识无效"}
+		default:
+			failure = &resource.Error{Status: 500, Code: "mcp_internal_error", Message: "MCP 请求处理失败"}
+		}
+	}
+	if references, ok := failure.References.(map[string]string); ok && references["transaction_id"] != "" {
+		w.Header().Set("X-Billing-Transaction-ID", references["transaction_id"])
+	}
+	data, _ := json.Marshal(resource.Object{"code": failure.Code, "references": failure.References})
+	rpcReply(w, failure.Status, id, nil, &rpcError{Code: -32000, Message: failure.Message, Data: data})
+}

--- a/monkeyai/backend/internal/mcp/protocol_test.go
+++ b/monkeyai/backend/internal/mcp/protocol_test.go
@@ -1,0 +1,105 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestRPCRequests(t *testing.T) {
+	for _, test := range []struct {
+		name, body, id string
+		code, status   int
+	}{
+		{name: "字符串 ID", body: `{"jsonrpc":"2.0","id":"call-1","method":"ping"}`, id: `"call-1"`},
+		{name: "大整数 ID", body: `{"jsonrpc":"2.0","id":9007199254740993,"method":"ping"}`, id: `9007199254740993`},
+		{name: "通知", body: `{"jsonrpc":"2.0","method":"notifications/initialized"}`},
+		{name: "解析失败", body: `{`, code: -32700, status: 400},
+		{name: "连续对象", body: `{} {}`, code: -32700, status: 400},
+		{name: "批量请求", body: `[{}]`, code: -32600, status: 400},
+		{name: "空对象", body: `null`, code: -32600, status: 400},
+		{name: "版本错误", body: `{"jsonrpc":"1.0","id":1,"method":"ping"}`, code: -32600, status: 400},
+		{name: "空 ID", body: `{"jsonrpc":"2.0","id":null,"method":"ping"}`, code: -32600, status: 400},
+		{name: "对象 ID", body: `{"jsonrpc":"2.0","id":{},"method":"ping"}`, code: -32600, status: 400},
+		{name: "布尔 ID", body: `{"jsonrpc":"2.0","id":true,"method":"ping"}`, code: -32600, status: 400},
+		{name: "数组参数", body: `{"jsonrpc":"2.0","id":"a","method":"tools/call","params":[]}`, code: -32602, status: 400},
+		{name: "超限", body: strings.Repeat(" ", (1<<20)+1), code: -32700, status: 413},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			in, ok := readRequest(w, httptest.NewRequest("POST", "/mcp", strings.NewReader(test.body)))
+			if test.code == 0 {
+				if !ok || string(in.ID) != test.id {
+					t.Fatalf("请求未被保真解析: %+v %s", in, w.Body.String())
+				}
+				return
+			}
+			var out struct {
+				Version string   `json:"jsonrpc"`
+				Error   rpcError `json:"error"`
+			}
+			if ok || w.Code != test.status || json.Unmarshal(w.Body.Bytes(), &out) != nil || out.Version != "2.0" || out.Error.Code != test.code {
+				t.Fatalf("错误协议不匹配: %d %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+type gatewayKeys struct{}
+
+func (gatewayKeys) Authenticate(_ context.Context, token, scope string) (string, error) {
+	if token != "invoke-key" || scope != "mcp:invoke" {
+		return "", errors.New("调用密钥无效")
+	}
+	return "user", nil
+}
+
+func TestGatewayTransport(t *testing.T) {
+	router := chi.NewRouter()
+	(&Service{PublicURL: "https://monkeyai.example"}).RegisterGateway(router, gatewayKeys{}, nil)
+	for _, test := range []struct {
+		name, method, token, origin, media, version string
+		status                                      int
+	}{
+		{name: "匿名", method: "POST", status: 401},
+		{name: "错误密钥", method: "POST", token: "wrong", status: 401},
+		{name: "外站来源", method: "POST", token: "invoke-key", origin: "https://evil.example", status: 403},
+		{name: "来源带用户信息", method: "POST", token: "invoke-key", origin: "https://name@monkeyai.example", status: 403},
+		{name: "空来源", method: "POST", token: "invoke-key", origin: "null", status: 403},
+		{name: "不支持订阅", method: "GET", token: "invoke-key", status: 405},
+		{name: "不维护下游会话", method: "DELETE", token: "invoke-key", status: 405},
+		{name: "不支持表单", method: "POST", token: "invoke-key", media: "text/plain", status: 415},
+		{name: "不支持版本", method: "POST", token: "invoke-key", media: "application/json", version: "2099-01-01", status: 400},
+		{name: "同站请求解析", method: "POST", token: "invoke-key", origin: "https://monkeyai.example", media: "application/json", version: protocolVersion, status: 400},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r := httptest.NewRequest(test.method, "/mcp/connectors/example", strings.NewReader("{"))
+			if test.token != "" {
+				r.Header.Set("Authorization", "bearer "+test.token)
+			}
+			r.Header.Set("Origin", test.origin)
+			r.Header.Set("Content-Type", test.media)
+			r.Header.Set("MCP-Protocol-Version", test.version)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, r)
+			if w.Code != test.status {
+				t.Fatalf("状态错误: %d %s", w.Code, w.Body.String())
+			}
+			if w.Header().Get("Cache-Control") != "no-store" {
+				t.Fatal("代理响应不能缓存")
+			}
+			if w.Code == http.StatusMethodNotAllowed && w.Header().Get("Allow") != "POST" {
+				t.Fatal("缺少允许的方法")
+			}
+			if w.Code == http.StatusUnauthorized && w.Header().Get("WWW-Authenticate") == "" {
+				t.Fatal("缺少认证挑战")
+			}
+		})
+	}
+}

--- a/monkeyai/backend/internal/mcp/remote.go
+++ b/monkeyai/backend/internal/mcp/remote.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strings"
+	"time"
 )
 
 type remoteClient struct {
@@ -17,13 +19,14 @@ type remoteClient struct {
 	headers                  map[string]string
 }
 type rpcError struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
 }
 
 func (e *rpcError) Error() string { return fmt.Sprintf("MCP 调用错误 %d", e.Code) }
-func (c *remoteClient) request(ctx context.Context, body []byte) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, "POST", c.target, bytes.NewReader(body))
+func (c *remoteClient) request(ctx context.Context, method string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.target, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -38,12 +41,26 @@ func (c *remoteClient) request(ctx context.Context, body []byte) (*http.Response
 	}
 	return c.http.Do(req)
 }
+
+func (c *remoteClient) close() {
+	defer c.http.CloseIdleConnections()
+	if c.session == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	response, err := c.request(ctx, http.MethodDelete, nil)
+	if err == nil {
+		response.Body.Close()
+	}
+}
+
 func (c *remoteClient) call(ctx context.Context, id int, method string, params any) (json.RawMessage, error) {
 	body, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params})
 	if err != nil {
 		return nil, err
 	}
-	response, err := c.request(ctx, body)
+	response, err := c.request(ctx, http.MethodPost, body)
 	if err != nil {
 		return nil, err
 	}
@@ -51,87 +68,102 @@ func (c *remoteClient) call(ctx context.Context, id int, method string, params a
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return nil, fmt.Errorf("MCP 返回 HTTP %d", response.StatusCode)
 	}
-	if sid := response.Header.Get("Mcp-Session-Id"); sid != "" {
-		c.session = sid
+	if method == "initialize" {
+		c.session = response.Header.Get("Mcp-Session-Id")
+	}
+	media, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, fmt.Errorf("MCP 响应类型无效")
 	}
 	var data []byte
-	if strings.Contains(response.Header.Get("Content-Type"), "text/event-stream") {
-		scanner := bufio.NewScanner(io.LimitReader(response.Body, 4<<20))
+	switch media {
+	case "text/event-stream":
+		scanner := bufio.NewScanner(io.LimitReader(response.Body, (4<<20)+1))
 		scanner.Buffer(make([]byte, 4096), 4<<20)
 		var event strings.Builder
-		check := func() bool {
-			var candidate struct {
-				ID int `json:"id"`
-			}
-			if json.Unmarshal([]byte(event.String()), &candidate) == nil && candidate.ID == id {
-				data = []byte(event.String())
-				return true
-			}
-			event.Reset()
-			return false
-		}
 		for scanner.Scan() {
 			line := scanner.Text()
 			if after, ok := strings.CutPrefix(line, "data:"); ok {
 				event.WriteString(strings.TrimPrefix(after, " "))
 				event.WriteByte('\n')
 			}
-			if line == "" && event.Len() > 0 && check() {
+			if line != "" || event.Len() == 0 {
+				continue
+			}
+			var candidate struct {
+				ID     int    `json:"id"`
+				Method string `json:"method"`
+			}
+			if json.Unmarshal([]byte(event.String()), &candidate) == nil && candidate.ID == id && candidate.Method == "" {
+				data = []byte(event.String())
 				break
 			}
+			event.Reset()
 		}
-		if data == nil && event.Len() > 0 {
-			check()
+		if scanner.Err() != nil || data == nil {
+			return nil, fmt.Errorf("MCP 事件流超限或未返回完整响应")
 		}
-		if data == nil {
-			return nil, fmt.Errorf("MCP 事件流未返回完整响应")
-		}
-	} else {
+	case "application/json":
 		data, err = io.ReadAll(io.LimitReader(response.Body, (4<<20)+1))
 		if err != nil || len(data) > 4<<20 {
 			return nil, fmt.Errorf("MCP 响应超限或不完整")
 		}
+	default:
+		return nil, fmt.Errorf("MCP 响应类型不支持")
 	}
 	var reply struct {
-		ID     int             `json:"id"`
-		Result json.RawMessage `json:"result"`
-		Error  *rpcError       `json:"error"`
+		Version string          `json:"jsonrpc"`
+		ID      int             `json:"id"`
+		Result  json.RawMessage `json:"result"`
+		Error   json.RawMessage `json:"error"`
 	}
-	if err = json.Unmarshal(data, &reply); err != nil || reply.ID != id {
+	if err = json.Unmarshal(data, &reply); err != nil || reply.ID != id || reply.Version != "2.0" || (len(reply.Result) == 0) == (len(reply.Error) == 0) {
 		return nil, fmt.Errorf("MCP 协议响应无效")
 	}
-	if reply.Error != nil {
-		return nil, reply.Error
-	}
-	if len(reply.Result) == 0 {
-		return nil, fmt.Errorf("MCP 缺少调用结果")
+	if len(reply.Error) > 0 {
+		var failure struct {
+			Code    *int            `json:"code"`
+			Message *string         `json:"message"`
+			Data    json.RawMessage `json:"data"`
+		}
+		if json.Unmarshal(reply.Error, &failure) != nil || failure.Code == nil || failure.Message == nil {
+			return nil, fmt.Errorf("MCP 错误响应无效")
+		}
+		return nil, &rpcError{Code: *failure.Code, Message: *failure.Message, Data: failure.Data}
 	}
 	return reply.Result, nil
 }
+
 func openRemote(ctx context.Context, target string, headers map[string]string) (*remoteClient, error) {
-	c := &remoteClient{http: client(), target: target, version: "2025-03-26", headers: headers}
+	if !validURL(target) {
+		return nil, fmt.Errorf("MCP URL 无效")
+	}
+	c := &remoteClient{http: client(), target: target, version: protocolVersion, headers: headers}
+	initialized := false
+	defer func() {
+		if !initialized {
+			c.close()
+		}
+	}()
 	result, err := c.call(ctx, 1, "initialize", map[string]any{"protocolVersion": c.version, "capabilities": map[string]any{}, "clientInfo": map[string]string{"name": "MonkeyAI", "version": "1"}})
 	if err != nil {
-		c.http.CloseIdleConnections()
 		return nil, err
 	}
 	var h struct {
 		Version string `json:"protocolVersion"`
 	}
-	if json.Unmarshal(result, &h) != nil || h.Version == "" {
-		c.http.CloseIdleConnections()
-		return nil, fmt.Errorf("MCP 握手无效")
+	if json.Unmarshal(result, &h) != nil || !supportedVersion(h.Version) {
+		return nil, fmt.Errorf("MCP 握手版本不支持")
 	}
 	c.version = h.Version
-	response, err := c.request(ctx, []byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}`))
+	response, err := c.request(ctx, http.MethodPost, []byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}`))
 	if err != nil {
-		c.http.CloseIdleConnections()
 		return nil, err
 	}
 	response.Body.Close()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		c.http.CloseIdleConnections()
 		return nil, fmt.Errorf("MCP 初始化通知失败")
 	}
+	initialized = true
 	return c, nil
 }

--- a/monkeyai/backend/internal/mcp/remote_test.go
+++ b/monkeyai/backend/internal/mcp/remote_test.go
@@ -1,0 +1,111 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRemoteSession(t *testing.T) {
+	t.Setenv("MONKEYAI_MCP_ALLOWED_CIDRS", "127.0.0.0/8")
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprint(stream), func(t *testing.T) {
+			var initialized, closed atomic.Bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Authorization") != "Bearer upstream-secret" {
+					t.Error("上游凭证未注入")
+				}
+				if r.Method == "DELETE" {
+					if r.Header.Get("Mcp-Session-Id") != "upstream-session" {
+						t.Error("清理会话错误")
+					}
+					closed.Store(true)
+					w.WriteHeader(204)
+					return
+				}
+				var in request
+				if json.NewDecoder(r.Body).Decode(&in) != nil {
+					t.Error("请求无效")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				switch in.Method {
+				case "initialize":
+					w.Header().Set("Mcp-Session-Id", "upstream-session")
+					fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26"}}`)
+				case "notifications/initialized":
+					if r.Header.Get("Mcp-Session-Id") != "upstream-session" || r.Header.Get("MCP-Protocol-Version") != "2025-03-26" {
+						t.Error("未沿用握手会话和协商版本")
+					}
+					initialized.Store(true)
+					w.WriteHeader(202)
+				case "tools/call":
+					if !initialized.Load() || r.Header.Get("Mcp-Session-Id") != "upstream-session" {
+						t.Error("调用未正确初始化")
+					}
+					if !strings.Contains(string(in.Params), "9007199254740993") || !strings.Contains(string(in.Params), `"_meta"`) {
+						t.Error("参数精度或元数据丢失")
+					}
+					response := `{"jsonrpc":"2.0","id":2,"result":{"content":[],"structuredContent":{"value":9007199254740993},"_meta":{"trace":"result"}}}`
+					if stream {
+						w.Header().Set("Content-Type", "text/event-stream")
+						fmt.Fprint(w, ": heartbeat\r\n\r\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{}}\r\n\r\n")
+						fmt.Fprint(w, "event: message\r\ndata: "+strings.Replace(response, `,"result":`, ",\r\ndata: \"result\":", 1)+"\r\n\r\n")
+						w.(http.Flusher).Flush()
+						<-r.Context().Done()
+					} else {
+						fmt.Fprint(w, response)
+					}
+				}
+			}))
+			defer server.Close()
+			remote, err := openRemote(t.Context(), server.URL, map[string]string{"Authorization": "Bearer upstream-secret"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := remote.call(t.Context(), 2, "tools/call", json.RawMessage(`{"name":"search","arguments":{"value":9007199254740993},"_meta":{"trace":"request"}}`))
+			remote.close()
+			if err != nil || !strings.Contains(string(result), "9007199254740993") || !closed.Load() {
+				t.Fatalf("调用结果或会话清理无效: %s %v", result, err)
+			}
+		})
+	}
+}
+
+func TestRemoteInvalidResponses(t *testing.T) {
+	for _, test := range []struct {
+		name, media, body string
+		rpc               bool
+	}{
+		{name: "上游业务错误", media: "application/json", body: `{"jsonrpc":"2.0","id":2,"error":{"code":-32602,"message":"bad arguments"}}`, rpc: true},
+		{name: "缺少版本", media: "application/json", body: `{"id":2,"result":{}}`},
+		{name: "请求 ID 不符", media: "application/json", body: `{"jsonrpc":"2.0","id":3,"result":{}}`},
+		{name: "结果与错误共存", media: "application/json", body: `{"jsonrpc":"2.0","id":2,"result":{},"error":{"code":1,"message":"err"}}`},
+		{name: "缺少错误码", media: "application/json", body: `{"jsonrpc":"2.0","id":2,"error":{"message":"err"}}`},
+		{name: "错误值为空", media: "application/json", body: `{"jsonrpc":"2.0","id":2,"error":null}`},
+		{name: "HTML 响应", media: "text/html", body: `<html>错误</html>`},
+		{name: "截断 JSON", media: "application/json", body: `{"jsonrpc":"2.0","id":2`},
+		{name: "无事件边界", media: "text/event-stream", body: "data: {\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{}}\n"},
+		{name: "响应超限", media: "application/json", body: strings.Repeat(" ", (4<<20)+1)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", test.media)
+				fmt.Fprint(w, test.body)
+			}))
+			defer server.Close()
+			remote := &remoteClient{http: server.Client(), target: server.URL, version: protocolVersion}
+			defer remote.close()
+			_, err := remote.call(context.Background(), 2, "tools/call", map[string]any{})
+			var rpc *rpcError
+			if err == nil || errors.As(err, &rpc) != test.rpc {
+				t.Fatalf("上游错误分类不符: %v", err)
+			}
+		})
+	}
+}

--- a/monkeyai/backend/internal/mcp/service.go
+++ b/monkeyai/backend/internal/mcp/service.go
@@ -297,6 +297,10 @@ func (s *Service) Tools(ctx context.Context, q resource.Queryer, c resource.Obje
 		}
 		return nil, err
 	}
+	return credentialTools(ctx, q, c, cred, admin)
+}
+
+func credentialTools(ctx context.Context, q resource.Queryer, c, cred resource.Object, admin bool) ([]resource.Object, error) {
 	credential := ""
 	if cred != nil {
 		credential = cred.String("id")
@@ -307,7 +311,7 @@ func (s *Service) Tools(ctx context.Context, q resource.Queryer, c resource.Obje
 		}
 		current = record != nil && *record
 
-		if !current {
+		if !current && cred.String("oauth_refresh_token") == "" {
 			return []resource.Object{}, nil
 		}
 	}

--- a/monkeyai/backend/internal/mcp/transport.go
+++ b/monkeyai/backend/internal/mcp/transport.go
@@ -70,7 +70,7 @@ func discover(ctx context.Context, target string, headers map[string]string) ([]
 	if err != nil {
 		return nil, err
 	}
-	defer rpc.http.CloseIdleConnections()
+	defer rpc.close()
 	call := func(id int, method string, params any) (json.RawMessage, error) {
 		return rpc.call(ctx, id, method, params)
 	}

--- a/monkeyai/backend/internal/mcp/transport_test.go
+++ b/monkeyai/backend/internal/mcp/transport_test.go
@@ -49,7 +49,7 @@ func TestDiscoveryPagination(t *testing.T) {
 			}
 			result["tools"] = []resource.Object{{"name": name, "inputSchema": resource.Object{"type": "object"}}}
 		}
-		_ = json.NewEncoder(w).Encode(resource.Object{"id": in.ID, "result": result})
+		_ = json.NewEncoder(w).Encode(resource.Object{"jsonrpc": "2.0", "id": in.ID, "result": result})
 	}))
 	defer s.Close()
 	tools, err := discover(context.Background(), s.URL, nil)

--- a/monkeyai/design/mcp-proxy-plan.md
+++ b/monkeyai/design/mcp-proxy-plan.md
@@ -1,0 +1,18 @@
+# MCP 代理实施状态
+
+目标：补齐 MonkeyAI HTTP MCP 工具代理，使标准客户端可从资源目录取得入口，使用 `mcp:invoke` 调用密钥完成握手、工具发现和调用。
+
+- [x] 同步 main，创建 `feat-mcp-proxy` worktree，确认既有授权和计费边界。
+- [x] MCP 协议校验、版本协商、通知、上游会话清理和 OAuth 刷新。
+- [x] Agent 下发 `invoke` 能力与代理地址，接通 Nginx 和开发代理，更新接口契约。
+- [x] 协议回归、数据库/计费集成、完整 Go 检查和代理配置验证。
+
+采用无状态 Streamable HTTP 工具入口：POST 返回 JSON，解析上游 JSON/SSE；GET 和 DELETE 返回 405。不维护客户端 MCP 会话，不宣告服务端推送、resources、prompts 或双向交互能力。每次工具调用独立建立上游会话，结束后释放；未知调用结果不重放，沿用已有计费核查流程。
+
+
+验证结果（2026-09-08）：
+
+- Go 1.27.1 下 `go test ./... -count=1` 全部通过，使用独立随机 PostgreSQL schema 和专用 RustFS 测试 Bucket；`go vet ./...`、`make sqlc-check` 通过。
+- 覆盖调用密钥作用域、资源授权、模板/工具禁用、独立凭证目录隔离、凭证撤销、OAuth 到期刷新、三种认证模式计费、JSON/SSE 响应、幂等去重、无效结果保留核查及参数精度。
+- 两份 OpenAPI 的重复键与本地引用校验通过。Nginx 配置检查、容器内真实 POST 转发及 Vite 开发代理转发验证通过，认证 Header 正确保留。
+- 已完成实现与验证，进入 PR 评审交付阶段；使用 `feat-mcp-proxy` 分支，主工作树保持原状。合并与部署另行执行。


### PR DESCRIPTION
原有 MCP 调用入口未向 Agent 下发执行地址，部署入口也未转发 `/mcp`。本次补齐无状态 Streamable HTTP 工具代理，通过 `mcp:invoke` 调用密钥完成握手、工具发现和调用，并在目录中下发 `invoke` 能力与真实代理地址。

补充协议校验、版本协商、用户凭证隔离、OAuth 自动刷新及上游会话清理；保留参数精度和元数据，沿用集中认证成功计费及未知结果待核查机制。同步更新 Nginx、Vite 和 OpenAPI。当前仅支持 HTTP 工具代理，不维护跨调用上游会话，不提供旧版 GET SSE、stdio 或双向交互。

验证通过：

- `go test ./... -count=1`，包含真实 PostgreSQL/RustFS 集成测试。
- `go vet ./...`、`make sqlc-check`、两份 OpenAPI 重复键与本地引用检查。
- Nginx 配置检查、容器 POST 转发及 Vite 转发验证，认证 Header 正确保留。
- 覆盖授权/禁用/撤销、OAuth 刷新、三种认证模式计费、JSON/SSE、幂等去重、参数精度及无效结果核查。
