### PR TITLE
修复管理员无法登录客户端的问题

### DIFF
--- a/monkeyai/admin/src/pages/client-login-page.tsx
+++ b/monkeyai/admin/src/pages/client-login-page.tsx
@@ -33,7 +33,6 @@ const callbackErrorMessages: Record<string, string> = {
   provider_unavailable: "该登录方式当前不可用，请选择其他方式。",
   oauth_exchange: "第三方身份验证失败，请重试。",
   user_unavailable: "当前账号不能登录，请联系管理员。",
-  admin_password_required: "管理员账号只能使用密码登录管理后台。",
   session_failed: "登录会话创建失败，请重试。",
 }
 

--- a/monkeyai/backend/api/agent.yaml
+++ b/monkeyai/backend/api/agent.yaml
@@ -258,7 +258,7 @@ paths:
   /api/auth/v1/login:
     post:
       summary: 使用密码登录客户端
-      description: 需要开启 password_enabled，仅允许启用状态的普通用户；成功设置 HttpOnly、SameSite=Lax 会话
+      description: 需要开启 password_enabled，允许启用状态的普通用户和管理员；成功设置 HttpOnly、SameSite=Lax 会话
         Cookie，HTTPS 环境附加 Secure。
       security: []
       requestBody:
@@ -345,7 +345,7 @@ paths:
     post:
       summary: 使用邮箱验证码登录客户端
       description: 需要开启 email_code_enabled，使用 login
-        用途验证码。仅允许启用状态的普通用户，成功建立浏览器会话；验证码最多允许 5 次错误尝试。
+        用途验证码。允许启用状态的普通用户和管理员，成功建立浏览器会话；验证码最多允许 5 次错误尝试。
       security: []
       requestBody:
         required: true

