### PR TITLE
为 MCP 提供独立 OAuth 回调地址

### DIFF
--- a/monkeyai/admin/src/i18n/locales/en-US.ts
+++ b/monkeyai/admin/src/i18n/locales/en-US.ts
@@ -98,7 +98,10 @@ export const enUS = {
     defaultModel: "Default model",
     noDefaultModel: "User selects a model",
     saveBeforeAuthorize:
-      "Save the connection, then reopen it to authorize with OAuth.",
+      "Create the MCP to get its callback URL, then register it in your OAuth app before authorizing.",
+    callbackURL: "OAuth callback URL",
+    callbackURLDescription:
+      "Copy this URL and register it as the callback URL in your OAuth app. Each MCP has its own URL.",
   },
   app: {
     documentTitle: "MonkeyAI Admin",

--- a/monkeyai/admin/src/i18n/locales/zh-CN.ts
+++ b/monkeyai/admin/src/i18n/locales/zh-CN.ts
@@ -96,7 +96,11 @@ export const zhCN = {
     selectScope: "选择用户或分组",
     defaultModel: "默认模型",
     noDefaultModel: "由用户选择模型",
-    saveBeforeAuthorize: "保存连接后，可重新打开编辑窗口完成 OAuth 授权。",
+    saveBeforeAuthorize:
+      "创建 MCP 后将显示专属回调地址，登记到 OAuth 应用后即可授权。",
+    callbackURL: "OAuth 回调地址",
+    callbackURLDescription:
+      "复制此地址并登记为 OAuth 应用的回调地址。每个 MCP 使用独立地址。",
   },
   app: {
     documentTitle: "MonkeyAI 管理后台",

--- a/monkeyai/admin/src/lib/resources.ts
+++ b/monkeyai/admin/src/lib/resources.ts
@@ -45,6 +45,7 @@ export type ResourceRow = {
   tool_count: number
   connection_status: "connected" | "error" | "unknown"
   oauth_config: Record<string, string>
+  callback_url: string
 }
 export const base = "/api/admin/v1"
 export function selection(

--- a/monkeyai/admin/src/pages/tools-page.tsx
+++ b/monkeyai/admin/src/pages/tools-page.tsx
@@ -106,6 +106,7 @@ type McpServer = {
   revision: number
   providerId: string
   oauthConfig: Record<string, string>
+  callbackURL: string
   id: string
   name: string
   description: string
@@ -145,6 +146,7 @@ function toServer(row: ResourceRow): McpServer {
     enabled: row.enabled,
     toolCount: row.tool_count ?? 0,
     oauthConfig: row.oauth_config ?? {},
+    callbackURL: row.callback_url ?? "",
   }
 }
 
@@ -377,8 +379,10 @@ export function ToolsPage() {
           method: "PUT",
           body: JSON.stringify({ http_headers: JSON.parse(httpHeaders) }),
         })
-      form.reset()
-      handleDialogOpenChange(false)
+      if (editingServer || !saved.callback_url) {
+        form.reset()
+        handleDialogOpenChange(false)
+      }
     })
   }
   const handleDeleteServer = async () => {
@@ -662,7 +666,24 @@ export function ToolsPage() {
                       {authorizationMode !== "none" &&
                         authorizationMethod === "oauth" && (
                           <>
-                            {!editingServer && (
+                            {editingServer?.callbackURL ? (
+                              <Field>
+                                <FieldLabel htmlFor="mcp-callback-url">
+                                  {t("resources.callbackURL")}
+                                </FieldLabel>
+                                <Input
+                                  id="mcp-callback-url"
+                                  readOnly
+                                  value={editingServer.callbackURL}
+                                  onFocus={(event) =>
+                                    event.currentTarget.select()
+                                  }
+                                />
+                                <FieldDescription>
+                                  {t("resources.callbackURLDescription")}
+                                </FieldDescription>
+                              </Field>
+                            ) : (
                               <p className="text-sm text-muted-foreground">
                                 {t("resources.saveBeforeAuthorize")}
                               </p>

--- a/monkeyai/backend/api/README.md
+++ b/monkeyai/backend/api/README.md
@@ -119,3 +119,11 @@ Accept: application/json, text/event-stream
 工具调用可携带 `X-Session-ID` 关联本人工作会话，或 `Idempotency-Key` 避免重复执行；重复请求返回 409 和原 `X-Billing-Transaction-ID`。集中认证仅成功调用收费，独立认证和免认证只记录调用。JSON-RPC 错误或 `isError=true` 释放预留；超时、断流、无效结果保持未知状态供核查，不自动重放。上游 JSON/SSE 响应限制为 4 MiB，请求体限制为 1 MiB。
 
 协议错误使用 JSON-RPC 数字错误码；权限、额度等业务错误保留 HTTP 状态，并在 `error.data.code` 中提供业务错误码。上游内部错误详情不直接返回，使用 `X-Billing-Transaction-ID` 查询交易。生产 Nginx 和本地 Vite 已将 `/mcp` 转发到后端。
+
+## MCP OAuth 回调
+
+OAuth MCP 创建、详情和管理列表响应提供 `callback_url`，格式为 `{MONKEYAI_PUBLIC_URL}/oauth/connectors/{id}/callback`，其中 `id` 为 Connector 实例 ID。非 OAuth 连接返回空字符串。创建后将此完整地址登记到第三方 OAuth 应用；同一模板下的不同 MCP 实例也使用各自的地址。
+
+`POST /api/admin/v1/connectors/{id}/oauth/authorizations`（集中认证）或 `POST /api/v1/connectors/{id}/oauth/authorizations`（独立认证）生成带 state 和 PKCE 的授权 URL，`redirect_uri` 与 `callback_url` 一致。浏览器回调无需登录凭据，服务端核验路径 id、state、事务有效期、发起人权限和配置版本，单次消费后交换 Token，并按集中或独立认证上下文保存。成功页面提示返回 MonkeyAI，发起端通过授权事务状态接口查询结果。
+
+原有 OAuth 应用需将统一的 `/oauth/connectors/callback` 更新为各 MCP 的专属地址，再重新发起授权。

--- a/monkeyai/backend/api/admin.yaml
+++ b/monkeyai/backend/api/admin.yaml
@@ -5,6 +5,48 @@ info:
 security:
   - AdminSession: []
 paths:
+  /oauth/connectors/{id}/callback:
+    get:
+      summary: 处理指定 MCP 的 OAuth 回调
+      description: 校验 MCP id 与 state 绑定、有效期及配置版本，单次消费授权事务并在服务端交换和保存 Token。无需浏览器会话或 Agent Token。
+      security: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: state
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: code
+        in: query
+        description: 授权成功时返回的授权码。
+        schema:
+          type: string
+      - name: error
+        in: query
+        description: 授权拒绝或取消时返回的错误码。
+        schema:
+          type: string
+      responses:
+        '200':
+          description: 凭证已保存，浏览器显示授权成功页面。
+          content:
+            text/html:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/ResourceError400'
+        '409':
+          $ref: '#/components/responses/ResourceError409'
+        '500':
+          $ref: '#/components/responses/ResourceError500'
+        '502':
+          $ref: '#/components/responses/ResourceError502'
   /api/auth/v1/methods:
     get:
       summary: 读取公开登录方式开关
@@ -6119,6 +6161,10 @@ components:
           - 'null'
         oauth_config:
           $ref: '#/components/schemas/OAuthConnectionConfig'
+        callback_url:
+          type: string
+          readOnly: true
+          description: OAuth MCP 的专属完整回调地址，格式为 {MONKEYAI_PUBLIC_URL}/oauth/connectors/{id}/callback；非 OAuth 连接为空字符串。
         config_revision:
           type: integer
         credential_configured:
@@ -6132,6 +6178,7 @@ components:
       - name
       - revision
       - grants
+      - callback_url
     ConnectorInput:
       type: object
       properties:

--- a/monkeyai/backend/api/agent.yaml
+++ b/monkeyai/backend/api/agent.yaml
@@ -5,6 +5,48 @@ info:
 security:
   - OAuthAccessToken: []
 paths:
+  /oauth/connectors/{id}/callback:
+    get:
+      summary: 处理指定 MCP 的 OAuth 回调
+      description: 校验 MCP id 与 state 绑定、有效期及配置版本，单次消费授权事务并在服务端交换和保存 Token。无需浏览器会话或 Agent Token。
+      security: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: state
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: code
+        in: query
+        description: 授权成功时返回的授权码。
+        schema:
+          type: string
+      - name: error
+        in: query
+        description: 授权拒绝或取消时返回的错误码。
+        schema:
+          type: string
+      responses:
+        '200':
+          description: 凭证已保存，浏览器显示授权成功页面。
+          content:
+            text/html:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/ResourceError400'
+        '409':
+          $ref: '#/components/responses/ResourceError409'
+        '500':
+          $ref: '#/components/responses/ResourceError500'
+        '502':
+          $ref: '#/components/responses/ResourceError502'
   /api/auth/v1/methods:
     get:
       summary: 读取公开登录方式开关
@@ -3913,6 +3955,10 @@ components:
           - 'null'
         oauth_config:
           $ref: '#/components/schemas/OAuthConnectionConfig'
+        callback_url:
+          type: string
+          readOnly: true
+          description: OAuth MCP 的专属完整回调地址，格式为 {MONKEYAI_PUBLIC_URL}/oauth/connectors/{id}/callback；非 OAuth 连接为空字符串。
         config_revision:
           type: integer
         credential_configured:
@@ -3926,6 +3972,7 @@ components:
       - name
       - revision
       - grants
+      - callback_url
     ConnectorInput:
       type: object
       properties:

--- a/monkeyai/backend/internal/app/app.go
+++ b/monkeyai/backend/internal/app/app.go
@@ -160,7 +160,7 @@ func newApplicationHandler(ctx context.Context, logger *slog.Logger, pool *pgxpo
 	modelProxy.Register(router)
 	connectors.RegisterGateway(router, keys, toolBilling{service: charges})
 	router.Get("/.well-known/oauth-authorization-server", identities.OAuthMetadata)
-	router.Get("/oauth/connectors/callback", connectors.Callback)
+	router.Get("/oauth/connectors/{id}/callback", connectors.Callback)
 	router.Mount("/oauth", identities.OAuthRouter())
 	auth := audits.Middleware(func(r *http.Request) audit.Actor {
 		switch r.URL.Path {

--- a/monkeyai/backend/internal/app/resources_test.go
+++ b/monkeyai/backend/internal/app/resources_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -586,12 +587,16 @@ DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION reject_test_tag();`)
 	if len(directory["items"].([]any)) != 0 {
 		t.Fatal("撤销凭证后工具仍可用")
 	}
-	// OAuth 回调绑定 state/PKCE，只能消费一次，Token 只存服务端。
+	// OAuth 回调绑定 MCP id、state 和 PKCE，只能消费一次，Token 只存服务端。
+	var redirect, challenge string
 	oauthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
-		if r.Form.Get("code_verifier") == "" && r.Form.Get("grant_type") == "authorization_code" {
-			http.Error(w, "missing pkce", 400)
-			return
+		if r.Form.Get("grant_type") == "authorization_code" {
+			digest := sha256.Sum256([]byte(r.Form.Get("code_verifier")))
+			if r.Form.Get("redirect_uri") != redirect || base64.RawURLEncoding.EncodeToString(digest[:]) != challenge || r.Form.Get("client_secret") != "private-client-secret" {
+				http.Error(w, "回调地址、PKCE 或客户端凭据不匹配", 400)
+				return
+			}
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"access_token":"private-oauth-token","refresh_token":"private-refresh-token","token_type":"Bearer","expires_in":3600}`)
@@ -599,13 +604,41 @@ DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION reject_test_tag();`)
 	defer oauthServer.Close()
 	p3 := must("POST", "/api/admin/v1/connector-providers", resource.Object{"name": "OAuth MCP", "url": upstream.URL, "authorization_mode": "centralized", "authorization_method": "oauth", "oauth_config": resource.Object{"authorization_url": oauthServer.URL + "/authorize", "token_url": oauthServer.URL + "/token", "client_id": "test-client"}, "oauth_client_secret": "private-client-secret"}, "", "")
 	c3 := must("POST", "/api/admin/v1/connectors", resource.Object{"name": "OAuth 连接", "provider_id": p3.String("id"), "grants": grantA}, "", "")
+	redirect = "http://localhost:8080/oauth/connectors/" + c3.String("id") + "/callback"
+	if c3.String("callback_url") != redirect {
+		t.Fatalf("创建 MCP 未返回专属回调地址：%v", c3)
+	}
+	detail := must("GET", "/api/admin/v1/connectors/"+c3.String("id"), nil, "", "")
+	if detail.String("callback_url") != redirect {
+		t.Fatal("MCP 详情回调地址与创建响应不一致")
+	}
+	other := must("POST", "/api/admin/v1/connectors", resource.Object{"name": "另一个 OAuth 连接", "provider_id": p3.String("id")}, "", "")
+	if other.String("callback_url") == redirect || other.String("callback_url") == "" {
+		t.Fatal("同一模板下的 MCP 未区分回调地址")
+	}
 	auth := must("POST", "/api/admin/v1/connectors/"+c3.String("id")+"/oauth/authorizations", nil, "", "")
 	target, err := url.Parse(auth.String("authorization_url"))
-	if err != nil || target.Query().Get("code_challenge") == "" {
-		t.Fatal("未生成 PKCE")
+	if err != nil || target.Query().Get("code_challenge") == "" || target.Query().Get("redirect_uri") != redirect {
+		t.Fatal("授权 URL 未绑定回调地址或 PKCE")
 	}
-	callback := "/oauth/connectors/callback?state=" + url.QueryEscape(target.Query().Get("state")) + "&code=test-code"
-	must("GET", callback, nil, "", "")
+	challenge = target.Query().Get("code_challenge")
+	query := "?state=" + url.QueryEscape(target.Query().Get("state")) + "&code=test-code"
+	for _, path := range []string{other.String("callback_url") + query, redirect + "?code=test-code", redirect + "?state=invalid&code=test-code"} {
+		if code, _, _ := call("GET", path, nil, "", ""); code != 400 {
+			t.Fatalf("无效回调未被拒绝：%s = %d", path, code)
+		}
+	}
+	if status := must("GET", "/api/admin/v1/connector-authorizations/"+auth.String("id"), nil, "", ""); status.String("status") != "pending" {
+		t.Fatal("错误 MCP id 消费了其他 MCP 的授权事务")
+	}
+	callback := redirect + query
+	adminCookie := cookie
+	cookie = nil
+	code, _, headers := call("GET", callback, nil, "", "")
+	cookie = adminCookie
+	if code != 200 || headers.Get("Cache-Control") != "no-store" || !strings.HasPrefix(headers.Get("Content-Type"), "text/html") {
+		t.Fatalf("公开回调未成功返回授权页面：%d %v", code, headers)
+	}
 	if code, _, _ := call("GET", callback, nil, "", ""); code != 400 {
 		t.Fatalf("OAuth callback 可重放: %d", code)
 	}
@@ -613,6 +646,75 @@ DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION reject_test_tag();`)
 	if status.String("status") != "authorized" {
 		t.Fatal("OAuth 状态未落库")
 	}
+	for _, scenario := range []string{"取消", "过期", "配置变更", "交换失败"} {
+		t.Run("OAuth 回调"+scenario, func(t *testing.T) {
+			auth := must("POST", "/api/admin/v1/connectors/"+other.String("id")+"/oauth/authorizations", nil, "", "")
+			target, err := url.Parse(auth.String("authorization_url"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := other.String("callback_url") + "?state=" + url.QueryEscape(target.Query().Get("state")) + "&code=test-code"
+			wantCode, wantStatus := 400, "error"
+			switch scenario {
+			case "取消":
+				path += "&error=access_denied"
+			case "过期":
+				_, err = pool.Exec(ctx, "UPDATE connector_oauth_requests SET expires_at=now()-interval '1 minute' WHERE id=$1", auth.String("id"))
+				wantStatus = "expired"
+			case "配置变更":
+				_, err = pool.Exec(ctx, "UPDATE connectors SET config_revision=config_revision+1 WHERE id=$1", other.String("id"))
+			case "交换失败":
+				wantCode = 502
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if code, _, _ := call("GET", path, nil, "", ""); code != wantCode {
+				t.Fatalf("回调状态码 = %d，预期 %d", code, wantCode)
+			}
+			status := must("GET", "/api/admin/v1/connector-authorizations/"+auth.String("id"), nil, "", "")
+			if status.String("status") != wantStatus {
+				t.Fatalf("授权状态 = %v，预期 %s", status, wantStatus)
+			}
+			var count int
+			if err := pool.QueryRow(ctx, "SELECT count(*) FROM connector_credentials WHERE connector_id=$1", other.String("id")).Scan(&count); err != nil || count != 0 {
+				t.Fatalf("失败回调保存了凭证：%d %v", count, err)
+			}
+		})
+	}
+	t.Run("个人 MCP OAuth 回调", func(t *testing.T) {
+		provider := must("POST", "/api/v1/connector-providers", resource.Object{"name": "个人 OAuth MCP", "url": upstream.URL, "authorization_mode": "independent", "authorization_method": "oauth", "oauth_config": p3["oauth_config"], "oauth_client_secret": "private-client-secret"}, "a", "")
+		connector := must("POST", "/api/v1/connectors", resource.Object{"name": "个人 OAuth 连接", "provider_id": provider.String("id")}, "a", "")
+		redirect = "http://localhost:8080/oauth/connectors/" + connector.String("id") + "/callback"
+		if connector.String("callback_url") != redirect {
+			t.Fatal("个人 MCP 创建未返回专属回调地址")
+		}
+		detail := must("GET", "/api/v1/connectors/"+connector.String("id"), nil, "a", "")
+		if detail.String("callback_url") != redirect {
+			t.Fatal("个人 MCP 详情回调地址错误")
+		}
+		auth := must("POST", "/api/v1/connectors/"+connector.String("id")+"/oauth/authorizations", nil, "a", "")
+		target, err := url.Parse(auth.String("authorization_url"))
+		if err != nil || target.Query().Get("redirect_uri") != redirect {
+			t.Fatal("个人 MCP 授权 URL 未绑定回调地址")
+		}
+		challenge = target.Query().Get("code_challenge")
+		adminCookie := cookie
+		cookie = nil
+		code, _, _ := call("GET", redirect+"?state="+url.QueryEscape(target.Query().Get("state"))+"&code=test-code", nil, "", "")
+		cookie = adminCookie
+		if code != 200 {
+			t.Fatalf("个人 MCP 公开回调失败：%d", code)
+		}
+		status := must("GET", "/api/v1/connector-authorizations/"+auth.String("id"), nil, "a", "")
+		if status.String("status") != "authorized" {
+			t.Fatal("个人 MCP OAuth 状态未落库")
+		}
+		var owner string
+		if err := pool.QueryRow(ctx, "SELECT user_id::text FROM connector_credentials WHERE connector_id=$1 AND status='authorized'", connector.String("id")).Scan(&owner); err != nil || owner != users[0] {
+			t.Fatalf("独立 OAuth 凭证未保存到发起用户：%s %v", owner, err)
+		}
+	})
 	must("POST", "/api/admin/v1/connectors/"+c3.String("id")+"/test", nil, "", "")
 	oauthTools := must("GET", "/api/admin/v1/connectors/"+c3.String("id")+"/tools", nil, "", "")["items"].([]any)
 	oauthTool := resource.Object(oauthTools[0].(map[string]any))

--- a/monkeyai/backend/internal/mcp/agent_test.go
+++ b/monkeyai/backend/internal/mcp/agent_test.go
@@ -166,6 +166,9 @@ func TestPersonalConnectors(t *testing.T) {
 		t.Fatalf("个人连接没有固定 Provider 配置：%v", c)
 	}
 	connectorPath := "/connectors/" + c.String("id")
+	if c.String("callback_url") != "" {
+		t.Fatal("非 OAuth 连接不应返回回调地址")
+	}
 	call("GET", connectorPath, nil, "other", "", 404)
 	call("PUT", connectorPath, resource.Object{"name": "越权"}, "other", etag(c), 404)
 	call("DELETE", connectorPath, nil, "other", etag(c), 404)

--- a/monkeyai/backend/internal/mcp/oauth.go
+++ b/monkeyai/backend/internal/mcp/oauth.go
@@ -40,6 +40,9 @@ func token() string {
 	return base64.RawURLEncoding.EncodeToString(b)
 }
 func hash(value string) string { v := sha256.Sum256([]byte(value)); return hex.EncodeToString(v[:]) }
+func (s *Service) callbackURL(id string) string {
+	return s.PublicURL + "/oauth/connectors/" + id + "/callback"
+}
 func (s *Service) authorize(w http.ResponseWriter, r *http.Request, admin bool) {
 	u, _ := identity.UserFromContext(r.Context())
 	c, err := s.Connector(r.Context(), s.Store.Pool, chi.URLParam(r, "id"), u.ID, admin)
@@ -52,7 +55,7 @@ func (s *Service) authorize(w http.ResponseWriter, r *http.Request, admin bool) 
 		return
 	}
 	state, verifier := token(), token()
-	redirect := s.PublicURL + "/oauth/connectors/callback"
+	redirect := s.callbackURL(c.String("id"))
 	id := resource.ID()
 	_, err = sqlc.New(s.Store.Pool).CreateOAuthRequest(r.Context(), sqlc.CreateOAuthRequestParams{
 		ID:             id,
@@ -92,6 +95,13 @@ func (s *Service) authorizationStatus(w http.ResponseWriter, r *http.Request) {
 	resource.JSON(w, 200, o)
 }
 func (s *Service) Callback(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	id, state := chi.URLParam(r, "id"), r.URL.Query().Get("state")
+	if id == "" || state == "" {
+		resource.Fail(w, resource.Invalid("授权事务无效或已使用"))
+		return
+	}
 	ctx := r.Context()
 	tx, err := s.Store.Pool.Begin(ctx)
 	if err != nil {
@@ -99,8 +109,8 @@ func (s *Service) Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer tx.Rollback(ctx)
-	request, err := resource.DecodeObject(sqlc.New(tx).ConsumeOAuthRequest(ctx, hash(r.URL.Query().Get("state"))))
-	if err != nil {
+	request, err := resource.DecodeObject(sqlc.New(tx).ConsumeOAuthRequest(ctx, hash(state)))
+	if err != nil || request.String("connector_id") != id {
 		resource.Fail(w, resource.Invalid("授权事务无效或已使用"))
 		return
 	}
@@ -117,7 +127,7 @@ func (s *Service) Callback(w http.ResponseWriter, r *http.Request) {
 		_, _ = sqlc.New(s.Store.Pool).SetOAuthStatus(context.WithoutCancel(ctx), sqlc.SetOAuthStatusParams{ID: request.String("id"), Status: status})
 	}()
 	c, err := s.Connector(ctx, s.Store.Pool, request.String("connector_id"), request.String("user_id"), request.Bool("centralized"))
-	if err != nil || c.Int("config_revision") != request.Int("config_revision") || r.URL.Query().Get("code") == "" {
+	if err != nil || c.Int("config_revision") != request.Int("config_revision") || r.URL.Query().Get("error") != "" || r.URL.Query().Get("code") == "" {
 		resource.Fail(w, resource.Invalid("授权已失效或取消"))
 		return
 	}
@@ -167,7 +177,6 @@ func (s *Service) Callback(w http.ResponseWriter, r *http.Request) {
 
 	success = true
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Header().Set("Cache-Control", "no-store")
 	_, _ = io.WriteString(w, "<!doctype html><html lang=\"zh-CN\"><meta charset=\"utf-8\"><title>授权成功</title><p>授权成功，请返回 MonkeyAI 并测试连接。</p></html>")
 }
 

--- a/monkeyai/backend/internal/mcp/service.go
+++ b/monkeyai/backend/internal/mcp/service.go
@@ -135,6 +135,10 @@ func (s *Service) validateConnector(ctx context.Context, tx pgx.Tx, in, old reso
 	return nil
 }
 func (s *Service) decorateConnector(ctx context.Context, q resource.Queryer, o resource.Object) error {
+	o["callback_url"] = ""
+	if o.String("authorization_method") == "oauth" {
+		o["callback_url"] = s.callbackURL(o.String("id"))
+	}
 	user := ""
 	if o.String("ownership_type") == "user" {
 		user = o.String("owner_user_id")


### PR DESCRIPTION
OAuth MCP 创建后返回 `callback_url` 并在配置窗口中展示，地址为 `{MONKEYAI_PUBLIC_URL}/oauth/connectors/{id}/callback`，其中 `id` 是 MCP 连接实例 ID。创建成功后保持窗口打开，点击地址可全选复制，便于登记到第三方 OAuth 应用并继续授权。

授权请求与 Token 交换使用同一回调地址。回调校验 MCP id 与 state 的绑定、事务有效期和配置版本，完成凭证保存并防止重放；错误 id 不会消费其他 MCP 的授权事务。支持集中授权和个人独立授权，同步更新管理端与 Agent API 文档。

已有 OAuth 应用需要将原 `/oauth/connectors/callback` 更新为对应 MCP 的专属地址，并重新发起授权。

验证：

- PostgreSQL / RustFS 环境下 `go test ./... -count=1`、`go vet ./...`、`make sqlc-check` 通过。
- 覆盖不同 MCP 的 id 隔离、错误 id 不消费事务、PKCE 与回调地址一致性、防重放、取消、过期、配置变更、Token 交换失败及个人凭证归属。
- 前端 build、lint 和 43 项测试通过；API YAML、内部引用与重复项检查通过。
- 浏览器实测创建后展示地址、全选复制及授权成功后更新为已授权；390px 窄屏检查无横向溢出。
