### PR TITLE
支持百智云 OAuth 获取邮箱并补齐已有账号

### DIFF
--- a/monkeyai/README.md
+++ b/monkeyai/README.md
@@ -110,7 +110,9 @@ Agent 按资源类型读取 `/api/v1/settings`、`/api/v1/models`、`/api/v1/rul
 
 ### 百智云钱包
 
-先在「其他设置 → 第三方登录」添加「百智云」提供方（`baizhiyun`）。配置字段与自定义 OIDC 相同，需要 Issuer URL、Client ID 和 Client Secret；默认 scopes 为 `auth_certification openid phone user`，接口配置的自定义 scopes 会保留。
+先在「其他设置 → 第三方登录」添加「百智云」提供方（`baizhiyun`）。配置字段与自定义 OIDC 相同，需要 Issuer URL、Client ID 和 Client Secret；默认 scopes 为 `auth_certification openid phone user email`，接口配置的自定义 scopes 会保留。百智云 OAuth 客户端需先获准 `email` 权限；已有自定义 scopes 的连接需自行加入 `email` 才能获取邮箱。
+
+用户信息接口的 `data.email` 用于新用户注册和关联同邮箱账号，未返回邮箱时保留占位邮箱登录。已有百智云账号下次登录时，会在邮箱未被其他未删除账号占用的情况下将占位邮箱补齐为真实邮箱；已有真实邮箱和用户身份保持不变。
 
 选择远程计费后，只有具有有效百智云登录身份的用户可以获取或调用系统模型、规则、技能、专家和 MCP 连接。该限制也适用于已有访问令牌和 API Key，并在暂停实际扣费时继续生效；个人资源遵循原有授权，管理员仍可维护后台配置。已有自定义 OIDC 身份不会自动视为百智云身份，用户需通过新提供方登录。
 

--- a/monkeyai/admin/src/i18n/locales/ar.ts
+++ b/monkeyai/admin/src/i18n/locales/ar.ts
@@ -831,7 +831,7 @@ export const ar = {
         name: "اسم العرض",
         namePlaceholder: "مثال: GitHub للشركة",
         baizhiyunScopes:
-          "نطاقات التفويض الافتراضية: auth_certification openid phone user",
+          "نطاقات التفويض الافتراضية: auth_certification openid phone user email",
         issuerUrl: "عنوان URL للمُصدر",
         clientId: "معرّف العميل",
         clientSecret: "سر العميل",

--- a/monkeyai/admin/src/i18n/locales/de-DE.ts
+++ b/monkeyai/admin/src/i18n/locales/de-DE.ts
@@ -875,7 +875,7 @@ export const deDE = {
         name: "Anzeigename",
         namePlaceholder: "Zum Beispiel: Firmen-GitHub",
         baizhiyunScopes:
-          "Standardberechtigungen: auth_certification openid phone user",
+          "Standardberechtigungen: auth_certification openid phone user email",
         issuerUrl: "Issuer-URL",
         clientId: "Client-ID",
         clientSecret: "Client-Secret",

--- a/monkeyai/admin/src/i18n/locales/en-US.ts
+++ b/monkeyai/admin/src/i18n/locales/en-US.ts
@@ -1076,7 +1076,7 @@ export const enUS = {
         name: "Display name",
         namePlaceholder: "For example: Company GitHub",
         baizhiyunScopes:
-          "Default scopes: auth_certification openid phone user.",
+          "Default scopes: auth_certification openid phone user email.",
         issuerUrl: "Issuer URL",
         clientId: "Client ID",
         clientSecret: "Client secret",

--- a/monkeyai/admin/src/i18n/locales/es-419.ts
+++ b/monkeyai/admin/src/i18n/locales/es-419.ts
@@ -862,7 +862,7 @@ export const es419 = {
         name: "Nombre para mostrar",
         namePlaceholder: "Por ejemplo: GitHub de la empresa",
         baizhiyunScopes:
-          "Permisos predeterminados: auth_certification openid phone user",
+          "Permisos predeterminados: auth_certification openid phone user email",
         issuerUrl: "URL del emisor",
         clientId: "ID de cliente",
         clientSecret: "Secreto del cliente",

--- a/monkeyai/admin/src/i18n/locales/fr-FR.ts
+++ b/monkeyai/admin/src/i18n/locales/fr-FR.ts
@@ -866,7 +866,7 @@ export const frFR = {
         name: "Nom affiché",
         namePlaceholder: "Par exemple : GitHub Entreprise",
         baizhiyunScopes:
-          "Autorisations par défaut : auth_certification openid phone user",
+          "Autorisations par défaut : auth_certification openid phone user email",
         issuerUrl: "URL de l’émetteur",
         clientId: "ID client",
         clientSecret: "Secret client",

--- a/monkeyai/admin/src/i18n/locales/ja-JP.ts
+++ b/monkeyai/admin/src/i18n/locales/ja-JP.ts
@@ -840,7 +840,7 @@ export const jaJP = {
         name: "表示名",
         namePlaceholder: "例：会社 GitHub",
         baizhiyunScopes:
-          "デフォルトのスコープ： auth_certification openid phone user",
+          "デフォルトのスコープ： auth_certification openid phone user email",
         issuerUrl: "Issuer URL",
         clientId: "Client ID",
         clientSecret: "Client Secret",

--- a/monkeyai/admin/src/i18n/locales/ko-KR.ts
+++ b/monkeyai/admin/src/i18n/locales/ko-KR.ts
@@ -831,7 +831,7 @@ export const koKR = {
         provider: "제공자",
         name: "표시 이름",
         namePlaceholder: "예: 회사 GitHub",
-        baizhiyunScopes: "기본 권한 범위: auth_certification openid phone user",
+        baizhiyunScopes: "기본 권한 범위: auth_certification openid phone user email",
         issuerUrl: "Issuer URL",
         clientId: "Client ID",
         clientSecret: "Client Secret",

--- a/monkeyai/admin/src/i18n/locales/ru-RU.ts
+++ b/monkeyai/admin/src/i18n/locales/ru-RU.ts
@@ -863,7 +863,7 @@ export const ruRU = {
         name: "Отображаемое имя",
         namePlaceholder: "Например: Корпоративный GitHub",
         baizhiyunScopes:
-          "Разрешения по умолчанию: auth_certification openid phone user",
+          "Разрешения по умолчанию: auth_certification openid phone user email",
         issuerUrl: "URL издателя",
         clientId: "Client ID",
         clientSecret: "Client Secret",

--- a/monkeyai/admin/src/i18n/locales/zh-CN.ts
+++ b/monkeyai/admin/src/i18n/locales/zh-CN.ts
@@ -1018,7 +1018,7 @@ export const zhCN = {
         provider: "提供方",
         name: "显示名称",
         namePlaceholder: "例如：公司 GitHub",
-        baizhiyunScopes: "默认授权范围：auth_certification openid phone user。",
+        baizhiyunScopes: "默认授权范围：auth_certification openid phone user email。",
         issuerUrl: "Issuer URL",
         clientId: "Client ID",
         clientSecret: "Client Secret",

--- a/monkeyai/admin/src/i18n/locales/zh-TW.ts
+++ b/monkeyai/admin/src/i18n/locales/zh-TW.ts
@@ -798,7 +798,7 @@ export const zhTW = {
         provider: "提供者",
         name: "顯示名稱",
         namePlaceholder: "例如：公司 GitHub",
-        baizhiyunScopes: "預設授權範圍： auth_certification openid phone user",
+        baizhiyunScopes: "預設授權範圍： auth_certification openid phone user email",
         issuerUrl: "Issuer URL",
         clientId: "Client ID",
         clientSecret: "Client Secret",

--- a/monkeyai/backend/api/agent.yaml
+++ b/monkeyai/backend/api/agent.yaml
@@ -3058,7 +3058,7 @@ components:
           description: 自定义用户信息端点；使用提供方默认端点时可不返回。
         scopes:
           type: array
-          description: 请求上游授权时使用的 Scope；使用默认 Scope 时可不返回。百智云默认为 auth_certification、openid、phone、user。
+          description: 请求上游授权时使用的 Scope；使用默认 Scope 时可不返回。百智云默认为 auth_certification、openid、phone、user、email。
           items:
             type: string
         enabled:

--- a/monkeyai/backend/internal/identity/postgres.go
+++ b/monkeyai/backend/internal/identity/postgres.go
@@ -249,6 +249,12 @@ func (s *Service) upsertIdentity(ctx context.Context, profile upstreamProfile, a
 			return User{}, err
 		}
 
+		if profile.Provider == "baizhiyun" && profile.Email != "" {
+			if err := sqlc.New(tx).UpdateBaizhiyunEmail(ctx, sqlc.UpdateBaizhiyunEmailParams{UserID: user.ID, Issuer: profile.Issuer, ProviderSubject: profile.Subject, Email: profile.Email}); err != nil {
+				return User{}, err
+			}
+		}
+
 		var record sqlc.UpdateIdentityUserRow
 		record, err = sqlc.New(tx).UpdateIdentityUser(ctx, sqlc.UpdateIdentityUserParams{ID: user.ID, Name: profile.Name, AvatarUrl: profile.AvatarURL})
 

--- a/monkeyai/backend/internal/identity/query.sql
+++ b/monkeyai/backend/internal/identity/query.sql
@@ -322,6 +322,28 @@ WHERE
     AND i.deleted_at IS NULL
     AND u.deleted_at IS NULL;
 
+-- name: UpdateBaizhiyunEmail :exec
+WITH identity AS (
+    UPDATE user_identities
+    SET email = sqlc.arg(email)::text
+    WHERE user_id = sqlc.arg(user_id)
+        AND provider = 'baizhiyun'
+        AND issuer = sqlc.arg(issuer)
+        AND provider_subject = sqlc.arg(provider_subject)
+        AND deleted_at IS NULL
+    RETURNING user_id, provider_subject
+)
+UPDATE users u
+SET email = sqlc.arg(email)::text, updated_at = now()
+FROM identity i
+WHERE u.id = i.user_id
+    AND u.email = i.provider_subject || '@baizhiyun.oauth.local'
+    AND NOT EXISTS (
+        SELECT 1 FROM users existing
+        WHERE lower(existing.email) = lower(sqlc.arg(email)::text)
+            AND existing.deleted_at IS NULL
+    );
+
 -- name: UpdateIdentityUser :one
 UPDATE
     users

--- a/monkeyai/backend/internal/identity/sqlc/query.sql.go
+++ b/monkeyai/backend/internal/identity/sqlc/query.sql.go
@@ -1157,6 +1157,46 @@ func (q *Queries) TouchLogin(ctx context.Context, id string) (pgconn.CommandTag,
 	return q.db.Exec(ctx, touchLogin, id)
 }
 
+const updateBaizhiyunEmail = `-- name: UpdateBaizhiyunEmail :exec
+WITH identity AS (
+    UPDATE user_identities
+    SET email = $1::text
+    WHERE user_id = $2
+        AND provider = 'baizhiyun'
+        AND issuer = $3
+        AND provider_subject = $4
+        AND deleted_at IS NULL
+    RETURNING user_id, provider_subject
+)
+UPDATE users u
+SET email = $1::text, updated_at = now()
+FROM identity i
+WHERE u.id = i.user_id
+    AND u.email = i.provider_subject || '@baizhiyun.oauth.local'
+    AND NOT EXISTS (
+        SELECT 1 FROM users existing
+        WHERE lower(existing.email) = lower($1::text)
+            AND existing.deleted_at IS NULL
+    )
+`
+
+type UpdateBaizhiyunEmailParams struct {
+	Email           string
+	UserID          string
+	Issuer          string
+	ProviderSubject string
+}
+
+func (q *Queries) UpdateBaizhiyunEmail(ctx context.Context, arg UpdateBaizhiyunEmailParams) error {
+	_, err := q.db.Exec(ctx, updateBaizhiyunEmail,
+		arg.Email,
+		arg.UserID,
+		arg.Issuer,
+		arg.ProviderSubject,
+	)
+	return err
+}
+
 const updateIdentityUser = `-- name: UpdateIdentityUser :one
 UPDATE
     users

