### PR TITLE
feat(frontend): 邀请积分文案补充奖励上限

### DIFF
--- a/frontend/src/i18n/resources/cn.ts
+++ b/frontend/src/i18n/resources/cn.ts
@@ -1754,7 +1754,7 @@ const cn = {
     },
     invite: {
       title: "邀请注册赚积分",
-      description: "将邀请链接分享给好友，好友通过该链接注册后，你将获得 5000 积分奖励。",
+      description: "分享邀请链接，好友通过链接注册后你可获 5000 积分（奖励上限 10 人，即 5 万积分）。",
       copyLink: "复制链接",
       invitedCount: "已邀请 {{count}} 人",
       collapseList: "收起",

--- a/frontend/src/i18n/resources/en.ts
+++ b/frontend/src/i18n/resources/en.ts
@@ -1754,7 +1754,7 @@ const en = {
     },
     invite: {
       title: "Invite users for credits",
-      description: "Share the invitation link with friends. After they register through this link, you will receive 5000 credits.",
+      description: "Share the invite link. After a friend registers through it, you earn 5,000 credits (reward cap: 10 people, 50,000 credits in total).",
       copyLink: "Copy link",
       invitedCount: "{{count}} invited",
       collapseList: "Collapse",

--- a/frontend/test/wallet-dialog-i18n.test.ts
+++ b/frontend/test/wallet-dialog-i18n.test.ts
@@ -22,6 +22,8 @@ test("钱包弹窗提供中英文资源", () => {
   assert.equal(en.walletDialog.nav.earn, "My credits");
   assert.equal(cn.walletDialog.earn.checkinAction, "签到领 100 积分");
   assert.equal(en.walletDialog.earn.checkinAction, "Check in for 100 credits");
+  assert.match(cn.walletDialog.invite.description, /奖励上限 10 人，即 5 万积分/);
+  assert.match(en.walletDialog.invite.description, /reward cap: 10 people, 50,000 credits in total/);
   assert.equal(cn.walletDialog.recharge.confirm, "确认充值");
   assert.equal(en.walletDialog.recharge.confirm, "Confirm recharge");
 });


### PR DESCRIPTION
## 改动
缩短钱包「我的积分」里邀请注册说明，并补上奖励上限。

- 中文：分享邀请链接，好友通过链接注册后你可获 5000 积分（奖励上限 10 人，即 5 万积分）。
- 英文同步补充 reward cap。
- 补充钱包弹窗 i18n 断言。

## 范围
仅文案与对应测试，不包含预览 mock 改动。