--- a/monkeyai/backend/internal/identity/email.go
+++ b/monkeyai/backend/internal/identity/email.go
@@ -295,7 +295,7 @@ func (s *Service) completeEmail(w http.ResponseWriter, r *http.Request, purpose 
 	default:
 		row, lookupErr := q.GetUserByEmail(ctx, input.Email)
 		admin := strings.HasPrefix(r.URL.Path, "/admin/") || strings.Contains(r.URL.Path, "/v1/admin/")
-		if lookupErr != nil || row.Status != "active" || admin && row.Role != "admin" || !admin && row.Role != "user" {
+		if lookupErr != nil || row.Status != "active" || admin && row.Role != "admin" {
 			writeError(w, 401, "invalid_credentials", "账号不可用于此登录入口")
 			return
 		}

--- a/monkeyai/backend/internal/identity/login_test.go
+++ b/monkeyai/backend/internal/identity/login_test.go
@@ -1,0 +1,144 @@
+package identity
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestLoginRoles(t *testing.T) {
+	pool := emailDatabase(t)
+	const password = "long-password-123"
+	hash, err := hashPassword(password)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, account := range []struct {
+		name    string
+		role    string
+		status  string
+		promote bool
+	}{
+		{name: "user", role: "user", status: "active"},
+		{name: "admin", role: "admin", status: "active"},
+		{name: "promoted", role: "user", status: "active", promote: true},
+		{name: "disabled_user", role: "user", status: "disabled"},
+		{name: "disabled_admin", role: "admin", status: "disabled"},
+	} {
+		for _, method := range []struct {
+			name  string
+			path  string
+			email bool
+			admin bool
+		}{
+			{name: "password", path: "/login"},
+			{name: "admin_password", path: "/admin/login", admin: true},
+			{name: "email", path: "/email/login", email: true},
+			{name: "admin_email", path: "/admin/email/login", email: true, admin: true},
+		} {
+			t.Run(account.name+"/"+method.name, func(t *testing.T) {
+				sender := &mailStub{}
+				s := NewService(pool, authenticationStub{json.RawMessage(`{"password_enabled":true,"email_code_enabled":true}`)}, "http://localhost", "http://localhost").WithEmailSender(sender)
+				email := account.name + "." + method.name + "@example.com"
+				user, err := s.insertUser(t.Context(), account.name, email, account.role, hash)
+				if err != nil {
+					t.Fatal(err)
+				}
+				input := emailInput{Email: email, Password: password}
+				if method.email {
+					authCall(t, s, "/email/code", emailInput{Email: email, Purpose: "login"}, http.StatusOK)
+					input.Code = sender.code
+				}
+				role := account.role
+				if account.promote {
+					role = "admin"
+				}
+				if _, err := s.updateUser(t.Context(), user.ID, user.Name, role, account.status, ""); err != nil {
+					t.Fatal(err)
+				}
+				want := http.StatusOK
+				if account.status != "active" || method.admin && role != "admin" {
+					want = http.StatusUnauthorized
+				}
+				response := authCall(t, s, method.path, input, want)
+				cookies := response.Result().Cookies()
+				if want != http.StatusOK {
+					if len(cookies) != 0 {
+						t.Fatal("登录被拒绝后不应创建会话")
+					}
+					return
+				}
+				var loggedIn User
+				if err := json.Unmarshal(response.Body.Bytes(), &loggedIn); err != nil {
+					t.Fatal(err)
+				}
+				if loggedIn.ID != user.ID || loggedIn.Role != role || len(cookies) != 1 {
+					t.Fatalf("登录身份或会话异常: user=%+v cookies=%d", loggedIn, len(cookies))
+				}
+				if !method.admin {
+					checkClientAuthorization(t, s, cookies[0], loggedIn)
+				}
+			})
+		}
+	}
+}
+
+func checkClientAuthorization(t *testing.T, s *Service, cookie *http.Cookie, user User) {
+	t.Helper()
+	const verifier = "012345678901234567890123456789012345678901234567890123456789"
+	digest := sha256.Sum256([]byte(verifier))
+	request, err := s.BeginAuthorization(t.Context(), url.Values{
+		"response_type": {"code"}, "client_id": {"monkeyai-desktop"},
+		"redirect_uri": {"monkeyai-desktop://oauth/callback"}, "state": {"login-state"},
+		"code_challenge": {base64.RawURLEncoding.EncodeToString(digest[:])}, "code_challenge_method": {"S256"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/client-requests/"+request.ID+"/complete", nil)
+	req.AddCookie(cookie)
+	response := httptest.NewRecorder()
+	s.AuthRouter().ServeHTTP(response, req)
+	if response.Code != http.StatusOK {
+		t.Fatalf("客户端授权失败: status=%d body=%s", response.Code, response.Body.String())
+	}
+	var result struct {
+		LaunchURL string `json:"launch_url"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	callback, err := url.Parse(result.LaunchURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callback.Query().Get("state") != request.State {
+		t.Fatal("客户端回调未保留 state")
+	}
+	token, err := s.ExchangeCode(t.Context(), request.ClientID, request.RedirectURI, callback.Query().Get("code"), verifier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refreshed, err := s.Refresh(t.Context(), request.ClientID, token.RefreshToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	agent := s.RequireAgent(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current, ok := UserFromContext(r.Context())
+		if !ok || current.ID != user.ID || current.Role != user.Role {
+			t.Fatalf("客户端身份异常: %+v", current)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	req.Header.Set("Authorization", "Bearer "+refreshed.AccessToken)
+	response = httptest.NewRecorder()
+	agent.ServeHTTP(response, req)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("客户端令牌不可用: status=%d body=%s", response.Code, response.Body.String())
+	}
+}

--- a/monkeyai/backend/internal/identity/oauth.go
+++ b/monkeyai/backend/internal/identity/oauth.go
@@ -258,8 +258,6 @@ func (s *Service) upstreamCallback(w http.ResponseWriter, r *http.Request) {
 			code = "admin_role_required"
 		case adminLogin && errors.Is(err, ErrUserDisabled):
 			code = "admin_role_required"
-		case errors.Is(err, ErrAdminPasswordRequired):
-			code = "admin_password_required"
 		}
 		http.Redirect(w, r, s.upstreamResultURL(state, code), http.StatusFound)
 		return

--- a/monkeyai/backend/internal/identity/password.go
+++ b/monkeyai/backend/internal/identity/password.go
@@ -69,10 +69,7 @@ func (s *Service) passwordLogin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, 403, "method_disabled", "密码登录未启用")
 		return
 	}
-	role := "user"
-	if strings.HasSuffix(r.URL.Path, "/admin/login") {
-		role = "admin"
-	}
+	adminOnly := strings.HasSuffix(r.URL.Path, "/admin/login")
 	var input struct {
 		Email    string `json:"email"`
 		Password string `json:"password"`
@@ -84,7 +81,7 @@ func (s *Service) passwordLogin(w http.ResponseWriter, r *http.Request) {
 	input.Email = strings.ToLower(strings.TrimSpace(input.Email))
 	var user User
 	var passwordHash string
-	row, err := sqlc.New(s.db).GetPasswordUser(r.Context(), sqlc.GetPasswordUserParams{Email: input.Email, Role: role})
+	row, err := sqlc.New(s.db).GetPasswordUser(r.Context(), sqlc.GetPasswordUserParams{Email: input.Email, AdminOnly: adminOnly})
 	if err == nil && row.PasswordHash == nil {
 		err = errors.New("未设置密码")
 	}

--- a/monkeyai/backend/internal/identity/postgres.go
+++ b/monkeyai/backend/internal/identity/postgres.go
@@ -306,7 +306,7 @@ func (s *Service) upsertIdentity(ctx context.Context, profile upstreamProfile, a
 			user.ID, user.Name, user.Email, user.AvatarURL, user.Role, user.Status, user.JoinedAt, user.LastLoginAt = row.ID, row.Name, row.Email, row.AvatarUrl, row.Role, row.Status, row.JoinedAt, row.LastLoginAt
 		}
 		if errors.Is(err, pgx.ErrNoRows) {
-			return User{}, ErrAdminPasswordRequired
+			return User{}, ErrUserDisabled
 		}
 		if err != nil {
 			return User{}, err
@@ -339,16 +339,12 @@ func validateUpstreamUser(user User, adminOnly bool) error {
 	if adminOnly && user.Role != "admin" {
 		return ErrAdminRoleRequired
 	}
-	if !adminOnly && user.Role == "admin" {
-		return ErrAdminPasswordRequired
-	}
 	return nil
 }
 
 var (
-	ErrNotFound              = errors.New("记录不存在")
-	ErrUserDisabled          = errors.New("用户已停用")
-	ErrRegistrationDisabled  = errors.New("未开放新用户注册")
-	ErrAdminPasswordRequired = errors.New("管理员必须使用密码登录")
-	ErrAdminRoleRequired     = errors.New("管理后台 OAuth 登录必须关联管理员")
+	ErrNotFound             = errors.New("记录不存在")
+	ErrUserDisabled         = errors.New("用户已停用")
+	ErrRegistrationDisabled = errors.New("未开放新用户注册")
+	ErrAdminRoleRequired    = errors.New("管理后台 OAuth 登录必须关联管理员")
 )

--- a/monkeyai/backend/internal/identity/postgres_test.go
+++ b/monkeyai/backend/internal/identity/postgres_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/chaitin/MonkeyCode/monkeyai/backend/internal/identity/sqlc"
+
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -100,5 +102,69 @@ func TestOAuthUserRegistration(t *testing.T) {
 				t.Fatalf("关闭注册后已有用户重复登录失败: err=%v id=%s", err, again.ID)
 			}
 		})
+	}
+}
+
+func TestOAuthAdminClientLogin(t *testing.T) {
+	pool := emailDatabase(t)
+	for _, bound := range []bool{false, true} {
+		name := "email_binding"
+		if bound {
+			name = "promoted_identity"
+		}
+		t.Run(name, func(t *testing.T) {
+			s := NewService(pool, authenticationStub{json.RawMessage(`{"registration_enabled":true}`)}, "http://localhost", "http://localhost")
+			profile := upstreamProfile{Provider: "oidc", Issuer: "https://issuer.example.com", Subject: name, Email: name + "@example.com", Name: name}
+			var user User
+			var err error
+			if bound {
+				user, err = s.upsertIdentity(t.Context(), profile, false)
+			} else {
+				user, err = s.insertUser(t.Context(), name, profile.Email, "user", "")
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := s.updateUser(t.Context(), user.ID, user.Name, "admin", "active", ""); err != nil {
+				t.Fatal(err)
+			}
+			s.settings = authenticationStub{json.RawMessage(`{"registration_enabled":false}`)}
+			for _, adminOnly := range []bool{false, true} {
+				loggedIn, err := s.upsertIdentity(t.Context(), profile, adminOnly)
+				if err != nil || loggedIn.ID != user.ID || loggedIn.Role != "admin" {
+					t.Fatalf("管理员 OAuth 登录失败: adminOnly=%t user=%+v err=%v", adminOnly, loggedIn, err)
+				}
+			}
+			var identities int
+			if err := pool.QueryRow(t.Context(), "SELECT count(*) FROM user_identities WHERE user_id = $1", user.ID).Scan(&identities); err != nil || identities != 1 {
+				t.Fatalf("第三方身份未正确复用: count=%d err=%v", identities, err)
+			}
+			if _, err := s.updateUser(t.Context(), user.ID, user.Name, "admin", "disabled", ""); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := s.upsertIdentity(t.Context(), profile, false); !errors.Is(err, ErrUserDisabled) {
+				t.Fatalf("停用管理员登录结果=%v", err)
+			}
+		})
+	}
+}
+
+func TestOAuthRegistrationConflictWithAdmin(t *testing.T) {
+	pool := emailDatabase(t)
+	s := NewService(pool, nil, "", "")
+	user, err := s.insertUser(t.Context(), "管理员", "admin@example.com", "admin", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	params := sqlc.CreateIdentityUserParams{Name: "OAuth 管理员", Email: user.Email}
+	row, err := sqlc.New(pool).CreateIdentityUser(t.Context(), params)
+	if err != nil || row.ID != user.ID || row.Role != "admin" {
+		t.Fatalf("OAuth 注册邮箱冲突未保留管理员身份: user=%+v err=%v", row, err)
+	}
+	if _, err := s.updateUser(t.Context(), user.ID, user.Name, "admin", "disabled", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlc.New(pool).CreateIdentityUser(t.Context(), params); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("OAuth 注册冲突不应更新停用管理员: %v", err)
 	}
 }

--- a/monkeyai/backend/internal/identity/query.sql
+++ b/monkeyai/backend/internal/identity/query.sql
@@ -61,7 +61,7 @@ FROM
     users
 WHERE
     lower(email) = $1
-    AND ROLE = sqlc.arg(role)
+    AND (NOT sqlc.arg(admin_only)::boolean OR ROLE = 'admin')
     AND status = 'active'
     AND deleted_at IS NULL
     AND password_hash IS NOT NULL;
@@ -371,8 +371,7 @@ WHERE
             last_login_at = now(),
             updated_at = now()
         WHERE
-            users.role = 'user'
-            AND users.status = 'active'
+            users.status = 'active'
         RETURNING
             id,
             name,

--- a/monkeyai/backend/internal/identity/service_test.go
+++ b/monkeyai/backend/internal/identity/service_test.go
@@ -98,7 +98,9 @@ func TestValidateUpstreamUserForAdminLogin(t *testing.T) {
 		{name: "active admin can use admin login", user: User{Role: "admin", Status: "active"}, adminOnly: true},
 		{name: "regular user cannot use admin login", user: User{Role: "user", Status: "active"}, adminOnly: true, want: ErrAdminRoleRequired},
 		{name: "disabled admin cannot use admin login", user: User{Role: "admin", Status: "disabled"}, adminOnly: true, want: ErrUserDisabled},
-		{name: "admin cannot enter client flow", user: User{Role: "admin", Status: "active"}, want: ErrAdminPasswordRequired},
+		{name: "admin can enter client flow", user: User{Role: "admin", Status: "active"}},
+		{name: "disabled admin cannot enter client flow", user: User{Role: "admin", Status: "disabled"}, want: ErrUserDisabled},
+		{name: "disabled user cannot enter client flow", user: User{Role: "user", Status: "disabled"}, want: ErrUserDisabled},
 		{name: "regular user can enter client flow", user: User{Role: "user", Status: "active"}},
 	}
 

--- a/monkeyai/backend/internal/identity/sqlc/query.sql.go
+++ b/monkeyai/backend/internal/identity/sqlc/query.sql.go
@@ -181,8 +181,7 @@ WHERE
             last_login_at = now(),
             updated_at = now()
         WHERE
-            users.role = 'user'
-            AND users.status = 'active'
+            users.status = 'active'
         RETURNING
             id,
             name,
@@ -624,15 +623,15 @@ FROM
     users
 WHERE
     lower(email) = $1
-    AND ROLE = $2
+    AND (NOT $2::boolean OR ROLE = 'admin')
     AND status = 'active'
     AND deleted_at IS NULL
     AND password_hash IS NOT NULL
 `
 
 type GetPasswordUserParams struct {
-	Email string
-	Role  string
+	Email     string
+	AdminOnly bool
 }
 
 type GetPasswordUserRow struct {
@@ -648,7 +647,7 @@ type GetPasswordUserRow struct {
 }
 
 func (q *Queries) GetPasswordUser(ctx context.Context, arg GetPasswordUserParams) (GetPasswordUserRow, error) {
-	row := q.db.QueryRow(ctx, getPasswordUser, arg.Email, arg.Role)
+	row := q.db.QueryRow(ctx, getPasswordUser, arg.Email, arg.AdminOnly)
 	var i GetPasswordUserRow
 	err := row.Scan(
 		&i.ID,

--- a/monkeyai/design/agent-auth-settings.md
+++ b/monkeyai/design/agent-auth-settings.md
@@ -30,7 +30,9 @@ OAuth 元数据位于 `GET /.well-known/oauth-authorization-server`，客户端�
 
 管理后台同时支持密码和管理员启用的 OAuth/OIDC 登录。密码使用 `users.email + password_hash` 校验，并以带随机 Salt 的 PBKDF2-HMAC-SHA256 保存；OAuth/OIDC 登录页动态列出当前启用的连接。两种方式成功后都会建立 HttpOnly 浏览器会话。
 
-OAuth/OIDC 回调只允许关联到已存在、启用状态且 `role = 'admin'` 的用户。首次使用某个第三方身份时，可以按上游返回的邮箱绑定同邮箱管理员；不会通过 OAuth 自动创建管理员，也不会把普通用户提升为管理员。普通用户或停用用户完成上游认证后仍会被管理后台拒绝。
+管理后台的 OAuth/OIDC 回调只允许关联到已存在、启用状态且 `role = 'admin'` 的用户。首次使用某个第三方身份时，可以按上游返回的邮箱绑定同邮箱管理员；不会通过 OAuth 自动创建管理员，也不会把普通用户提升为管理员。普通用户或停用用户完成上游认证后仍会被管理后台拒绝。
+
+管理员同时可以登录客户端，使用已启用的密码、邮箱验证码或 OAuth/OIDC 登录方式。普通用户提升为管理员后，继续复用原用户身份和第三方绑定完成客户端登录、授权码交换及令牌刷新。
 
 空数据库首次启动时必须使用以下环境变量创建第一个管理员：
 
@@ -96,14 +98,14 @@ OAuth access token 用于 Agent API；模型代理只接受具有 `model:invoke`
 
 ## 8. 邮箱认证与 SMTP
 
-管理端与客户端通过 `GET /api/auth/v1/methods` 获取公开开关。`password_enabled` 默认开启，`email_code_enabled`、`registration_enabled` 默认关闭；开关在服务端认证入口再次校验。管理员入口仅接受管理员，客户端邮箱登录入口仅接受普通用户。
+管理端与客户端通过 `GET /api/auth/v1/methods` 获取公开开关。`password_enabled` 默认开启，`email_code_enabled`、`registration_enabled` 默认关闭；开关在服务端认证入口再次校验。管理员入口仅接受启用状态的管理员，客户端登录入口接受启用状态的普通用户和管理员。
 
 | 接口 | 用途 |
 | --- | --- |
 | `POST /api/admin/v1/settings/email/test` | 管理员使用已保存 SMTP 配置向 `recipient` 发送测试邮件 |
-| `POST /api/auth/v1/login` | 普通用户密码登录，管理员沿用 `/admin/login` |
+| `POST /api/auth/v1/login` | 普通用户和管理员的客户端密码登录；管理后台使用 `/admin/login` |
 | `POST /api/auth/v1/email/code` | 提交 `email` 与 `purpose`（`login`、`register`、`reset`）发送验证码 |
-| `POST /api/auth/v1/email/login` | 普通用户验证码登录，管理员使用 `/admin/email/login` |
+| `POST /api/auth/v1/email/login` | 普通用户和管理员的客户端验证码登录；管理后台使用 `/admin/email/login` |
 | `POST /api/auth/v1/email/register` | 通过注册验证码提交邮箱、姓名和至少 12 字符密码，仅创建普通用户 |
 | `POST /api/auth/v1/email/reset-password` | 通过重置验证码设置至少 12 字符的新密码 |
 


### PR DESCRIPTION
用户被设置为管理员后，客户端的密码、邮箱验证码及 OAuth 登录会因角色限制而被拒绝。本次修复允许启用状态的管理员登录客户端，复用原用户身份及第三方绑定完成客户端授权，同时继续校验管理后台角色和账号停用状态。

同步修正 OAuth 邮箱冲突处理、清理过期错误提示并更新接口和设计文档。

验证：
- 新增回归测试已在修复前复现失败，修复后全部通过，覆盖角色提升、三种登录方式、客户端授权码交换和令牌刷新。
- 使用临时 PostgreSQL 与 RustFS 完成后端全量测试，go vet 与 sqlc 生成一致性检查通过。
- 前端 OAuth 测试、OpenAPI YAML 与本地引用检查、迁移版本冲突检查通过。
