### PR TITLE
fix: 兼容 MCP 请求中的 null 参数

### DIFF
--- a/monkeyai/backend/internal/mcp/protocol.go
+++ b/monkeyai/backend/internal/mcp/protocol.go
@@ -46,6 +46,9 @@ func readRequest(w http.ResponseWriter, r *http.Request) (request, bool) {
 		rpcReply(w, 400, nil, nil, &rpcError{Code: -32600, Message: "JSON-RPC 请求无效"})
 		return in, false
 	}
+	if bytes.Equal(bytes.TrimSpace(in.Params), []byte("null")) {
+		in.Params = nil
+	}
 	if len(in.Params) > 0 && !bytes.HasPrefix(bytes.TrimSpace(in.Params), []byte("{")) {
 		rpcReply(w, 400, in.ID, nil, &rpcError{Code: -32602, Message: "参数必须为 JSON 对象"})
 		return in, false

--- a/monkeyai/backend/internal/mcp/protocol_test.go
+++ b/monkeyai/backend/internal/mcp/protocol_test.go
@@ -14,12 +14,21 @@ import (
 
 func TestRPCRequests(t *testing.T) {
 	for _, test := range []struct {
-		name, body, id string
-		code, status   int
+		name, body, id, params string
+		code, status           int
 	}{
 		{name: "字符串 ID", body: `{"jsonrpc":"2.0","id":"call-1","method":"ping"}`, id: `"call-1"`},
 		{name: "大整数 ID", body: `{"jsonrpc":"2.0","id":9007199254740993,"method":"ping"}`, id: `9007199254740993`},
 		{name: "通知", body: `{"jsonrpc":"2.0","method":"notifications/initialized"}`},
+		{name: "无参工具目录", body: `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`, id: `2`},
+		{name: "null 工具目录参数", body: `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":null}`, id: `2`},
+		{name: "空对象工具目录参数", body: `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`, id: `2`, params: `{}`},
+		{name: "工具目录游标", body: `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{"cursor":"next"}}`, id: `2`, params: `{"cursor":"next"}`},
+		{name: "null 心跳参数", body: `{"jsonrpc":"2.0","id":2,"method":"ping","params": null }`, id: `2`},
+		{name: "null 通知参数", body: `{"jsonrpc":"2.0","method":"notifications/initialized","params":null}`},
+		{name: "null 初始化参数留给方法校验", body: `{"jsonrpc":"2.0","id":1,"method":"initialize","params":null}`, id: `1`},
+		{name: "null 调用参数留给方法校验", body: `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":null}`, id: `2`},
+		{name: "调用参数保真", body: `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search","arguments":{"value":9007199254740993},"_meta":{"trace":"request"}}}`, id: `2`, params: `{"name":"search","arguments":{"value":9007199254740993},"_meta":{"trace":"request"}}`},
 		{name: "解析失败", body: `{`, code: -32700, status: 400},
 		{name: "连续对象", body: `{} {}`, code: -32700, status: 400},
 		{name: "批量请求", body: `[{}]`, code: -32600, status: 400},
@@ -29,13 +38,17 @@ func TestRPCRequests(t *testing.T) {
 		{name: "对象 ID", body: `{"jsonrpc":"2.0","id":{},"method":"ping"}`, code: -32600, status: 400},
 		{name: "布尔 ID", body: `{"jsonrpc":"2.0","id":true,"method":"ping"}`, code: -32600, status: 400},
 		{name: "数组参数", body: `{"jsonrpc":"2.0","id":"a","method":"tools/call","params":[]}`, code: -32602, status: 400},
+		{name: "工具目录数组参数", body: `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":[]}`, code: -32602, status: 400},
+		{name: "字符串参数", body: `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":"null"}`, code: -32602, status: 400},
+		{name: "数字参数", body: `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":0}`, code: -32602, status: 400},
+		{name: "布尔参数", body: `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":false}`, code: -32602, status: 400},
 		{name: "超限", body: strings.Repeat(" ", (1<<20)+1), code: -32700, status: 413},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			in, ok := readRequest(w, httptest.NewRequest("POST", "/mcp", strings.NewReader(test.body)))
 			if test.code == 0 {
-				if !ok || string(in.ID) != test.id {
+				if !ok || string(in.ID) != test.id || string(in.Params) != test.params {
 					t.Fatalf("请求未被保真解析: %+v %s", in, w.Body.String())
 				}
 				return

--- a/monkeyai/design/mcp-proxy-plan.md
+++ b/monkeyai/design/mcp-proxy-plan.md
@@ -16,3 +16,10 @@
 - 覆盖调用密钥作用域、资源授权、模板/工具禁用、独立凭证目录隔离、凭证撤销、OAuth 到期刷新、三种认证模式计费、JSON/SSE 响应、幂等去重、无效结果保留核查及参数精度。
 - 两份 OpenAPI 的重复键与本地引用校验通过。Nginx 配置检查、容器内真实 POST 转发及 Vite 开发代理转发验证通过，认证 Header 正确保留。
 - 已完成实现与验证，进入 PR 评审交付阶段；使用 `feat-mcp-proxy` 分支，主工作树保持原状。合并与部署另行执行。
+
+兼容性修复（2026-09-10）：
+
+- [x] 同步 main，在独立 worktree 创建 `fix-mcp-null-params` 分支。
+- [x] 复现 `tools/list` 携带 `params: null` 时返回 `-32602`；将顶层 null 参数视为未传参数，继续拒绝数组和标量，并保留各方法的必填参数校验。
+- [x] 补充空参数、无效参数类型、调用参数精度及元数据保真的协议回归；Go 1.27.1 下 `go test ./internal/mcp/... -count=1 -v` 和 `go vet ./internal/mcp/...` 通过，使用本地专用 PostgreSQL 测试容器及独立随机 schema，无跳过的测试。
+- 当前修复已完成本地验证，进入 PR 评审交付阶段；使用 `fix-mcp-null-params` 分支，尚未合并或部署。


### PR DESCRIPTION
MCP 客户端发送 `tools/list` 且携带 `params: null` 时，MonkeyAI 返回 `-32602 参数必须为 JSON 对象`，导致 Streamable HTTP 连接失败。现在将顶层 `null` 参数视为未传参数，使无参请求可以正常处理；数组、字符串、数字和布尔参数仍会被拒绝，具体方法继续校验必填参数。

补充协议回归，覆盖省略参数、`null`、空对象、游标、无效参数类型，以及工具调用中的大整数和 `_meta` 保真。

验证：

- 已在修复前复现相同的 `tools/list` 错误。
- Go 1.27.1 下 `go test ./internal/mcp/... -count=1 -v` 通过，包含使用专用 PostgreSQL 测试容器和独立随机 schema 的数据库测试，无跳过的测试。
- `go vet ./internal/mcp/...`、`git diff --check` 通过。