--- a/monkeyai/backend/internal/identity/upstream.go
+++ b/monkeyai/backend/internal/identity/upstream.go
@@ -147,7 +147,7 @@ func (s *Service) upstreamAuthorizeURL(ctx context.Context, connection OAuthConn
 		case "github":
 			scopes = []string{"read:user", "user:email"}
 		case "baizhiyun":
-			scopes = []string{"auth_certification", "openid", "phone", "user"}
+			scopes = []string{"auth_certification", "openid", "phone", "user", "email"}
 		}
 	}
 	query := endpoint.Query()
@@ -217,6 +217,7 @@ func (s *Service) exchangeUpstream(ctx context.Context, connection OAuthConnecti
 				ID     string `json:"id"`
 				Name   string `json:"name"`
 				Avatar string `json:"avatar"`
+				Email  string `json:"email"`
 			} `json:"data"`
 		}
 		if err := decoder.Decode(&result); err != nil {
@@ -233,6 +234,7 @@ func (s *Service) exchangeUpstream(ctx context.Context, connection OAuthConnecti
 			Issuer:    connection.IssuerURL,
 			Subject:   result.Data.ID,
 			Name:      result.Data.Name,
+			Email:     strings.ToLower(strings.TrimSpace(result.Data.Email)),
 			AvatarURL: result.Data.Avatar,
 		}
 	} else {

--- a/monkeyai/backend/internal/identity/upstream_test.go
+++ b/monkeyai/backend/internal/identity/upstream_test.go
@@ -2,6 +2,7 @@ package identity
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -40,7 +41,7 @@ func TestBaizhiyunOIDC(t *testing.T) {
 		scopes   []string
 		want     string
 	}{
-		{"baizhiyun", nil, "auth_certification openid phone user"},
+		{"baizhiyun", nil, "auth_certification openid phone user email"},
 		{"baizhiyun", []string{"openid", "user"}, "openid user"},
 		{"oidc", nil, "openid profile email"},
 	} {
@@ -69,6 +70,24 @@ func TestBaizhiyunOIDC(t *testing.T) {
 			provider: "baizhiyun",
 			body:     `{"code":0,"message":"success","data":{"id":"1001","name":"百智云用户","avatar":"https://example.com/avatar.png","phone_number":"13800000000","is_certified":false,"user_type":"personal"}}`,
 			want:     upstreamProfile{Provider: "baizhiyun", Issuer: issuer, Subject: "1001", Name: "百智云用户", AvatarURL: "https://example.com/avatar.png"},
+		},
+		{
+			name:     "baizhiyun_email",
+			provider: "baizhiyun",
+			body:     `{"code":0,"data":{"id":"1001","name":"百智云用户","email":" User@Example.com "}}`,
+			want:     upstreamProfile{Provider: "baizhiyun", Issuer: issuer, Subject: "1001", Name: "百智云用户", Email: "user@example.com"},
+		},
+		{
+			name:     "baizhiyun_empty_email",
+			provider: "baizhiyun",
+			body:     `{"code":0,"data":{"id":"1001","email":" "}}`,
+			want:     upstreamProfile{Provider: "baizhiyun", Issuer: issuer, Subject: "1001"},
+		},
+		{
+			name:     "baizhiyun_null_email",
+			provider: "baizhiyun",
+			body:     `{"code":0,"data":{"id":"1001","email":null}}`,
+			want:     upstreamProfile{Provider: "baizhiyun", Issuer: issuer, Subject: "1001"},
 		},
 		{
 			name:     "oidc",
@@ -118,19 +137,112 @@ func TestBaizhiyunOIDC(t *testing.T) {
 }
 
 func TestBaizhiyunIdentityRegistration(t *testing.T) {
+	for _, email := range []string{"", "user@example.com"} {
+		t.Run(email, func(t *testing.T) {
+			pool := emailDatabase(t)
+			s := NewService(pool, authenticationStub{json.RawMessage(`{"registration_enabled":true}`)}, "", "")
+			profile := upstreamProfile{Provider: "baizhiyun", Issuer: "https://identity.example", Subject: "1001", Name: "百智云用户", Email: email}
+			first, err := s.upsertIdentity(t.Context(), profile, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantEmail := email
+			if wantEmail == "" {
+				wantEmail = "1001@baizhiyun.oauth.local"
+			}
+			if first.Email != wantEmail {
+				t.Fatalf("注册邮箱错误: got=%q want=%q", first.Email, wantEmail)
+			}
+			again, err := s.upsertIdentity(t.Context(), profile, false)
+			if err != nil || first.ID != again.ID || again.Email != wantEmail {
+				t.Fatalf("重复登录未复用身份: %+v %v", again, err)
+			}
+			var provider, subject, savedEmail string
+			if err := pool.QueryRow(t.Context(), `SELECT provider,provider_subject,email FROM user_identities WHERE user_id=$1`, first.ID).Scan(&provider, &subject, &savedEmail); err != nil || provider != "baizhiyun" || subject != "1001" || savedEmail != wantEmail {
+				t.Fatalf("百智云身份未持久化: %s %s %s %v", provider, subject, savedEmail, err)
+			}
+		})
+	}
+}
+
+func TestBaizhiyunIdentityEmail(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		initialEmail string
+		ownerStatus  string
+		wantEmail    string
+	}{
+		{name: "backfill", wantEmail: "user@example.com"},
+		{name: "existing_email", initialEmail: "original@example.com", wantEmail: "original@example.com"},
+		{name: "email_conflict", ownerStatus: "active", wantEmail: "1001@baizhiyun.oauth.local"},
+		{name: "disabled_owner", ownerStatus: "disabled", wantEmail: "1001@baizhiyun.oauth.local"},
+		{name: "deleted_owner", ownerStatus: "deleted", wantEmail: "user@example.com"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := emailDatabase(t)
+			s := NewService(pool, authenticationStub{json.RawMessage(`{"registration_enabled":true}`)}, "", "")
+			profile := upstreamProfile{Provider: "baizhiyun", Issuer: "https://identity.example", Subject: "1001", Name: "百智云用户", Email: tc.initialEmail}
+			first, err := s.upsertIdentity(t.Context(), profile, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			profile.Email = "user@example.com"
+			if tc.ownerStatus != "" {
+				owner, err := s.insertUser(t.Context(), "邮箱所有者", profile.Email, "admin", "")
+				if err != nil {
+					t.Fatal(err)
+				}
+				switch tc.ownerStatus {
+				case "disabled":
+					_, err = s.updateUser(t.Context(), owner.ID, owner.Name, owner.Role, "disabled", "")
+				case "deleted":
+					_, err = pool.Exec(t.Context(), `UPDATE users SET deleted_at=now() WHERE id=$1`, owner.ID)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			s.settings = authenticationStub{json.RawMessage(`{"registration_enabled":false}`)}
+			for range 2 {
+				again, err := s.upsertIdentity(t.Context(), profile, false)
+				if err != nil || again.ID != first.ID || again.Email != tc.wantEmail || again.Role != "user" {
+					t.Fatalf("邮箱补齐改变了用户身份或邮箱错误: user=%+v err=%v", again, err)
+				}
+				var savedEmail string
+				if err := pool.QueryRow(t.Context(), `SELECT email FROM user_identities WHERE user_id=$1`, first.ID).Scan(&savedEmail); err != nil || savedEmail != "user@example.com" {
+					t.Fatalf("上游身份邮箱未保留: email=%q err=%v", savedEmail, err)
+				}
+				profile.Email = ""
+			}
+		})
+	}
+}
+
+func TestBaizhiyunEmailBinding(t *testing.T) {
 	pool := emailDatabase(t)
-	s := NewService(pool, authenticationStub{json.RawMessage(`{"registration_enabled":true}`)}, "", "")
-	profile := upstreamProfile{Provider: "baizhiyun", Issuer: "https://identity.example", Subject: "1001", Name: "百智云用户"}
-	first, err := s.upsertIdentity(t.Context(), profile, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	again, err := s.upsertIdentity(t.Context(), profile, false)
-	if err != nil || first.ID != again.ID {
-		t.Fatalf("重复登录未复用身份: %+v %v", again, err)
-	}
-	var provider, subject string
-	if err := pool.QueryRow(t.Context(), `SELECT provider,provider_subject FROM user_identities WHERE user_id=$1`, first.ID).Scan(&provider, &subject); err != nil || provider != "baizhiyun" || subject != "1001" {
-		t.Fatalf("百智云身份未持久化: %s %s %v", provider, subject, err)
+	s := NewService(pool, authenticationStub{json.RawMessage(`{"registration_enabled":false}`)}, "", "")
+	for _, role := range []string{"user", "admin"} {
+		t.Run(role, func(t *testing.T) {
+			profile := upstreamProfile{Provider: "baizhiyun", Issuer: "https://identity.example", Subject: role, Name: "百智云用户", Email: role + "@example.com"}
+			owner, err := s.insertUser(t.Context(), "已有用户", strings.ToUpper(profile.Email), role, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if role == "user" {
+				if _, err := s.upsertIdentity(t.Context(), profile, true); !errors.Is(err, ErrAdminRoleRequired) {
+					t.Fatalf("普通用户不应通过管理后台登录: %v", err)
+				}
+			}
+			again, err := s.upsertIdentity(t.Context(), profile, role == "admin")
+			if err != nil || again.ID != owner.ID || again.Role != role || again.Email != owner.Email {
+				t.Fatalf("未复用同邮箱账号: user=%+v err=%v", again, err)
+			}
+			if _, err := s.updateUser(t.Context(), owner.ID, owner.Name, role, "disabled", ""); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := s.upsertIdentity(t.Context(), profile, false); !errors.Is(err, ErrUserDisabled) {
+				t.Fatalf("停用用户不应通过邮箱关联登录: %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
百智云 OAuth 已支持邮箱，但当前登录流程未申请独立的 `email` 权限，也未读取 `data.email`，导致用户仍以占位邮箱注册。此改动默认申请 `email`，规范化并读取返回邮箱，复用已有的同邮箱账号关联逻辑，并同步管理端提示和 API 文档。

已有百智云账号再次登录时，在邮箱未被其他未删除账号占用的情况下补齐占位邮箱；保留已有真实邮箱、用户身份和权限。未返回邮箱时继续兼容原登录流程，邮箱冲突时不合并账号。

启用前需在百智云侧为 OAuth 客户端开通 `email` 权限；已有自定义 scopes 的连接需自行加入 `email`。

验证已通过：

- PostgreSQL 身份模块测试，覆盖邮箱解析、注册、旧账号补齐、邮箱冲突、邮箱缺失、停用账号及管理员权限。
- `go test ./...`（含 PostgreSQL、RustFS 集成测试及迁移检查）、`go vet ./...`。
- `make sqlc-check`、OpenAPI YAML 重复键、内部引用和 operationId 检查。
- 管理端 OAuth 和其他设置国际化相关测试。
