### PR TITLE
按扩展包全量同步规则并跳过未变化的重复导入

### DIFF
--- a/backend/biz/team/usecase/extension_package_manifest.go
+++ b/backend/biz/team/usecase/extension_package_manifest.go
@@ -115,7 +115,8 @@ func parseExtensionPackage(data []byte) (*parsedExtensionPackage, error) {
 	if strings.TrimSpace(manifest.PackageID) == "" || strings.TrimSpace(manifest.Version) == "" {
 		return nil, errcode.ErrBadRequest.Wrap(fmt.Errorf("extension manifest missing package_id or version"))
 	}
-	if len(manifest.Rules) == 0 && len(manifest.Skills) == 0 && len(manifest.Images) == 0 {
+	// 显式空 rules 表示清空该包已有的规则。
+	if manifest.Rules == nil && len(manifest.Skills) == 0 && len(manifest.Images) == 0 {
 		return nil, errcode.ErrBadRequest.Wrap(fmt.Errorf("extension manifest contains no resources"))
 	}
 

--- a/backend/biz/team/usecase/extension_package_manifest_test.go
+++ b/backend/biz/team/usecase/extension_package_manifest_test.go
@@ -96,7 +96,7 @@ func TestParseExtensionPackageRejectsDuplicateRuleID(t *testing.T) {
 	}
 }
 
-func TestParseExtensionPackageRequiresAtLeastOneResource(t *testing.T) {
+func TestParseExtensionPackageRejectsMissingResources(t *testing.T) {
 	data := makeExtensionZip(t, map[string]string{
 		"manifest.json": `{"package_id":"pack","version":"1.0.0"}`,
 	})

--- a/backend/biz/team/usecase/extension_package_rules.go
+++ b/backend/biz/team/usecase/extension_package_rules.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/chaitin/MonkeyCode/backend/db"
 	"github.com/chaitin/MonkeyCode/backend/db/agentrule"
+	"github.com/chaitin/MonkeyCode/backend/db/agentruleversion"
 	"github.com/chaitin/MonkeyCode/backend/domain"
 	"github.com/chaitin/MonkeyCode/backend/errcode"
 )
@@ -21,13 +23,53 @@ type extensionRuleImporter struct {
 const VersionFormat = "20060102150405"
 
 func (i *extensionRuleImporter) ImportRules(ctx context.Context, userID uuid.UUID, pkg *parsedExtensionPackage) (domain.ExtensionRuleImportResult, error) {
+	// 防止并发导入将同一个包的两批规则混在一起。
+	tx, err := i.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return domain.ExtensionRuleImportResult{}, err
+	}
+	defer tx.Rollback()
+
+	result, err := i.replaceRules(ctx, tx, userID, pkg)
+	if err != nil {
+		return domain.ExtensionRuleImportResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return domain.ExtensionRuleImportResult{}, err
+	}
+	return result, nil
+}
+
+func (i *extensionRuleImporter) replaceRules(ctx context.Context, tx *db.Tx, userID uuid.UUID, pkg *parsedExtensionPackage) (domain.ExtensionRuleImportResult, error) {
 	var result domain.ExtensionRuleImportResult
-	for _, item := range pkg.Rules {
-		created, err := i.importRule(ctx, userID, pkg, item)
-		if err != nil {
-			return result, err
+	source := agentrule.ExtensionPackageIDEQ(pkg.PackageID)
+	rules, err := tx.AgentRule.Query().Where(source).All(ctx)
+	if err != nil {
+		return domain.ExtensionRuleImportResult{}, err
+	}
+	existing := make(map[string]*db.AgentRule, len(rules))
+	for _, rule := range rules {
+		if !rule.IsDeleted && rule.ExtensionRuleID != nil {
+			existing[*rule.ExtensionRuleID] = rule
 		}
-		if created {
+	}
+
+	// 生效版本与规则互相引用，先解除引用再清理历史版本。
+	if err := tx.AgentRule.Update().Where(source).ClearActiveVersionID().Exec(ctx); err != nil {
+		return domain.ExtensionRuleImportResult{}, err
+	}
+	if _, err := tx.AgentRuleVersion.Delete().Where(agentruleversion.HasRuleWith(source)).Exec(ctx); err != nil {
+		return domain.ExtensionRuleImportResult{}, err
+	}
+	if _, err := tx.AgentRule.Delete().Where(source).Exec(ctx); err != nil {
+		return domain.ExtensionRuleImportResult{}, err
+	}
+	for _, item := range pkg.Rules {
+		previous := existing[item.RuleID]
+		if err := i.importRule(ctx, tx, userID, pkg, item, previous); err != nil {
+			return domain.ExtensionRuleImportResult{}, err
+		}
+		if previous == nil {
 			result.CreatedRules++
 		} else {
 			result.UpdatedRules++
@@ -36,31 +78,8 @@ func (i *extensionRuleImporter) ImportRules(ctx context.Context, userID uuid.UUI
 	return result, nil
 }
 
-func (i *extensionRuleImporter) importRule(ctx context.Context, userID uuid.UUID, pkg *parsedExtensionPackage, item parsedExtensionRule) (bool, error) {
-	existingBySource, err := i.db.AgentRule.Query().
-		Where(
-			agentrule.ExtensionPackageIDEQ(pkg.PackageID),
-			agentrule.ExtensionRuleIDEQ(item.RuleID),
-			agentrule.IsDeletedEQ(false),
-		).
-		Only(ctx)
-	if err != nil && !db.IsNotFound(err) {
-		return false, err
-	}
-	if existingBySource != nil {
-		version, err := i.createRuleVersion(ctx, existingBySource.ID, item.Content)
-		if err != nil {
-			return false, err
-		}
-		_, err = i.db.AgentRule.UpdateOneID(existingBySource.ID).
-			SetDescription(item.Description).
-			SetExtensionVersion(pkg.Version).
-			SetActiveVersionID(version.ID).
-			Save(ctx)
-		return false, err
-	}
-
-	conflict, err := i.db.AgentRule.Query().
+func (i *extensionRuleImporter) importRule(ctx context.Context, tx *db.Tx, userID uuid.UUID, pkg *parsedExtensionPackage, item parsedExtensionRule, previous *db.AgentRule) error {
+	conflict, err := tx.AgentRule.Query().
 		Where(
 			agentrule.NameEQ(item.Name),
 			agentrule.ScopeTypeEQ("global"),
@@ -69,13 +88,13 @@ func (i *extensionRuleImporter) importRule(ctx context.Context, userID uuid.UUID
 		).
 		Exist(ctx)
 	if err != nil {
-		return false, err
+		return err
 	}
 	if conflict {
-		return false, errcode.ErrBadRequest.Wrap(fmt.Errorf("agent rule name conflict: %s", item.Name))
+		return errcode.ErrBadRequest.Wrap(fmt.Errorf("agent rule name conflict: %s", item.Name))
 	}
 
-	rule, err := i.db.AgentRule.Create().
+	create := tx.AgentRule.Create().
 		SetID(uuid.New()).
 		SetName(item.Name).
 		SetDescription(item.Description).
@@ -84,23 +103,25 @@ func (i *extensionRuleImporter) importRule(ctx context.Context, userID uuid.UUID
 		SetCreatedBy(userID).
 		SetExtensionPackageID(pkg.PackageID).
 		SetExtensionRuleID(item.RuleID).
-		SetExtensionVersion(pkg.Version).
-		Save(ctx)
-	if err != nil {
-		return false, err
+		SetExtensionVersion(pkg.Version)
+	if previous != nil {
+		create.SetID(previous.ID).SetCreatedAt(previous.CreatedAt).SetCreatedBy(previous.CreatedBy)
 	}
-	version, err := i.createRuleVersion(ctx, rule.ID, item.Content)
+	rule, err := create.Save(ctx)
 	if err != nil {
-		return false, err
+		return err
 	}
-	_, err = i.db.AgentRule.UpdateOneID(rule.ID).SetActiveVersionID(version.ID).Save(ctx)
-	return true, err
+	version, err := i.createRuleVersion(ctx, tx, rule.ID, item.Content)
+	if err != nil {
+		return err
+	}
+	return tx.AgentRule.UpdateOneID(rule.ID).SetActiveVersionID(version.ID).Exec(ctx)
 }
 
-func (i *extensionRuleImporter) createRuleVersion(ctx context.Context, ruleID uuid.UUID, content string) (*db.AgentRuleVersion, error) {
+func (i *extensionRuleImporter) createRuleVersion(ctx context.Context, tx *db.Tx, ruleID uuid.UUID, content string) (*db.AgentRuleVersion, error) {
 	now := time.Now()
 	version := now.UTC().Format(VersionFormat)
-	return i.db.AgentRuleVersion.Create().
+	return tx.AgentRuleVersion.Create().
 		SetID(uuid.New()).
 		SetRuleID(ruleID).
 		SetVersion(version).

--- a/backend/biz/team/usecase/extension_package_rules.go
+++ b/backend/biz/team/usecase/extension_package_rules.go
@@ -43,7 +43,7 @@ func (i *extensionRuleImporter) ImportRules(ctx context.Context, userID uuid.UUI
 func (i *extensionRuleImporter) replaceRules(ctx context.Context, tx *db.Tx, userID uuid.UUID, pkg *parsedExtensionPackage) (domain.ExtensionRuleImportResult, error) {
 	var result domain.ExtensionRuleImportResult
 	source := agentrule.ExtensionPackageIDEQ(pkg.PackageID)
-	rules, err := tx.AgentRule.Query().Where(source).All(ctx)
+	rules, err := tx.AgentRule.Query().Where(source).WithVersions().All(ctx)
 	if err != nil {
 		return domain.ExtensionRuleImportResult{}, err
 	}
@@ -52,6 +52,9 @@ func (i *extensionRuleImporter) replaceRules(ctx context.Context, tx *db.Tx, use
 		if !rule.IsDeleted && rule.ExtensionRuleID != nil {
 			existing[*rule.ExtensionRuleID] = rule
 		}
+	}
+	if len(rules) == len(pkg.Rules) && extensionRulesMatch(existing, pkg) {
+		return result, nil
 	}
 
 	// 生效版本与规则互相引用，先解除引用再清理历史版本。
@@ -76,6 +79,26 @@ func (i *extensionRuleImporter) replaceRules(ctx context.Context, tx *db.Tx, use
 		}
 	}
 	return result, nil
+}
+
+func extensionRulesMatch(existing map[string]*db.AgentRule, pkg *parsedExtensionPackage) bool {
+	if len(existing) != len(pkg.Rules) {
+		return false
+	}
+	for _, item := range pkg.Rules {
+		rule := existing[item.RuleID]
+		if rule == nil || rule.Name != item.Name || rule.Description != item.Description {
+			return false
+		}
+		if rule.ScopeType != "global" || rule.ScopeID != "global" || rule.ExtensionVersion == nil || *rule.ExtensionVersion != pkg.Version {
+			return false
+		}
+		versions := rule.Edges.Versions
+		if rule.ActiveVersionID == nil || len(versions) != 1 || versions[0].ID != *rule.ActiveVersionID || versions[0].Content != item.Content {
+			return false
+		}
+	}
+	return true
 }
 
 func (i *extensionRuleImporter) importRule(ctx context.Context, tx *db.Tx, userID uuid.UUID, pkg *parsedExtensionPackage, item parsedExtensionRule, previous *db.AgentRule) error {

--- a/backend/biz/team/usecase/extension_package_rules_test.go
+++ b/backend/biz/team/usecase/extension_package_rules_test.go
@@ -10,7 +10,10 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/chaitin/MonkeyCode/backend/db"
+	"github.com/chaitin/MonkeyCode/backend/db/agentrule"
+	"github.com/chaitin/MonkeyCode/backend/db/agentruleversion"
 	"github.com/chaitin/MonkeyCode/backend/db/enttest"
+	"github.com/chaitin/MonkeyCode/backend/domain"
 )
 
 func newRuleImportTestClient(t *testing.T) *db.Client {
@@ -87,7 +90,10 @@ func TestExtensionRuleImporterUpdatesSamePackageRule(t *testing.T) {
 	if _, err := importer.ImportRules(ctx, userID, pkg); err != nil {
 		t.Fatal(err)
 	}
+	previous := client.AgentRule.Query().OnlyX(ctx)
 	pkg.Version = "1.0.1"
+	pkg.Rules[0].Name = "renamed-base"
+	pkg.Rules[0].Description = "updated"
 	pkg.Rules[0].Content = "v2"
 	result, err := importer.ImportRules(ctx, userID, pkg)
 	if err != nil {
@@ -100,7 +106,7 @@ func TestExtensionRuleImporterUpdatesSamePackageRule(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if count != 2 {
+	if count != 1 {
 		t.Fatalf("version count = %d", count)
 	}
 	versions, err := client.AgentRuleVersion.Query().All(ctx)
@@ -117,6 +123,12 @@ func TestExtensionRuleImporterUpdatesSamePackageRule(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if rule.ID != previous.ID || rule.Name != "renamed-base" || rule.Description != "updated" {
+		t.Fatalf("updated rule = %#v", rule)
+	}
+	if rule.ExtensionVersion == nil || *rule.ExtensionVersion != pkg.Version {
+		t.Fatalf("extension version = %v", rule.ExtensionVersion)
+	}
 	active, err := client.AgentRuleVersion.Get(ctx, *rule.ActiveVersionID)
 	if err != nil {
 		t.Fatal(err)
@@ -124,6 +136,149 @@ func TestExtensionRuleImporterUpdatesSamePackageRule(t *testing.T) {
 	assertRuleVersionFormat(t, active.Version)
 	if active.Content != "v2" {
 		t.Fatalf("active content = %q, want v2", active.Content)
+	}
+	if _, err := importer.ImportRules(ctx, userID, pkg); err != nil {
+		t.Fatal(err)
+	}
+	if count := client.AgentRuleVersion.Query().CountX(ctx); count != 1 {
+		t.Fatalf("version count after repeated import = %d, want 1", count)
+	}
+}
+
+func TestExtensionRuleImporterReplacesPackageRules(t *testing.T) {
+	ctx := context.Background()
+	client := newRuleImportTestClient(t)
+	importer := &extensionRuleImporter{db: client}
+	userID := uuid.New()
+	pkg := &parsedExtensionPackage{
+		PackageID: "pack",
+		Version:   "1.0.0",
+		Rules: []parsedExtensionRule{
+			{RuleID: "keep", Name: "keep", Content: "old"},
+			{RuleID: "remove", Name: "remove", Content: "removed"},
+			{RuleID: "deleted", Name: "deleted", Content: "deleted"},
+		},
+	}
+	if _, err := importer.ImportRules(ctx, userID, pkg); err != nil {
+		t.Fatal(err)
+	}
+	client.AgentRule.Update().Where(agentrule.ExtensionRuleIDEQ("deleted")).SetIsDeleted(true).ExecX(ctx)
+	keep := client.AgentRule.Query().Where(agentrule.ExtensionRuleIDEQ("keep")).OnlyX(ctx)
+	client.AgentRuleVersion.Create().SetRuleID(keep.ID).SetVersion("20260623115903").SetContent("historical").SaveX(ctx)
+	other := &parsedExtensionPackage{
+		PackageID: "other",
+		Version:   "1.0.0",
+		Rules:     []parsedExtensionRule{{RuleID: "keep", Name: "other", Content: "other"}},
+	}
+	if _, err := importer.ImportRules(ctx, userID, other); err != nil {
+		t.Fatal(err)
+	}
+	otherRule := client.AgentRule.Query().Where(agentrule.ExtensionPackageIDEQ("other")).OnlyX(ctx)
+	manual := client.AgentRule.Create().SetName("manual").SetCreatedBy(userID).SaveX(ctx)
+	manualVersion := client.AgentRuleVersion.Create().SetRuleID(manual.ID).SetVersion("20260623115903").SetContent("manual").SaveX(ctx)
+	client.AgentRule.UpdateOne(manual).SetActiveVersionID(manualVersion.ID).ExecX(ctx)
+
+	pkg.Version = "1.0.1"
+	pkg.Rules = []parsedExtensionRule{
+		{RuleID: "keep", Name: "keep", Content: "latest"},
+		{RuleID: "new", Name: "remove", Content: "new"},
+	}
+	result, err := importer.ImportRules(ctx, userID, pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CreatedRules != 1 || result.UpdatedRules != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	rules := client.AgentRule.Query().Where(agentrule.ExtensionPackageIDEQ(pkg.PackageID)).AllX(ctx)
+	if len(rules) != 2 {
+		t.Fatalf("package rule count = %d, want 2", len(rules))
+	}
+	for _, rule := range rules {
+		if rule.IsDeleted || rule.ExtensionRuleID == nil || rule.ActiveVersionID == nil {
+			t.Fatalf("unexpected rule = %#v", rule)
+		}
+		want := "new"
+		if *rule.ExtensionRuleID == "keep" {
+			want = "latest"
+			if rule.ID != keep.ID {
+				t.Fatalf("retained rule ID = %s, want %s", rule.ID, keep.ID)
+			}
+		} else if *rule.ExtensionRuleID != "new" {
+			t.Fatalf("stale rule retained: %s", *rule.ExtensionRuleID)
+		}
+		versions := client.AgentRuleVersion.Query().Where(agentruleversion.RuleID(rule.ID)).AllX(ctx)
+		if len(versions) != 1 || versions[0].ID != *rule.ActiveVersionID || versions[0].Content != want {
+			t.Fatalf("versions for %s = %#v", rule.Name, versions)
+		}
+	}
+	if count := client.AgentRule.Query().CountX(ctx); count != 4 {
+		t.Fatalf("total rule count = %d, want 4", count)
+	}
+	if count := client.AgentRuleVersion.Query().CountX(ctx); count != 4 {
+		t.Fatalf("total version count = %d, want 4", count)
+	}
+	if got := client.AgentRule.GetX(ctx, otherRule.ID); got.ActiveVersionID == nil || *got.ActiveVersionID != *otherRule.ActiveVersionID {
+		t.Fatal("other package rule changed")
+	}
+	if got := client.AgentRule.GetX(ctx, manual.ID); got.ActiveVersionID == nil || *got.ActiveVersionID != manualVersion.ID {
+		t.Fatal("manual rule changed")
+	}
+
+	pkg, err = parseExtensionPackage(makeExtensionZip(t, map[string]string{
+		"manifest.json": `{"package_id":"pack","version":"1.0.2","rules":[]}`,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := importer.ImportRules(ctx, userID, pkg); err != nil {
+		t.Fatal(err)
+	}
+	if count := client.AgentRule.Query().Where(agentrule.ExtensionPackageIDEQ(pkg.PackageID)).CountX(ctx); count != 0 {
+		t.Fatalf("rule count after empty replacement = %d, want 0", count)
+	}
+	if count := client.AgentRuleVersion.Query().CountX(ctx); count != 2 {
+		t.Fatalf("version count after empty replacement = %d, want 2", count)
+	}
+}
+
+func TestExtensionRuleImporterRollsBackReplacement(t *testing.T) {
+	ctx := context.Background()
+	client := newRuleImportTestClient(t)
+	importer := &extensionRuleImporter{db: client}
+	userID := uuid.New()
+	pkg := &parsedExtensionPackage{
+		PackageID: "pack",
+		Version:   "1.0.0",
+		Rules:     []parsedExtensionRule{{RuleID: "old", Name: "old", Content: "original"}},
+	}
+	if _, err := importer.ImportRules(ctx, userID, pkg); err != nil {
+		t.Fatal(err)
+	}
+	original := client.AgentRule.Query().OnlyX(ctx)
+	client.AgentRule.Create().SetName("conflict").SetCreatedBy(userID).SaveX(ctx)
+	pkg.Version = "1.0.1"
+	pkg.Rules = []parsedExtensionRule{
+		{RuleID: "new", Name: "new", Content: "new"},
+		{RuleID: "conflict", Name: "conflict", Content: "conflict"},
+	}
+	result, err := importer.ImportRules(ctx, userID, pkg)
+	if err == nil {
+		t.Fatal("expected name conflict")
+	}
+	if result != (domain.ExtensionRuleImportResult{}) {
+		t.Fatalf("rolled back result = %#v", result)
+	}
+	rule := client.AgentRule.GetX(ctx, original.ID)
+	if rule.ActiveVersionID == nil || *rule.ActiveVersionID != *original.ActiveVersionID || *rule.ExtensionVersion != "1.0.0" {
+		t.Fatalf("original rule changed after failed import: %#v", rule)
+	}
+	if count := client.AgentRule.Query().CountX(ctx); count != 2 {
+		t.Fatalf("rule count after rollback = %d, want 2", count)
+	}
+	version := client.AgentRuleVersion.Query().OnlyX(ctx)
+	if version.ID != *original.ActiveVersionID || version.Content != "original" {
+		t.Fatalf("original version changed after failed import: %#v", version)
 	}
 }
 

--- a/backend/biz/team/usecase/extension_package_rules_test.go
+++ b/backend/biz/team/usecase/extension_package_rules_test.go
@@ -137,11 +137,73 @@ func TestExtensionRuleImporterUpdatesSamePackageRule(t *testing.T) {
 	if active.Content != "v2" {
 		t.Fatalf("active content = %q, want v2", active.Content)
 	}
-	if _, err := importer.ImportRules(ctx, userID, pkg); err != nil {
+	result, err = (&extensionRuleImporter{db: client}).ImportRules(ctx, userID, pkg)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if result != (domain.ExtensionRuleImportResult{}) {
+		t.Fatalf("unchanged import result = %#v", result)
 	}
 	if count := client.AgentRuleVersion.Query().CountX(ctx); count != 1 {
 		t.Fatalf("version count after repeated import = %d, want 1", count)
+	}
+	unchanged := client.AgentRule.GetX(ctx, rule.ID)
+	if unchanged.ActiveVersionID == nil || *unchanged.ActiveVersionID != active.ID || !unchanged.UpdatedAt.Equal(rule.UpdatedAt) {
+		t.Fatalf("unchanged rule was rewritten: %#v", unchanged)
+	}
+}
+
+func TestExtensionRuleImporterReimportsChanges(t *testing.T) {
+	for _, change := range []string{"content", "name", "description", "version", "history", "deleted", "missing-active", "database-content"} {
+		t.Run(change, func(t *testing.T) {
+			ctx := context.Background()
+			client := newRuleImportTestClient(t)
+			importer := &extensionRuleImporter{db: client}
+			userID := uuid.New()
+			pkg := &parsedExtensionPackage{
+				PackageID: "pack",
+				Version:   "1.0.0",
+				Rules:     []parsedExtensionRule{{RuleID: "base", Name: "base", Description: "base", Content: "original"}},
+			}
+			if _, err := importer.ImportRules(ctx, userID, pkg); err != nil {
+				t.Fatal(err)
+			}
+			original := client.AgentRule.Query().OnlyX(ctx)
+			switch change {
+			case "content":
+				pkg.Rules[0].Content = "updated"
+			case "name":
+				pkg.Rules[0].Name = "renamed"
+			case "description":
+				pkg.Rules[0].Description = "updated"
+			case "version":
+				pkg.Version = "1.0.1"
+			case "history":
+				client.AgentRuleVersion.Create().SetRuleID(original.ID).SetVersion("20260623115903").SetContent("historical").SaveX(ctx)
+			case "deleted":
+				client.AgentRule.UpdateOne(original).SetIsDeleted(true).ExecX(ctx)
+			case "missing-active":
+				client.AgentRule.UpdateOne(original).ClearActiveVersionID().ExecX(ctx)
+			case "database-content":
+				client.AgentRuleVersion.UpdateOneID(*original.ActiveVersionID).SetContent("manual change").ExecX(ctx)
+			}
+
+			result, err := importer.ImportRules(ctx, userID, pkg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.CreatedRules+result.UpdatedRules != 1 {
+				t.Fatalf("changed import result = %#v", result)
+			}
+			rule := client.AgentRule.Query().OnlyX(ctx)
+			version := client.AgentRuleVersion.Query().OnlyX(ctx)
+			if rule.IsDeleted || rule.ActiveVersionID == nil || *rule.ActiveVersionID != version.ID || version.ID == *original.ActiveVersionID {
+				t.Fatalf("changed rule was not replaced: %#v", rule)
+			}
+			if rule.Name != pkg.Rules[0].Name || rule.Description != pkg.Rules[0].Description || rule.ExtensionVersion == nil || *rule.ExtensionVersion != pkg.Version || version.Content != pkg.Rules[0].Content {
+				t.Fatalf("rule does not match package: rule=%#v version=%#v", rule, version)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
扩展规则包删掉规则后，旧规则仍留在数据库；后端每次启动还会为未变化的规则重新生成版本。本次将导入改为按 `extension_package_id` 全量同步，并在规则与包内容完全一致时跳过替换。

- 在串行化事务中清理同包旧规则及历史版本，只保留当前包中的规则和每条规则的当前版本。保留仍存在的规则 ID、创建时间和创建人，覆盖名称、描述、内容和包版本；失败时整体回滚。
- 同时比较规则集合、元数据、生效版本内容及历史版本数量。重复导入不修改生效版本 ID 和更新时间；版本号不变但内容变化、软删除、缺失生效版本或存在多余历史版本时仍重新同步。
- 支持显式 `rules: []` 清空同包规则。其他扩展包和手工规则不受影响，无需数据库迁移。

验证：

- `go test ./biz/team/usecase ./biz/agentresource -count=1` 通过。
- 私有化依赖环境下的规则导入和包解析测试通过。
- 全量替换、历史版本清理和失败回滚已在临时 PostgreSQL 实例上验证，包含生产环境的双向外键和名称唯一约束。

上线后仍在后端启动时检查本地 ZIP；首次发现旧数据或内容变化时执行全量同步，后续内容一致时跳过规则写入。
